### PR TITLE
fix: correct NetBox configuration path and heredoc indentation in CI

### DIFF
--- a/.github/workflows/test-netbox-main.yaml
+++ b/.github/workflows/test-netbox-main.yaml
@@ -65,26 +65,29 @@ jobs:
 
       - name: Configure NetBox
         run: |
-          cat > netbox/netbox/configuration.py << 'EOF'
-          ALLOWED_HOSTS = ['*']
-          DATABASE = {
-              'NAME': 'netbox',
-              'USER': 'netbox',
-              'PASSWORD': 'netbox',
-              'HOST': 'localhost',
-              'PORT': '5432',
-              'CONN_MAX_AGE': 300,
-              'ENGINE': 'django.db.backends.postgresql',
-          }
-          REDIS = {
-              'tasks':   {'HOST': 'localhost', 'PORT': 6379, 'DATABASE': 0, 'SSL': False},
-              'caching': {'HOST': 'localhost', 'PORT': 6379, 'DATABASE': 1, 'SSL': False},
-          }
-          SECRET_KEY = 'test-secret-key-not-for-production-1234567890123456'  # checkov:skip=CKV_SECRET_6
-          API_TOKEN_PEPPERS = {0: 'a' * 64}  # checkov:skip=CKV_SECRET_6
-          DEBUG = True
-          LOGIN_REQUIRED = False
-          EOF
+          python3 -c "
+          import textwrap, pathlib
+          pathlib.Path('netbox/netbox/netbox/configuration.py').write_text(textwrap.dedent('''
+              ALLOWED_HOSTS = ['*']
+              DATABASE = {
+                  'NAME': 'netbox',
+                  'USER': 'netbox',
+                  'PASSWORD': 'netbox',
+                  'HOST': 'localhost',
+                  'PORT': '5432',
+                  'CONN_MAX_AGE': 300,
+                  'ENGINE': 'django.db.backends.postgresql',
+              }
+              REDIS = {
+                  'tasks':   {'HOST': 'localhost', 'PORT': 6379, 'DATABASE': 0, 'SSL': False},
+                  'caching': {'HOST': 'localhost', 'PORT': 6379, 'DATABASE': 1, 'SSL': False},
+              }
+              SECRET_KEY = 'test-secret-key-not-for-production-1234567890123456'
+              API_TOKEN_PEPPERS = {0: 'a' * 64}
+              DEBUG = True
+              LOGIN_REQUIRED = False
+          ''').lstrip())
+          "
 
       - name: Run NetBox migrations
         working-directory: netbox/netbox

--- a/.github/workflows/test-netbox-main.yaml
+++ b/.github/workflows/test-netbox-main.yaml
@@ -82,11 +82,11 @@ jobs:
                   'tasks':   {'HOST': 'localhost', 'PORT': 6379, 'DATABASE': 0, 'SSL': False},
                   'caching': {'HOST': 'localhost', 'PORT': 6379, 'DATABASE': 1, 'SSL': False},
               }
-              SECRET_KEY = 'test-secret-key-not-for-production-1234567890123456'
-              API_TOKEN_PEPPERS = {0: 'a' * 64}
+              SECRET_KEY = 'test-secret-key-not-for-production-1234567890123456'  # checkov:skip=CKV_SECRET_6
+              API_TOKEN_PEPPERS = {0: 'a' * 64}  # checkov:skip=CKV_SECRET_6
               DEBUG = True
               LOGIN_REQUIRED = False
-          ''').lstrip())
+          ''').lstrip(), encoding='utf-8')
           "
 
       - name: Run NetBox migrations


### PR DESCRIPTION
The configuration.py was written to netbox/netbox/ but NetBox expects it at netbox/netbox/netbox/ (alongside settings.py). The cat heredoc also preserved YAML indentation, producing invalid Python. Replace with python3 textwrap.dedent to generate clean unindented output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->