### PR TITLE
Fix broken Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Copy source code
 COPY *.py ./
 
-COPY core/ .
+COPY core/ core/
 
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,6 @@ RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
 # Set the command
-CMD ["uv", "run", "nb-dt-import.py"]
+# venv is already on PATH, no need for `uv run` overhead
+# -u for unbuffered stdout/stderr (important for Docker logging)
+CMD ["python", "-u", "nb-dt-import.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Copy source code
 COPY *.py ./
 
+COPY core/ .
+
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "device-type-library-import"
-version = "0.1.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
This pull request introduces a small change to the Docker build process by ensuring the `core/` directory is included in the image. This fixes an issue when running the container.

```
Downloading black (1.7MiB)
Downloading virtualenv (5.7MiB)
Downloading ruff (10.6MiB)
 Downloaded black
 Downloaded virtualenv
 Downloaded ruff
Installed 19 packages in 16ms
Bytecode compiled 1106 files in 390ms
Traceback (most recent call last):
  File "/app/nb-dt-import.py", line 8, in <module>
    from core import settings
ModuleNotFoundError: No module named 'core'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker image build now includes core runtime components so required code is present in the container.
  * Container startup updated to run the application directly with unbuffered output, improving startup reliability and ensuring logs appear promptly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->