### PR TITLE
feat: add full port-mappings stanza support with multi-mapping and change detection

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/core/change_detector.py
+++ b/core/change_detector.py
@@ -94,7 +94,7 @@ COMPONENT_TYPES = {
     "power-outlets": ("power_outlet_templates", ["name", "type", "feed_leg", "label"]),
     "console-server-ports": ("console_server_port_templates", ["name", "type", "label"]),
     "rear-ports": ("rear_port_templates", ["name", "type", "positions", "label"]),
-    "front-ports": ("front_port_templates", ["name", "type", "rear_port_position", "label"]),
+    "front-ports": ("front_port_templates", ["name", "type", "_mappings", "label"]),
     "device-bays": ("device_bay_templates", ["name", "label"]),
     "module-bays": ("module_bay_templates", ["name", "position", "label"]),
 }
@@ -361,7 +361,9 @@ class ChangeDetector:
                 else:
                     # Check for property changes on existing component
                     existing = existing_components[comp_name]
-                    prop_changes = self._compare_component_properties(yaml_comp, existing, properties)
+                    prop_changes = self._compare_component_properties(
+                        yaml_comp, existing, properties, comp_type=yaml_key
+                    )
                     if prop_changes:
                         changes.append(
                             ComponentChange(
@@ -379,6 +381,7 @@ class ChangeDetector:
         yaml_comp: dict,
         netbox_comp,
         properties: List[str],
+        comp_type: str = "",
     ) -> List[PropertyChange]:
         """Compare properties between YAML and NetBox component."""
         changes = []
@@ -386,6 +389,44 @@ class ChangeDetector:
         for prop in properties:
             if prop == "name":
                 # Name is the key, skip comparison
+                continue
+
+            if prop == "_mappings" and comp_type == "front-ports":
+                # Only compare when YAML explicitly declares _mappings (absent key = not managed).
+                if "_mappings" not in yaml_comp:
+                    continue
+                # Full port-mapping comparison: compare sets of (rear_port, fp_pos, rp_pos)
+                # so that any change to rear port name, front_port_position, or
+                # rear_port_position is detected.
+                yaml_mappings = yaml_comp.get("_mappings") or []
+                yaml_set = frozenset(
+                    (m.get("rear_port", ""), m.get("front_port_position", 1), m.get("rear_port_position", 1))
+                    for m in yaml_mappings
+                )
+                canonical = getattr(netbox_comp, "_mappings_canonical", None) or []
+                has_names = any(m.get("rear_port_name") is not None for m in canonical)
+                if has_names:
+                    # NetBox >= 4.5: compare with rear port names
+                    netbox_set = frozenset(
+                        (m.get("rear_port_name", ""), m.get("front_port_position", 1), m.get("rear_port_position", 1))
+                        for m in canonical
+                    )
+                else:
+                    # NetBox < 4.5: rear port names unavailable; compare positions only
+                    yaml_set = frozenset(
+                        (m.get("front_port_position", 1), m.get("rear_port_position", 1)) for m in yaml_mappings
+                    )
+                    netbox_set = frozenset(
+                        (m.get("front_port_position", 1), m.get("rear_port_position", 1)) for m in canonical
+                    )
+                if yaml_set != netbox_set:
+                    changes.append(
+                        PropertyChange(
+                            property_name="_mappings",
+                            old_value=netbox_set,
+                            new_value=yaml_set,
+                        )
+                    )
                 continue
 
             # Only compare properties explicitly present in the YAML component;

--- a/core/change_detector.py
+++ b/core/change_detector.py
@@ -88,11 +88,20 @@ IMAGE_PROPERTIES = ["front_image", "rear_image"]
 
 # Component type mapping: YAML key -> (cache_key, comparable_properties)
 COMPONENT_TYPES = {
-    "interfaces": ("interface_templates", ["name", "type", "mgmt_only", "label", "enabled", "poe_mode", "poe_type"]),
-    "power-ports": ("power_port_templates", ["name", "type", "maximum_draw", "allocated_draw", "label"]),
+    "interfaces": (
+        "interface_templates",
+        ["name", "type", "mgmt_only", "label", "enabled", "poe_mode", "poe_type"],
+    ),
+    "power-ports": (
+        "power_port_templates",
+        ["name", "type", "maximum_draw", "allocated_draw", "label"],
+    ),
     "console-ports": ("console_port_templates", ["name", "type", "label"]),
     "power-outlets": ("power_outlet_templates", ["name", "type", "feed_leg", "label"]),
-    "console-server-ports": ("console_server_port_templates", ["name", "type", "label"]),
+    "console-server-ports": (
+        "console_server_port_templates",
+        ["name", "type", "label"],
+    ),
     "rear-ports": ("rear_port_templates", ["name", "type", "positions", "label"]),
     "front-ports": ("front_port_templates", ["name", "type", "_mappings", "label"]),
     "device-bays": ("device_bay_templates", ["name", "label"]),
@@ -400,7 +409,11 @@ class ChangeDetector:
                 # rear_port_position is detected.
                 yaml_mappings = yaml_comp.get("_mappings") or []
                 yaml_set = frozenset(
-                    (m.get("rear_port", ""), m.get("front_port_position", 1), m.get("rear_port_position", 1))
+                    (
+                        m.get("rear_port", ""),
+                        m.get("front_port_position", 1),
+                        m.get("rear_port_position", 1),
+                    )
                     for m in yaml_mappings
                 )
                 canonical = getattr(netbox_comp, "_mappings_canonical", None) or []
@@ -408,16 +421,28 @@ class ChangeDetector:
                 if has_names:
                     # NetBox >= 4.5: compare with rear port names
                     netbox_set = frozenset(
-                        (m.get("rear_port_name", ""), m.get("front_port_position", 1), m.get("rear_port_position", 1))
+                        (
+                            m.get("rear_port_name", ""),
+                            m.get("front_port_position", 1),
+                            m.get("rear_port_position", 1),
+                        )
                         for m in canonical
                     )
                 else:
                     # NetBox < 4.5: rear port names unavailable; compare positions only
                     yaml_set = frozenset(
-                        (m.get("front_port_position", 1), m.get("rear_port_position", 1)) for m in yaml_mappings
+                        (
+                            m.get("front_port_position", 1),
+                            m.get("rear_port_position", 1),
+                        )
+                        for m in yaml_mappings
                     )
                     netbox_set = frozenset(
-                        (m.get("front_port_position", 1), m.get("rear_port_position", 1)) for m in canonical
+                        (
+                            m.get("front_port_position", 1),
+                            m.get("rear_port_position", 1),
+                        )
+                        for m in canonical
                     )
                 if yaml_set != netbox_set:
                     changes.append(

--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -90,7 +90,13 @@ COMPONENT_TEMPLATE_FIELDS = {
     "console_server_port_templates": ["id", "name", "type", "label"],
     "power_outlet_templates": ["id", "name", "type", "feed_leg", "label"],
     "rear_port_templates": ["id", "name", "type", "positions", "label"],
-    "front_port_templates": ["id", "name", "type", "label", "rear_port_position"],
+    "front_port_templates": [
+        "id",
+        "name",
+        "type",
+        "label",
+        "mappings { id front_port_position rear_port_position rear_port { id name } }",
+    ],
     "device_bay_templates": ["id", "name", "label"],
     "module_bay_templates": ["id", "name", "position", "label"],
 }
@@ -509,10 +515,19 @@ class NetBoxGraphQLClient:
         try:
             items = self.query_all(query, list_key=list_key, on_page=on_page)
         except GraphQLError as original_exc:
-            if endpoint_name == "front_port_templates" and "rear_port_position" in fields:
-                # rear_port_position was removed in NetBox >= 4.5 (replaced by M2M rear_ports).
-                # Retry without it so the query works on both schema versions.
-                fallback_fields = [f for f in fields if f != "rear_port_position"]
+            if endpoint_name == "front_port_templates":
+                # mappings subfield was added in NetBox 4.5.  On older versions fall back to
+                # the legacy rear_port_position direct field.  Conversely, rear_port_position
+                # was removed in 4.5, so if mappings failed for some other reason we also
+                # try rear_port_position as last resort.
+                has_mappings = any("mappings" in f for f in fields)
+                has_rpp = "rear_port_position" in fields
+                if has_mappings:
+                    fallback_fields = ["rear_port_position" if "mappings" in f else f for f in fields]
+                elif has_rpp:
+                    fallback_fields = [f for f in fields if f != "rear_port_position"]
+                else:
+                    raise
                 field_block = "\n            ".join(fallback_fields)
                 fallback_query = f"""
         query($pagination: OffsetPaginationInput) {{

--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -84,8 +84,24 @@ ENDPOINT_TO_LIST_KEY = {
 # Mapping of endpoint names (as used in DeviceTypes) to their GraphQL fields.
 # Every entry also includes ``device_type { id }`` and ``module_type { id }`` automatically.
 COMPONENT_TEMPLATE_FIELDS = {
-    "interface_templates": ["id", "name", "type", "mgmt_only", "label", "enabled", "poe_mode", "poe_type"],
-    "power_port_templates": ["id", "name", "type", "maximum_draw", "allocated_draw", "label"],
+    "interface_templates": [
+        "id",
+        "name",
+        "type",
+        "mgmt_only",
+        "label",
+        "enabled",
+        "poe_mode",
+        "poe_type",
+    ],
+    "power_port_templates": [
+        "id",
+        "name",
+        "type",
+        "maximum_draw",
+        "allocated_draw",
+        "label",
+    ],
     "console_port_templates": ["id", "name", "type", "label"],
     "console_server_port_templates": ["id", "name", "type", "label"],
     "power_outlet_templates": ["id", "name", "type", "feed_leg", "label"],
@@ -516,18 +532,16 @@ class NetBoxGraphQLClient:
             items = self.query_all(query, list_key=list_key, on_page=on_page)
         except GraphQLError as original_exc:
             if endpoint_name == "front_port_templates":
-                # mappings subfield was added in NetBox 4.5.  On older versions fall back to
-                # the legacy rear_port_position direct field.  Conversely, rear_port_position
-                # was removed in 4.5, so if mappings failed for some other reason we also
-                # try rear_port_position as last resort.
+                # Three-tier fallback for front_port_templates:
+                #   1. Primary:         mappings { ... }       (NetBox 4.5+)
+                #   2. First fallback:  rear_port_position     (<4.5 direct scalar field)
+                #   3. Second fallback: neither                (future: field removed entirely)
                 has_mappings = any("mappings" in f for f in fields)
-                has_rpp = "rear_port_position" in fields
-                if has_mappings:
-                    fallback_fields = ["rear_port_position" if "mappings" in f else f for f in fields]
-                elif has_rpp:
-                    fallback_fields = [f for f in fields if f != "rear_port_position"]
-                else:
+                if not has_mappings:
                     raise
+
+                # First fallback: replace the mappings block with the scalar rear_port_position
+                fallback_fields = ["rear_port_position" if "mappings" in f else f for f in fields]
                 field_block = "\n            ".join(fallback_fields)
                 fallback_query = f"""
         query($pagination: OffsetPaginationInput) {{
@@ -540,7 +554,24 @@ class NetBoxGraphQLClient:
                 try:
                     items = self.query_all(fallback_query, list_key=list_key, on_page=on_page)
                 except GraphQLError as fallback_exc:
-                    raise fallback_exc from original_exc
+                    # Second fallback: strip rear_port_position too
+                    second_fallback_fields = [f for f in fallback_fields if f != "rear_port_position"]
+                    if len(second_fallback_fields) == len(fallback_fields):
+                        # rear_port_position wasn't in fallback_fields — nothing more to try
+                        raise fallback_exc from original_exc
+                    field_block = "\n            ".join(second_fallback_fields)
+                    second_fallback_query = f"""
+        query($pagination: OffsetPaginationInput) {{
+          {list_key}(pagination: $pagination) {{
+            {field_block}
+            {parent_fields}
+          }}
+        }}
+        """
+                    try:
+                        items = self.query_all(second_fallback_query, list_key=list_key, on_page=on_page)
+                    except GraphQLError as second_exc:
+                        raise second_exc from original_exc
             else:
                 raise
         return [_to_dotdict(item) for item in items]

--- a/core/log_handler.py
+++ b/core/log_handler.py
@@ -42,8 +42,11 @@ class LogHandler:
                 f"SSL verification failed. IGNORE_SSL_ERRORS is {exception}. "
                 f"Set IGNORE_SSL_ERRORS to True if you want to ignore this error. EXITING."
             ),
-            "GitCommandError": f'The repo "{exception}" is not a valid git repo.',
+            "GitCommandError": f'Git error for repo "{exception}".',
             "GitInvalidRepositoryError": f'The repo "{exception}" is not a valid git repo.',
+            "GitBranchNotFound": (
+                f'Branch "{exception}" was not found in the remote repository. Check your REPO_BRANCH setting.'
+            ),
             "InvalidGitURL": f"Invalid Git URL: {exception}. URL must use HTTPS, SSH, or file protocol.",
             "InvalidRepoPath": f'Invalid repository path "{exception}".',
             "Exception": f'An unknown error occurred: "{exception}"',

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -1832,41 +1832,44 @@ class DeviceTypes:
         """Merge a ``_mappings`` PropertyChange into *update_data*.
 
         On NetBox >= 4.5 (M2M model) builds and sets ``update_data["rear_ports"]``.
-        On legacy NetBox (<4.5) translates the first mapping to scalar ``rear_port``
-        and ``rear_port_position`` fields.  Logs a warning and leaves *update_data*
-        unchanged when the referenced rear port cannot be resolved.
+        On legacy NetBox (<4.5) translates a mapping tuple to scalar ``rear_port``
+        and ``rear_port_position`` fields, or clears those fields when the mapping
+        is empty.  Logs a warning and leaves *update_data* unchanged when the
+        referenced rear port cannot be resolved.
         """
         if self.m2m_front_ports:
             payload = self._build_mappings_patch(comp_name, new_mappings, device_type_id, parent_type)
             if payload is not None:
                 update_data["rear_ports"] = payload
         else:
-            if new_mappings:
-                first = next(iter(new_mappings))
-                if len(first) != 3:
-                    # Legacy NetBox (<4.5): ChangeDetector emits 2-tuples (fp_pos, rp_pos)
-                    # because rear port names are unavailable via the GraphQL API.
-                    # Cannot update the FK without the rear port name; skip and warn.
-                    self.handle.log(
-                        f"Warning: cannot update mappings for '{comp_name}' on NetBox < 4.5:"
-                        " rear port names unavailable, skipping mapping update"
-                    )
-                    return
-                rp_name, _fp_pos, rp_pos = first
-                rps = self._get_cached_or_fetch(
-                    "rear_port_templates",
-                    device_type_id,
-                    parent_type,
-                    self.netbox.dcim.rear_port_templates,
+            if not new_mappings:
+                # Explicit empty stanza: clear the existing legacy rear port link.
+                update_data["rear_port"] = None
+                update_data["rear_port_position"] = None
+                return
+            first = next(iter(new_mappings))
+            if len(first) != 3:
+                # Legacy NetBox (<4.5): ChangeDetector emits 2-tuples (fp_pos, rp_pos)
+                # because rear port names are unavailable via the GraphQL API.
+                # Cannot update the FK without the rear port name; skip and warn.
+                self.handle.log(
+                    f"Warning: cannot update mappings for '{comp_name}' on NetBox < 4.5:"
+                    " rear port names unavailable, skipping mapping update"
                 )
-                rp = rps.get(rp_name)
-                if rp:
-                    update_data["rear_port"] = rp.id
-                    update_data["rear_port_position"] = rp_pos
-                else:
-                    self.handle.log(
-                        f"Warning: cannot update mappings for '{comp_name}': rear port '{rp_name}' not found"
-                    )
+                return
+            rp_name, _fp_pos, rp_pos = first
+            rps = self._get_cached_or_fetch(
+                "rear_port_templates",
+                device_type_id,
+                parent_type,
+                self.netbox.dcim.rear_port_templates,
+            )
+            rp = rps.get(rp_name)
+            if rp:
+                update_data["rear_port"] = rp.id
+                update_data["rear_port_position"] = rp_pos
+            else:
+                self.handle.log(f"Warning: cannot update mappings for '{comp_name}': rear port '{rp_name}' not found")
 
     def _apply_updates_for_type(self, comp_type, changes, device_type_id, parent_type):
         """Apply property updates for all changed components of a single type.

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -1842,8 +1842,23 @@ class DeviceTypes:
                 update_data["rear_ports"] = payload
         else:
             if new_mappings:
-                rp_name, _fp_pos, rp_pos = next(iter(new_mappings))
-                rps = self.cached_components.get("rear_port_templates", {}).get((parent_type, device_type_id), {})
+                first = next(iter(new_mappings))
+                if len(first) != 3:
+                    # Legacy NetBox (<4.5): ChangeDetector emits 2-tuples (fp_pos, rp_pos)
+                    # because rear port names are unavailable via the GraphQL API.
+                    # Cannot update the FK without the rear port name; skip and warn.
+                    self.handle.log(
+                        f"Warning: cannot update mappings for '{comp_name}' on NetBox < 4.5:"
+                        " rear port names unavailable, skipping mapping update"
+                    )
+                    return
+                rp_name, _fp_pos, rp_pos = first
+                rps = self._get_cached_or_fetch(
+                    "rear_port_templates",
+                    device_type_id,
+                    parent_type,
+                    self.netbox.dcim.rear_port_templates,
+                )
                 rp = rps.get(rp_name)
                 if rp:
                     update_data["rear_port"] = rp.id

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -962,27 +962,56 @@ ENDPOINT_CACHE_MAP = {
 }
 
 
-class _FrontPortRecord45:
-    """Thin wrapper around a pynetbox front port template record from NetBox >= 4.5.
+class _FrontPortRecordWithMappings:
+    """Wrapper around a front port template record that normalises port mappings.
 
-    NetBox 4.5 replaced the ``rear_port`` FK + ``rear_port_position`` integer with a
-    ManyToMany ``rear_ports`` mapping (``PortMapping`` through-table).  This wrapper
-    extracts the first mapping entry's ``rear_port_position`` and exposes it as a
-    plain attribute so that :class:`~change_detector.ChangeDetector` can compare it
-    against YAML values using the same ``getattr(record, "rear_port_position")`` call
-    as before, without any changes to the detection logic.
+    Supports two data shapes returned by the GraphQL client:
+
+    * **NetBox >= 4.5** — GraphQL ``mappings`` list with ``front_port_position``,
+      ``rear_port_position``, and ``rear_port { id name }`` per entry.
+    * **NetBox < 4.5** — GraphQL ``rear_port_position`` scalar (legacy direct field).
+
+    Exposes ``_mappings_canonical`` as a list of dicts for use by
+    :class:`~change_detector.ChangeDetector` and the update-mode PATCH logic::
+
+        [{"rear_port_name": str | None, "front_port_position": int, "rear_port_position": int}]
+
+    All other attribute accesses are forwarded to the underlying record.
     """
 
-    __slots__ = ("_record", "rear_port_position")
+    __slots__ = ("_record", "_mappings_canonical")
 
     def __init__(self, record):
         object.__setattr__(self, "_record", record)
-        rear_ports = list(getattr(record, "rear_ports", None) or [])
-        # None (not 1) is intentional when rear_ports is empty: it means "no
-        # mapping exists" rather than silently defaulting to position 1, which
-        # would hide a genuine data inconsistency (missing M2M linkage).
-        rp_pos = getattr(rear_ports[0], "rear_port_position", 1) if rear_ports else None
-        object.__setattr__(self, "rear_port_position", rp_pos)
+        mappings_raw = getattr(record, "mappings", None)
+        if mappings_raw is not None:
+            # NetBox >= 4.5: mappings is a list of PortTemplateMapping objects
+            canonical = []
+            for m in mappings_raw or []:
+                rp = m.get("rear_port") if isinstance(m, dict) else getattr(m, "rear_port", None)
+                rp_name = (
+                    (rp.get("name") if isinstance(rp, dict) else getattr(rp, "name", None)) if rp is not None else None
+                )
+                fp_pos = (
+                    m.get("front_port_position", 1) if isinstance(m, dict) else getattr(m, "front_port_position", 1)
+                )
+                rp_pos = m.get("rear_port_position", 1) if isinstance(m, dict) else getattr(m, "rear_port_position", 1)
+                canonical.append(
+                    {
+                        "rear_port_name": rp_name,
+                        "front_port_position": fp_pos,
+                        "rear_port_position": rp_pos,
+                    }
+                )
+        else:
+            # NetBox < 4.5: rear_port_position is a direct scalar field
+            rp_pos = getattr(record, "rear_port_position", None)
+            canonical = (
+                [{"rear_port_name": None, "front_port_position": 1, "rear_port_position": rp_pos}]
+                if rp_pos is not None
+                else []
+            )
+        object.__setattr__(self, "_mappings_canonical", canonical)
 
     def __getattr__(self, name):
         return getattr(self._record, name)
@@ -1470,12 +1499,11 @@ class DeviceTypes:
         instead because their GraphQL schema is missing fields that are required
         for accurate change detection.
 
-        ``front_port_templates`` is always fetched via REST when running against
-        NetBox >= 4.5 because the 4.5 M2M port mapping model stores
-        ``rear_port_position`` inside the ``rear_ports`` list rather than as a
-        direct field (GraphQL exposes neither).  Each record is wrapped in
-        :class:`_FrontPortRecord45` so change-detection sees ``rear_port_position``
-        as a regular attribute.
+        ``front_port_templates`` records are always wrapped in
+        :class:`_FrontPortRecordWithMappings` after fetching so that
+        :class:`~change_detector.ChangeDetector` can access ``_mappings_canonical``
+        regardless of whether the server returned ``mappings`` (>= 4.5) or the
+        legacy ``rear_port_position`` scalar (< 4.5).
 
         Args:
             endpoint_name (str): Component template endpoint name (e.g. ``"interface_templates"``).
@@ -1485,23 +1513,19 @@ class DeviceTypes:
         Returns:
             list: All component template records.
         """
-        use_rest = endpoint_name in self.REST_ONLY_ENDPOINTS or (
-            endpoint_name == "front_port_templates" and self.m2m_front_ports
-        )
+        use_rest = endpoint_name in self.REST_ONLY_ENDPOINTS
 
         if use_rest:
             endpoint = getattr(self.netbox.dcim, endpoint_name)
-            raw = list(endpoint.all())
-            if endpoint_name == "front_port_templates" and self.m2m_front_ports:
-                records = [_FrontPortRecord45(r) for r in raw]
-            else:
-                records = raw
+            records = list(endpoint.all())
             if progress_callback is not None and records:
                 progress_callback(endpoint_name, len(records))
             return records
 
         on_page = (lambda n: progress_callback(endpoint_name, n)) if progress_callback is not None else None
         records = self.graphql.get_component_templates(endpoint_name, on_page=on_page)
+        if endpoint_name == "front_port_templates":
+            records = [_FrontPortRecordWithMappings(r) for r in records]
         return records
 
     @staticmethod
@@ -1693,6 +1717,40 @@ class DeviceTypes:
                         f"Error '{excep.error}' creating {component_name}. Items: {failed_items}{context_str}"
                     )
 
+    def _build_mappings_patch(self, comp_name, new_mappings_set, device_type_id, parent_type):
+        """Build the ``rear_ports`` PATCH payload for a front port ``_mappings`` change.
+
+        Args:
+            comp_name (str): Component name for log messages.
+            new_mappings_set: frozenset of ``(rear_port_name, fp_pos, rp_pos)`` tuples.
+            device_type_id: NetBox ID of the parent device or module type.
+            parent_type (str): ``"device"`` or ``"module"``.
+
+        Returns:
+            list | None: ``rear_ports`` payload list, or ``None`` if resolution failed.
+        """
+        existing_rp = self._get_cached_or_fetch(
+            "rear_port_templates", device_type_id, parent_type, self.netbox.dcim.rear_port_templates
+        )
+        rear_ports_payload = []
+        for tup in sorted(new_mappings_set):
+            if len(tup) != 3:
+                # positions-only tuple (<4.5 fallback); cannot rebuild M2M
+                return None
+            rp_name, fp_pos, rp_pos = tup
+            rear_port = existing_rp.get(rp_name)
+            if rear_port is None:
+                self.handle.log(f'Cannot update mapping for "{comp_name}": rear port "{rp_name}" not found in cache.')
+                return None
+            rear_ports_payload.append(
+                {
+                    "position": fp_pos,
+                    "rear_port": rear_port.id,
+                    "rear_port_position": rp_pos,
+                }
+            )
+        return rear_ports_payload
+
     def _apply_updates_for_type(self, comp_type, changes, device_type_id, parent_type):
         """Apply property updates for all changed components of a single type.
 
@@ -1722,29 +1780,12 @@ class DeviceTypes:
                 comp = existing[change.component_name]
                 update_data = {"id": comp.id}
                 for pc in change.property_changes:
-                    if comp_type == "front-ports" and self.m2m_front_ports and pc.property_name == "rear_port_position":
-                        # Build M2M rear_ports array with the updated position
-                        record = getattr(comp, "_record", comp)
-                        existing_mappings = list(getattr(record, "rear_ports", None) or [])
-                        if existing_mappings:
-                            mapping = existing_mappings[0]
-                            rp = getattr(mapping, "rear_port", None)
-                            rear_port_id = getattr(rp, "id", rp)
-                            # "position" is the correct API field name (not
-                            # "front_port_position") — see serializer comment
-                            # in _build_link_rear_ports.
-                            update_data["rear_ports"] = [
-                                {
-                                    "position": getattr(mapping, "position", 1),
-                                    "rear_port": rear_port_id,
-                                    "rear_port_position": pc.new_value,
-                                }
-                            ]
-                        else:
-                            self.handle.log(
-                                f'Cannot update rear_port_position for "{change.component_name}" '
-                                f"— no existing M2M mapping found."
-                            )
+                    if comp_type == "front-ports" and self.m2m_front_ports and pc.property_name == "_mappings":
+                        payload = self._build_mappings_patch(
+                            change.component_name, pc.new_value, device_type_id, parent_type
+                        )
+                        if payload is not None:
+                            update_data["rear_ports"] = payload
                         continue
                     update_data[pc.property_name] = pc.new_value
                 if len(update_data) > 1:  # has fields beyond just "id"
@@ -2061,13 +2102,21 @@ class DeviceTypes:
     def _build_link_rear_ports(self, parent_type, label, context=None):
         """Return a ``post_process`` callable that resolves rear-port name references.
 
-        Resolves each ``rear_port`` name to the corresponding rear-port template ID.
-        Front ports whose ``rear_port`` cannot be resolved are skipped with a log entry.
+        Reads the ``_mappings`` list placed on each front-port dict by
+        :func:`~core.repo.normalize_port_mappings` and resolves each entry's
+        ``rear_port`` name to the corresponding rear-port template ID.
 
-        On NetBox >= 4.5 the M2M port-mapping model is used: the resolved ID and
-        ``rear_port_position`` are sent as ``rear_ports: [{position, rear_port,
-        rear_port_position}]`` instead of the legacy ``rear_port`` / ``rear_port_position``
-        top-level fields (https://github.com/netbox-community/netbox/issues/20564).
+        On NetBox >= 4.5 the M2M port-mapping model is used: each front port
+        receives ``rear_ports: [{position, rear_port, rear_port_position}, ...]``
+        (``position`` is the API name for ``front_port_position``).  Multiple
+        mappings per front port are fully supported.
+
+        On NetBox < 4.5 only the **first** mapping is sent (single FK model); a
+        warning is logged when more than one mapping is present.
+
+        Front ports with no ``_mappings`` and no legacy inline ``rear_port`` key
+        are sent as-is (no rear port linkage).  Front ports whose mapped rear port
+        name cannot be resolved are skipped with a log entry.
 
         Args:
             parent_type (str): ``"device"`` or ``"module"`` — passed to :meth:`_get_cached_or_fetch`.
@@ -2083,29 +2132,76 @@ class DeviceTypes:
 
             ports_to_remove = []
             for port in items:
-                rp_name = port.get("rear_port")
-                if not rp_name:
+                mappings = port.pop("_mappings", None)
+                if mappings is None:
+                    # Legacy inline fallback (should not happen after normalize_port_mappings,
+                    # but kept for safety when files are loaded without going through repo.py).
+                    rp_name = port.get("rear_port")
+                    if not rp_name:
+                        continue
+                    mappings = [
+                        {
+                            "rear_port": port.pop("rear_port"),
+                            "front_port_position": 1,
+                            "rear_port_position": port.pop("rear_port_position", 1),
+                        }
+                    ]
+                elif not mappings:
                     continue
-                rear_port = existing_rp.get(rp_name)
-                if rear_port is None:
-                    available = list(existing_rp.keys()) if existing_rp else []
-                    ctx = f" (Context: {context})" if context else ""
-                    self.handle.log(
-                        f'Could not find Rear Port "{rp_name}" for {label} "{port["name"]}". '
-                        f"Available: {available}{ctx}"
+
+                resolved = []
+                skip = False
+                for m in mappings:
+                    rp_name = m["rear_port"]
+                    rear_port = existing_rp.get(rp_name)
+                    if rear_port is None:
+                        available = list(existing_rp.keys()) if existing_rp else []
+                        ctx = f" (Context: {context})" if context else ""
+                        self.handle.log(
+                            f'Could not find Rear Port "{rp_name}" for {label} "{port["name"]}". '
+                            f"Available: {available}{ctx}"
+                        )
+                        skip = True
+                        break
+                    resolved.append(
+                        {
+                            "rear_port": rear_port.id,
+                            "front_port_position": m.get("front_port_position", 1),
+                            "rear_port_position": m.get("rear_port_position", 1),
+                        }
                     )
+
+                if skip:
                     ports_to_remove.append(port)
                     continue
 
                 if m2m:
-                    rp_pos = port.pop("rear_port_position", 1)
-                    port.pop("rear_port", None)
+                    if len(resolved) > 1 and not m2m:
+                        ctx = f" (Context: {context})" if context else ""
+                        self.handle.log(
+                            f'Multiple mappings for {label} "{port["name"]}" on NetBox < 4.5: '
+                            f"only first mapping applied{ctx}"
+                        )
                     # "position" is the correct API field name — the NetBox serializer
                     # declares `position = IntegerField(source='front_port_position')`,
                     # so the REST API accepts "position", NOT "front_port_position".
-                    port["rear_ports"] = [{"position": 1, "rear_port": rear_port.id, "rear_port_position": rp_pos}]
+                    port["rear_ports"] = [
+                        {
+                            "position": r["front_port_position"],
+                            "rear_port": r["rear_port"],
+                            "rear_port_position": r["rear_port_position"],
+                        }
+                        for r in resolved
+                    ]
                 else:
-                    port["rear_port"] = rear_port.id
+                    if len(resolved) > 1:
+                        ctx = f" (Context: {context})" if context else ""
+                        self.handle.log(
+                            f'Multiple mappings for {label} "{port["name"]}" on NetBox < 4.5: '
+                            f"only first mapping applied{ctx}"
+                        )
+                    port["rear_port"] = resolved[0]["rear_port"]
+                    port["rear_port_position"] = resolved[0]["rear_port_position"]
 
             for port in ports_to_remove:
                 items.remove(port)

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -20,7 +20,17 @@ def _build_auth_header(token):
 
 
 # Supported image file extensions for module-type image uploads
-IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tif", ".tiff", ".svg"}
+IMAGE_EXTENSIONS = {
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".bmp",
+    ".webp",
+    ".tif",
+    ".tiff",
+    ".svg",
+}
 
 # Maximum number of IDs per endpoint.filter() call to avoid excessively long URLs.
 FILTER_CHUNK_SIZE = 200
@@ -111,7 +121,11 @@ class NetBox:
         self.connect_api()
         self.verify_compatibility()
         self.graphql = NetBoxGraphQLClient(
-            self.url, self.token, self.ignore_ssl, log_handler=self.handle, page_size=settings.GRAPHQL_PAGE_SIZE
+            self.url,
+            self.token,
+            self.ignore_ssl,
+            log_handler=self.handle,
+            page_size=settings.GRAPHQL_PAGE_SIZE,
         )
         self.existing_manufacturers = self.get_manufacturers()
         self.device_types = DeviceTypes(
@@ -261,7 +275,14 @@ class NetBox:
         return saved_images
 
     def _handle_existing_device_type(
-        self, dt, device_type, manufacturer_slug, saved_images, only_new, dt_change, remove_components
+        self,
+        dt,
+        device_type,
+        manufacturer_slug,
+        saved_images,
+        only_new,
+        dt_change,
+        remove_components,
     ):
         """Process an existing device type: upload images, apply updates, and log status.
 
@@ -321,7 +342,10 @@ class NetBox:
             # Apply component changes
             if dt_change.component_changes:
                 self.device_types.update_components(
-                    device_type, dt.id, dt_change.component_changes, parent_type="device"
+                    device_type,
+                    dt.id,
+                    dt_change.component_changes,
+                    parent_type="device",
                 )
                 if remove_components:
                     self.device_types.remove_components(dt.id, dt_change.component_changes, parent_type="device")
@@ -460,7 +484,13 @@ class NetBox:
             if dt is not None:
                 dt_change = change_by_key.get((manufacturer_slug, device_type.get("model", "")))
                 if self._handle_existing_device_type(
-                    dt, device_type, manufacturer_slug, saved_images, only_new, dt_change, remove_components
+                    dt,
+                    device_type,
+                    manufacturer_slug,
+                    saved_images,
+                    only_new,
+                    dt_change,
+                    remove_components,
                 ):
                     continue
 
@@ -755,7 +785,12 @@ class NetBox:
         return True
 
     def create_module_types(
-        self, module_types, progress=None, only_new=False, all_module_types=None, module_type_existing_images=None
+        self,
+        module_types,
+        progress=None,
+        only_new=False,
+        all_module_types=None,
+        module_type_existing_images=None,
     ):
         """Create or update module types and their component templates in NetBox.
 
@@ -785,7 +820,11 @@ class NetBox:
             if "src" in curr_mt:
                 del curr_mt["src"]
             if not self._process_single_module_type(
-                curr_mt, src_file, all_module_types, module_type_existing_images, only_new
+                curr_mt,
+                src_file,
+                all_module_types,
+                module_type_existing_images,
+                only_new,
             ):
                 continue
 
@@ -954,7 +993,10 @@ ENDPOINT_CACHE_MAP = {
     "power-port": ("power_port_templates", "power_port_templates"),
     "console-ports": ("console_port_templates", "console_port_templates"),
     "power-outlets": ("power_outlet_templates", "power_outlet_templates"),
-    "console-server-ports": ("console_server_port_templates", "console_server_port_templates"),
+    "console-server-ports": (
+        "console_server_port_templates",
+        "console_server_port_templates",
+    ),
     "rear-ports": ("rear_port_templates", "rear_port_templates"),
     "front-ports": ("front_port_templates", "front_port_templates"),
     "device-bays": ("device_bay_templates", "device_bay_templates"),
@@ -1007,7 +1049,13 @@ class _FrontPortRecordWithMappings:
             # NetBox < 4.5: rear_port_position is a direct scalar field
             rp_pos = getattr(record, "rear_port_position", None)
             canonical = (
-                [{"rear_port_name": None, "front_port_position": 1, "rear_port_position": rp_pos}]
+                [
+                    {
+                        "rear_port_name": None,
+                        "front_port_position": 1,
+                        "rear_port_position": rp_pos,
+                    }
+                ]
                 if rp_pos is not None
                 else []
             )
@@ -1283,7 +1331,14 @@ class DeviceTypes:
         self._preload_global(components, progress_wrapper, progress=progress)
 
     def _preload_track_progress(
-        self, components, futures, progress, task_ids, preload_job, progress_updates, endpoint_totals
+        self,
+        components,
+        futures,
+        progress,
+        task_ids,
+        preload_job,
+        progress_updates,
+        endpoint_totals,
     ):
         """Collect preload results and advance progress tasks as each endpoint future completes.
 
@@ -1332,12 +1387,25 @@ class DeviceTypes:
             # Exclude from pending to avoid double stop_task.
             pending -= already_done
         self._drain_pending(
-            pending, future_map, progress, task_ids, progress_updates, endpoint_totals, records_by_endpoint
+            pending,
+            future_map,
+            progress,
+            task_ids,
+            progress_updates,
+            endpoint_totals,
+            records_by_endpoint,
         )
         return records_by_endpoint
 
     def _drain_pending(
-        self, pending, future_map, progress, task_ids, progress_updates, endpoint_totals, records_by_endpoint
+        self,
+        pending,
+        future_map,
+        progress,
+        task_ids,
+        progress_updates,
+        endpoint_totals,
+        records_by_endpoint,
     ):
         """Wait for pending endpoint futures to complete, collecting results and updating progress.
 
@@ -1473,7 +1541,13 @@ class DeviceTypes:
                         for endpoint, label in components
                     }
                 records_by_endpoint = self._preload_track_progress(
-                    components, futures, progress, task_ids, preload_job, progress_updates, endpoint_totals
+                    components,
+                    futures,
+                    progress,
+                    task_ids,
+                    preload_job,
+                    progress_updates,
+                    endpoint_totals,
                 )
             else:
                 records_by_endpoint = self._preload_no_progress(components, futures)
@@ -1730,7 +1804,10 @@ class DeviceTypes:
             list | None: ``rear_ports`` payload list, or ``None`` if resolution failed.
         """
         existing_rp = self._get_cached_or_fetch(
-            "rear_port_templates", device_type_id, parent_type, self.netbox.dcim.rear_port_templates
+            "rear_port_templates",
+            device_type_id,
+            parent_type,
+            self.netbox.dcim.rear_port_templates,
         )
         rear_ports_payload = []
         for tup in sorted(new_mappings_set):
@@ -1750,6 +1827,31 @@ class DeviceTypes:
                 }
             )
         return rear_ports_payload
+
+    def _apply_mappings_change(self, comp_name, new_mappings, update_data, device_type_id, parent_type):
+        """Merge a ``_mappings`` PropertyChange into *update_data*.
+
+        On NetBox >= 4.5 (M2M model) builds and sets ``update_data["rear_ports"]``.
+        On legacy NetBox (<4.5) translates the first mapping to scalar ``rear_port``
+        and ``rear_port_position`` fields.  Logs a warning and leaves *update_data*
+        unchanged when the referenced rear port cannot be resolved.
+        """
+        if self.m2m_front_ports:
+            payload = self._build_mappings_patch(comp_name, new_mappings, device_type_id, parent_type)
+            if payload is not None:
+                update_data["rear_ports"] = payload
+        else:
+            if new_mappings:
+                rp_name, _fp_pos, rp_pos = next(iter(new_mappings))
+                rps = self.cached_components.get("rear_port_templates", {}).get((parent_type, device_type_id), {})
+                rp = rps.get(rp_name)
+                if rp:
+                    update_data["rear_port"] = rp.id
+                    update_data["rear_port_position"] = rp_pos
+                else:
+                    self.handle.log(
+                        f"Warning: cannot update mappings for '{comp_name}': rear port '{rp_name}' not found"
+                    )
 
     def _apply_updates_for_type(self, comp_type, changes, device_type_id, parent_type):
         """Apply property updates for all changed components of a single type.
@@ -1780,12 +1882,14 @@ class DeviceTypes:
                 comp = existing[change.component_name]
                 update_data = {"id": comp.id}
                 for pc in change.property_changes:
-                    if comp_type == "front-ports" and self.m2m_front_ports and pc.property_name == "_mappings":
-                        payload = self._build_mappings_patch(
-                            change.component_name, pc.new_value, device_type_id, parent_type
+                    if comp_type == "front-ports" and pc.property_name == "_mappings":
+                        self._apply_mappings_change(
+                            change.component_name,
+                            pc.new_value,
+                            update_data,
+                            device_type_id,
+                            parent_type,
                         )
-                        if payload is not None:
-                            update_data["rear_ports"] = payload
                         continue
                     update_data[pc.property_name] = pc.new_value
                 if len(update_data) > 1:  # has fields beyond just "id"
@@ -1983,7 +2087,10 @@ class DeviceTypes:
 
         if bridged_interfaces:
             all_interfaces = self._get_cached_or_fetch(
-                "interface_templates", device_type, "device", self.netbox.dcim.interface_templates
+                "interface_templates",
+                device_type,
+                "device",
+                self.netbox.dcim.interface_templates,
             )
 
             to_update = []
@@ -2035,7 +2142,10 @@ class DeviceTypes:
 
         def link_ports(items, pid):
             existing_pp = self._get_cached_or_fetch(
-                "power_port_templates", pid, "device", self.netbox.dcim.power_port_templates
+                "power_port_templates",
+                pid,
+                "device",
+                self.netbox.dcim.power_port_templates,
             )
 
             outlets_to_remove = []
@@ -2127,7 +2237,10 @@ class DeviceTypes:
 
         def link_rear_ports(items, pid):
             existing_rp = self._get_cached_or_fetch(
-                "rear_port_templates", pid, parent_type, self.netbox.dcim.rear_port_templates
+                "rear_port_templates",
+                pid,
+                parent_type,
+                self.netbox.dcim.rear_port_templates,
             )
 
             ports_to_remove = []
@@ -2292,7 +2405,10 @@ class DeviceTypes:
 
         def link_ports(items, pid):
             existing_pp = self._get_cached_or_fetch(
-                "power_port_templates", pid, "module", self.netbox.dcim.power_port_templates
+                "power_port_templates",
+                pid,
+                "module",
+                self.netbox.dcim.power_port_templates,
             )
 
             outlets_to_remove = []
@@ -2403,7 +2519,11 @@ class DeviceTypes:
             for field, path in images.items():
                 file_handles[field] = (os.path.basename(path), open(path, "rb"))
             response = requests.patch(
-                url, headers=headers, files=file_handles, verify=(not self.ignore_ssl), timeout=60
+                url,
+                headers=headers,
+                files=file_handles,
+                verify=(not self.ignore_ssl),
+                timeout=60,
             )
             response.raise_for_status()
             self.handle.verbose_log(f"Images {images} updated at {url}: {response.status_code}")

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -1828,7 +1828,7 @@ class DeviceTypes:
             )
         return rear_ports_payload
 
-    def _apply_mappings_change(self, comp_name, new_mappings, update_data, device_type_id, parent_type):
+    def _apply_mappings_change(self, comp_name, new_mappings, yaml_mappings, update_data, device_type_id, parent_type):
         """Merge a ``_mappings`` PropertyChange into *update_data*.
 
         On NetBox >= 4.5 (M2M model) builds and sets ``update_data["rear_ports"]``.
@@ -1836,6 +1836,15 @@ class DeviceTypes:
         and ``rear_port_position`` fields, or clears those fields when the mapping
         is empty.  Logs a warning and leaves *update_data* unchanged when the
         referenced rear port cannot be resolved.
+
+        Args:
+            comp_name (str): Front port component name (for logging).
+            new_mappings: New mapping value from PropertyChange (frozenset of tuples).
+            yaml_mappings (list): Raw YAML ``_mappings`` entries for this front port,
+                used as a fallback on legacy NetBox when ChangeDetector emits 2-tuples.
+            update_data (dict): Payload dict being built for the NetBox update call.
+            device_type_id: NetBox ID of the parent device or module type.
+            parent_type (str): ``"device"`` or ``"module"``.
         """
         if self.m2m_front_ports:
             payload = self._build_mappings_patch(comp_name, new_mappings, device_type_id, parent_type)
@@ -1851,13 +1860,18 @@ class DeviceTypes:
             if len(first) != 3:
                 # Legacy NetBox (<4.5): ChangeDetector emits 2-tuples (fp_pos, rp_pos)
                 # because rear port names are unavailable via the GraphQL API.
-                # Cannot update the FK without the rear port name; skip and warn.
-                self.handle.log(
-                    f"Warning: cannot update mappings for '{comp_name}' on NetBox < 4.5:"
-                    " rear port names unavailable, skipping mapping update"
-                )
-                return
-            rp_name, _fp_pos, rp_pos = first
+                # Fall back to the YAML _mappings entry which does include the name.
+                if not yaml_mappings:
+                    self.handle.log(
+                        f"Warning: cannot update mappings for '{comp_name}' on NetBox < 4.5:"
+                        " rear port names unavailable, skipping mapping update"
+                    )
+                    return
+                first_yaml = yaml_mappings[0]
+                rp_name = first_yaml.get("rear_port")
+                rp_pos = first_yaml.get("rear_port_position", 1)
+            else:
+                rp_name, _fp_pos, rp_pos = first
             rps = self._get_cached_or_fetch(
                 "rear_port_templates",
                 device_type_id,
@@ -1871,7 +1885,7 @@ class DeviceTypes:
             else:
                 self.handle.log(f"Warning: cannot update mappings for '{comp_name}': rear port '{rp_name}' not found")
 
-    def _apply_updates_for_type(self, comp_type, changes, device_type_id, parent_type):
+    def _apply_updates_for_type(self, comp_type, changes, yaml_data, device_type_id, parent_type):
         """Apply property updates for all changed components of a single type.
 
         Looks up the NetBox endpoint for *comp_type*, fetches or uses the cached
@@ -1881,6 +1895,8 @@ class DeviceTypes:
         Args:
             comp_type (str): YAML component key (e.g. ``"interfaces"``).
             changes (list): ComponentChange objects with change_type COMPONENT_CHANGED.
+            yaml_data (dict): Full parsed YAML for the device type, used to look up
+                ``_mappings`` entries for front ports on legacy NetBox.
             device_type_id: NetBox ID of the parent device or module type.
             parent_type (str): ``"device"`` or ``"module"``.
         """
@@ -1901,9 +1917,14 @@ class DeviceTypes:
                 update_data = {"id": comp.id}
                 for pc in change.property_changes:
                     if comp_type == "front-ports" and pc.property_name == "_mappings":
+                        yaml_front_port = next(
+                            (p for p in (yaml_data.get("front-ports") or []) if p.get("name") == change.component_name),
+                            None,
+                        )
                         self._apply_mappings_change(
                             change.component_name,
                             pc.new_value,
+                            (yaml_front_port or {}).get("_mappings") or [],
                             update_data,
                             device_type_id,
                             parent_type,
@@ -2016,7 +2037,7 @@ class DeviceTypes:
                 changes_to_add[change.component_type].append(change)
 
         for comp_type, changes in changes_to_update.items():
-            self._apply_updates_for_type(comp_type, changes, device_type_id, parent_type)
+            self._apply_updates_for_type(comp_type, changes, yaml_data, device_type_id, parent_type)
 
         for comp_type, changes in changes_to_add.items():
             self._apply_additions_for_type(comp_type, changes, yaml_data, device_type_id, parent_type)

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -2307,12 +2307,6 @@ class DeviceTypes:
                     continue
 
                 if m2m:
-                    if len(resolved) > 1 and not m2m:
-                        ctx = f" (Context: {context})" if context else ""
-                        self.handle.log(
-                            f'Multiple mappings for {label} "{port["name"]}" on NetBox < 4.5: '
-                            f"only first mapping applied{ctx}"
-                        )
                     # "position" is the correct API field name — the NetBox serializer
                     # declares `position = IntegerField(source='front_port_position')`,
                     # so the REST API accepts "position", NOT "front_port_position".

--- a/core/repo.py
+++ b/core/repo.py
@@ -86,6 +86,117 @@ def validate_repo_path(repo_path):
     return True, ""
 
 
+def normalize_port_mappings(data):
+    """Normalize port mapping definitions in a parsed YAML device/module type dict.
+
+    Supports two input formats and converts both to a unified internal representation:
+
+    **Old inline format** (``rear_port`` / ``rear_port_position`` on each front-port entry)::
+
+        front-ports:
+          - name: FP1
+            type: 8p8c
+            rear_port: RP1
+            rear_port_position: 1   # optional, default 1
+
+    **New NetBox 4.5 port-mappings stanza**::
+
+        port-mappings:
+          - front_port: FP1
+            rear_port: RP1
+            front_port_position: 1  # optional, default 1
+            rear_port_position: 1   # optional, default 1
+
+    In both cases the result is that each front-port entry gains a ``_mappings`` list::
+
+        [{"rear_port": "<rear-port-name>", "front_port_position": 1, "rear_port_position": 1}]
+
+    The inline ``rear_port`` / ``rear_port_position`` keys and the top-level
+    ``port-mappings`` stanza are removed from *data* in-place.
+
+    Args:
+        data (dict): Parsed YAML dict.  Modified in-place.
+
+    Returns:
+        str | None: An ``"Error: ..."`` string describing a validation failure, or
+            ``None`` on success.
+    """
+    front_ports = data.get("front-ports") or []
+    port_mappings_stanza = data.get("port-mappings")
+
+    if not front_ports and not port_mappings_stanza:
+        return None
+
+    front_by_name = {fp["name"]: fp for fp in front_ports if fp.get("name")}
+    rear_ports = data.get("rear-ports") or []
+    rear_by_name = {rp["name"]: rp for rp in rear_ports if rp.get("name")}
+
+    # --- Old inline format ---
+    # Collect rear_port references declared directly on front-port entries.
+    inline_mappings = {}  # {front_port_name: [mapping_dict, ...]}
+    for fp in front_ports:
+        rp_name = fp.get("rear_port")
+        if rp_name is None:
+            continue
+        fp_name = fp.get("name")
+        rp_pos = fp.pop("rear_port_position", 1)
+        fp.pop("rear_port")
+        inline_mappings.setdefault(fp_name, []).append(
+            {
+                "rear_port": rp_name,
+                "front_port_position": 1,
+                "rear_port_position": rp_pos,
+            }
+        )
+
+    # --- New port-mappings stanza ---
+    stanza_mappings = {}  # {front_port_name: [mapping_dict, ...]}
+    if port_mappings_stanza:
+        for entry in port_mappings_stanza:
+            fp_name = entry.get("front_port")
+            rp_name = entry.get("rear_port")
+            if not fp_name or not rp_name:
+                return f"Error: port-mappings entry missing front_port or rear_port: {entry!r}"
+            if fp_name not in front_by_name:
+                return f"Error: port-mappings references unknown front_port '{fp_name}'"
+            if rear_by_name and rp_name not in rear_by_name:
+                return f"Error: port-mappings references unknown rear_port '{rp_name}'"
+            stanza_mappings.setdefault(fp_name, []).append(
+                {
+                    "rear_port": rp_name,
+                    "front_port_position": entry.get("front_port_position", 1),
+                    "rear_port_position": entry.get("rear_port_position", 1),
+                }
+            )
+        del data["port-mappings"]
+
+    # --- Conflict detection ---
+    # Accept both formats simultaneously only when they describe identical mappings.
+    if inline_mappings and stanza_mappings:
+        all_names = set(inline_mappings) | set(stanza_mappings)
+        for name in all_names:
+            inline = sorted(
+                (m["rear_port"], m["front_port_position"], m["rear_port_position"])
+                for m in inline_mappings.get(name, [])
+            )
+            stanza = sorted(
+                (m["rear_port"], m["front_port_position"], m["rear_port_position"])
+                for m in stanza_mappings.get(name, [])
+            )
+            if inline != stanza:
+                return (
+                    f"Error: front port '{name}' has conflicting mapping definitions "
+                    f"(inline: {inline}, port-mappings stanza: {stanza})"
+                )
+
+    effective = stanza_mappings if stanza_mappings else inline_mappings
+    for fp_name, mappings in effective.items():
+        if fp_name in front_by_name:
+            front_by_name[fp_name]["_mappings"] = mappings
+
+    return None
+
+
 def parse_single_file(file):
     """Load a YAML device mapping, convert its `manufacturer` to a slug dictionary, and record the source path.
 
@@ -106,6 +217,9 @@ def parse_single_file(file):
             # (e.g., RuggedCOM vs RuggedCom in upstream data)
             data["manufacturer"] = {"slug": re_sub(r"\W+", "-", manufacturer.lower())}
             data["src"] = file
+            err = normalize_port_mappings(data)
+            if err:
+                return err
             return data
         except yaml.YAMLError as excep:
             return f"Error: {excep}"

--- a/core/repo.py
+++ b/core/repo.py
@@ -317,8 +317,9 @@ class DTLRepo:
     def pull_repo(self):
         """Pull the latest changes for the configured branch from the existing local repository.
 
-        Opens the existing clone at ``self.repo_path``, validates the origin URL, pulls from
-        origin, and checks out ``self.branch``. Reports errors via the configured exception handler.
+        Opens the existing clone at ``self.repo_path``, validates the origin URL (updating it
+        if REPO_URL has changed), fetches from origin, and checks out ``self.branch``.
+        Reports errors via the configured exception handler.
         """
         try:
             self.handle.log(
@@ -326,12 +327,29 @@ class DTLRepo:
             )
             self.repo = Repo(self.repo_path)
             origin_url = self.repo.remotes.origin.url
-            is_valid, error_msg = validate_git_url(origin_url)
-            if not is_valid:
-                self.handle.exception("InvalidGitURL", origin_url, error_msg)
-            self.repo.remotes.origin.pull()
-            self.repo.git.checkout(self.branch)
-            self.handle.verbose_log(f"Pulled Repo {self.repo.remotes.origin.url}")
+
+            # If the configured URL differs from the current remote, update it so the
+            # fetch pulls from the right place (e.g. user switched forks in .env).
+            if self.url and origin_url != self.url:
+                is_valid, error_msg = validate_git_url(self.url)
+                if not is_valid:
+                    self.handle.exception("InvalidGitURL", self.url, error_msg)
+                self.handle.verbose_log(f"Remote URL changed ({origin_url} → {self.url}), updating origin")
+                self.repo.remotes.origin.set_url(self.url)
+            else:
+                is_valid, error_msg = validate_git_url(origin_url)
+                if not is_valid:
+                    self.handle.exception("InvalidGitURL", origin_url, error_msg)
+
+            self.repo.remotes.origin.fetch()
+
+            remote_branch_names = [ref.name for ref in self.repo.remotes.origin.refs]
+            if f"origin/{self.branch}" not in remote_branch_names:
+                self.handle.exception("GitBranchNotFound", self.branch)
+
+            # -B creates the branch if absent or resets it to the remote ref if present
+            self.repo.git.checkout("-B", self.branch, f"origin/{self.branch}")
+            self.handle.verbose_log(f"Updated repo from {self.repo.remotes.origin.url}")
         except exc.GitCommandError as git_error:
             self.handle.exception("GitCommandError", self.repo.remotes.origin.url, git_error)
         except Exception as git_error:

--- a/core/repo.py
+++ b/core/repo.py
@@ -124,7 +124,7 @@ def normalize_port_mappings(data):
     front_ports = data.get("front-ports") or []
     port_mappings_stanza = data.get("port-mappings")
 
-    if not front_ports and not port_mappings_stanza:
+    if not front_ports and "port-mappings" not in data:
         return None
 
     front_by_name = {fp["name"]: fp for fp in front_ports if fp.get("name")}
@@ -344,7 +344,7 @@ class DTLRepo:
                 if not is_valid:
                     self.handle.exception("InvalidGitURL", origin_url, error_msg)
 
-            self.repo.remotes.origin.fetch()
+            self.repo.remotes.origin.fetch(prune=True)
 
             remote_branch_names = [ref.name for ref in self.repo.remotes.origin.refs]
             if f"origin/{self.branch}" not in remote_branch_names:

--- a/core/repo.py
+++ b/core/repo.py
@@ -128,6 +128,7 @@ def normalize_port_mappings(data):
         return None
 
     front_by_name = {fp["name"]: fp for fp in front_ports if fp.get("name")}
+    rear_ports_declared = "rear-ports" in data
     rear_ports = data.get("rear-ports") or []
     rear_by_name = {rp["name"]: rp for rp in rear_ports if rp.get("name")}
 
@@ -139,7 +140,7 @@ def normalize_port_mappings(data):
         if rp_name is None:
             continue
         fp_name = fp.get("name")
-        if rear_by_name and rp_name not in rear_by_name:
+        if rear_ports_declared and rp_name not in rear_by_name:
             return f"Error: front-port '{fp_name}' references unknown rear_port '{rp_name}'"
         rp_pos = fp.pop("rear_port_position", 1)
         fp.pop("rear_port")
@@ -161,7 +162,7 @@ def normalize_port_mappings(data):
                 return f"Error: port-mappings entry missing front_port or rear_port: {entry!r}"
             if fp_name not in front_by_name:
                 return f"Error: port-mappings references unknown front_port '{fp_name}'"
-            if rear_by_name and rp_name not in rear_by_name:
+            if rear_ports_declared and rp_name not in rear_by_name:
                 return f"Error: port-mappings references unknown rear_port '{rp_name}'"
             stanza_mappings.setdefault(fp_name, []).append(
                 {

--- a/core/repo.py
+++ b/core/repo.py
@@ -139,6 +139,8 @@ def normalize_port_mappings(data):
         if rp_name is None:
             continue
         fp_name = fp.get("name")
+        if rear_by_name and rp_name not in rear_by_name:
+            return f"Error: front-port '{fp_name}' references unknown rear_port '{rp_name}'"
         rp_pos = fp.pop("rear_port_position", 1)
         fp.pop("rear_port")
         inline_mappings.setdefault(fp_name, []).append(
@@ -151,8 +153,8 @@ def normalize_port_mappings(data):
 
     # --- New port-mappings stanza ---
     stanza_mappings = {}  # {front_port_name: [mapping_dict, ...]}
-    if port_mappings_stanza:
-        for entry in port_mappings_stanza:
+    if "port-mappings" in data:
+        for entry in port_mappings_stanza or []:
             fp_name = entry.get("front_port")
             rp_name = entry.get("rear_port")
             if not fp_name or not rp_name:

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -451,7 +451,11 @@ def _process_device_types(args, netbox, handle, progress, device_types, cache_pr
             with _image_progress_scope(progress, netbox.device_types, total=image_total):
                 netbox.create_device_types(
                     device_types_to_process,
-                    progress=get_progress_wrapper(progress, device_types_to_process, desc="Processing Device Types"),
+                    progress=get_progress_wrapper(
+                        progress,
+                        device_types_to_process,
+                        desc="Processing Device Types",
+                    ),
                     only_new=False,
                     update=True,
                     change_report=change_report,
@@ -666,9 +670,17 @@ def main():
 
     parser = ArgumentParser(description="Import Netbox Device Types")
     parser.add_argument(
-        "--vendors", nargs="+", default=settings.VENDORS, help="List of vendors to import eg. apc cisco"
+        "--vendors",
+        nargs="+",
+        default=settings.VENDORS,
+        help="List of vendors to import eg. apc cisco",
     )
-    parser.add_argument("--url", "--git", default=settings.REPO_URL, help="Git URL with valid Device Type YAML files")
+    parser.add_argument(
+        "--url",
+        "--git",
+        default=settings.REPO_URL,
+        help="Git URL with valid Device Type YAML files",
+    )
     parser.add_argument(
         "--slugs",
         nargs="+",
@@ -686,7 +698,10 @@ def main():
 
     mode_group = parser.add_mutually_exclusive_group()
     mode_group.add_argument(
-        "--only-new", action="store_true", default=False, help="Only create new devices, skip existing ones"
+        "--only-new",
+        action="store_true",
+        default=False,
+        help="Only create new devices, skip existing ones",
     )
     mode_group.add_argument(
         "--update",

--- a/tests/fixtures/device-types/TestVendor/patch-panel-4-stanza.yaml
+++ b/tests/fixtures/device-types/TestVendor/patch-panel-4-stanza.yaml
@@ -1,0 +1,38 @@
+---
+manufacturer: TestVendor
+model: Test Patch Panel 4-Port Stanza
+slug: testvendor-patch-panel-4-stanza
+part_number: TPP-4S
+u_height: 1
+is_full_depth: false
+front-ports:
+  - name: FP1
+    type: 8p8c
+  - name: FP2
+    type: 8p8c
+  - name: FP3
+    type: 8p8c
+  - name: FP4
+    type: 8p8c
+rear-ports:
+  - name: RP1
+    type: 110-punch
+    positions: 1
+  - name: RP2
+    type: 110-punch
+    positions: 1
+  - name: RP3
+    type: 110-punch
+    positions: 1
+  - name: RP4
+    type: 110-punch
+    positions: 1
+port-mappings:
+  - front_port: FP1
+    rear_port: RP1
+  - front_port: FP2
+    rear_port: RP2
+  - front_port: FP3
+    rear_port: RP3
+  - front_port: FP4
+    rear_port: RP4

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -71,7 +71,11 @@ sys.path.insert(0, str(REPO_ROOT))
 
 # Import after sys.path manipulation so local modules resolve correctly.
 from core.change_detector import DEVICE_TYPE_PROPERTIES  # noqa: E402
-from core.graphql_client import COMPONENT_TEMPLATE_FIELDS, NetBoxGraphQLClient, _NO_MODULE_TYPE  # noqa: E402
+from core.graphql_client import (  # noqa: E402
+    COMPONENT_TEMPLATE_FIELDS,
+    NetBoxGraphQLClient,
+    _NO_MODULE_TYPE,
+)
 
 NETBOX_URL = (os.environ.get("NETBOX_URL") or "").rstrip("/") or None
 NETBOX_TOKEN = os.environ.get("NETBOX_TOKEN")
@@ -186,7 +190,12 @@ def test_first_import() -> None:
     assert_field(fd, "weight", 10.5, "full-device")
     assert_field(fd.get("weight_unit") or {}, "value", "kg", "full-device weight_unit")
     assert_field(fd.get("airflow") or {}, "value", "front-to-rear", "full-device airflow")
-    assert_field(fd, "comments", "Integration test device covering all component types.", "full-device")
+    assert_field(
+        fd,
+        "comments",
+        "Integration test device covering all component types.",
+        "full-device",
+    )
 
     fd_id = fd["id"]
 

--- a/tests/test_change_detector.py
+++ b/tests/test_change_detector.py
@@ -464,7 +464,8 @@ class TestCompareComponentPropertiesMappings:
                     "front_port_position": 1,
                     "rear_port_position": 1,
                 }
-            ]
+            ],
+            type="8p8c",
         )
         changes = self._cd()._compare_component_properties(
             yaml_comp,
@@ -472,8 +473,7 @@ class TestCompareComponentPropertiesMappings:
             ["name", "type", "_mappings"],
             comp_type="front-ports",
         )
-        mapping_changes = [c for c in changes if c.property_name == "_mappings"]
-        assert mapping_changes == []
+        assert changes == []
 
     def test_rear_port_name_changed_detected(self):
         """Mapping to a different rear port → change detected."""

--- a/tests/test_change_detector.py
+++ b/tests/test_change_detector.py
@@ -446,11 +446,9 @@ class TestCompareComponentPropertiesMappings:
         """Create a minimal ChangeDetector instance for calling instance methods."""
         return ChangeDetector(MagicMock(), MagicMock())
 
-    def _make_netbox_comp(self, canonical):
-        """Build a mock netbox component with _mappings_canonical."""
-        comp = MagicMock()
-        comp._mappings_canonical = canonical
-        return comp
+    def _make_netbox_comp(self, canonical, **attrs):
+        """Build a netbox component with _mappings_canonical and explicit attributes."""
+        return SimpleNamespace(_mappings_canonical=canonical, **attrs)
 
     def test_identical_mappings_no_change(self):
         """Same mapping on both sides → no property change."""

--- a/tests/test_change_detector.py
+++ b/tests/test_change_detector.py
@@ -266,7 +266,14 @@ class TestDetectChanges:
             existing_by_model={("cisco", "X"): existing},
             cached_components={},
         )
-        dt_data = [{"manufacturer": {"slug": "cisco"}, "model": "X", "slug": "x", "u_height": 2}]
+        dt_data = [
+            {
+                "manufacturer": {"slug": "cisco"},
+                "model": "X",
+                "slug": "x",
+                "u_height": 2,
+            }
+        ]
         report = detector.detect_changes(dt_data)
         assert len(report.modified_device_types) == 1
 
@@ -453,10 +460,19 @@ class TestCompareComponentPropertiesMappings:
             "_mappings": [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1}],
         }
         netbox_comp = self._make_netbox_comp(
-            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+            [
+                {
+                    "rear_port_name": "RP1",
+                    "front_port_position": 1,
+                    "rear_port_position": 1,
+                }
+            ]
         )
         changes = self._cd()._compare_component_properties(
-            yaml_comp, netbox_comp, ["name", "type", "_mappings"], comp_type="front-ports"
+            yaml_comp,
+            netbox_comp,
+            ["name", "type", "_mappings"],
+            comp_type="front-ports",
         )
         mapping_changes = [c for c in changes if c.property_name == "_mappings"]
         assert mapping_changes == []
@@ -468,7 +484,13 @@ class TestCompareComponentPropertiesMappings:
             "_mappings": [{"rear_port": "RP2", "front_port_position": 1, "rear_port_position": 1}],
         }
         netbox_comp = self._make_netbox_comp(
-            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+            [
+                {
+                    "rear_port_name": "RP1",
+                    "front_port_position": 1,
+                    "rear_port_position": 1,
+                }
+            ]
         )
         changes = self._cd()._compare_component_properties(
             yaml_comp, netbox_comp, ["name", "_mappings"], comp_type="front-ports"
@@ -482,7 +504,13 @@ class TestCompareComponentPropertiesMappings:
             "_mappings": [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 2}],
         }
         netbox_comp = self._make_netbox_comp(
-            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+            [
+                {
+                    "rear_port_name": "RP1",
+                    "front_port_position": 1,
+                    "rear_port_position": 1,
+                }
+            ]
         )
         changes = self._cd()._compare_component_properties(
             yaml_comp, netbox_comp, ["name", "_mappings"], comp_type="front-ports"
@@ -499,7 +527,13 @@ class TestCompareComponentPropertiesMappings:
             ],
         }
         netbox_comp = self._make_netbox_comp(
-            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+            [
+                {
+                    "rear_port_name": "RP1",
+                    "front_port_position": 1,
+                    "rear_port_position": 1,
+                }
+            ]
         )
         changes = self._cd()._compare_component_properties(
             yaml_comp, netbox_comp, ["_mappings"], comp_type="front-ports"
@@ -510,7 +544,13 @@ class TestCompareComponentPropertiesMappings:
         """When _mappings is absent from YAML, no comparison is done (absent != removal)."""
         yaml_comp = {"name": "FP1", "type": "8p8c"}  # no _mappings key
         netbox_comp = self._make_netbox_comp(
-            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+            [
+                {
+                    "rear_port_name": "RP1",
+                    "front_port_position": 1,
+                    "rear_port_position": 1,
+                }
+            ]
         )
         changes = self._cd()._compare_component_properties(
             yaml_comp, netbox_comp, ["name", "_mappings"], comp_type="front-ports"
@@ -525,7 +565,13 @@ class TestCompareComponentPropertiesMappings:
         }
         # rear_port_name=None signals < 4.5 path
         netbox_comp = self._make_netbox_comp(
-            [{"rear_port_name": None, "front_port_position": 1, "rear_port_position": 1}]
+            [
+                {
+                    "rear_port_name": None,
+                    "front_port_position": 1,
+                    "rear_port_position": 1,
+                }
+            ]
         )
         changes = self._cd()._compare_component_properties(
             yaml_comp, netbox_comp, ["_mappings"], comp_type="front-ports"

--- a/tests/test_change_detector.py
+++ b/tests/test_change_detector.py
@@ -425,3 +425,110 @@ class TestCompareImageProperties:
 
         assert len(changes) == 1
         assert changes[0].property_name == "front_image"
+
+
+# ---------------------------------------------------------------------------
+# _compare_component_properties: front-port _mappings comparison
+# ---------------------------------------------------------------------------
+
+
+class TestCompareComponentPropertiesMappings:
+    """Tests for _mappings comparison in _compare_component_properties."""
+
+    def _cd(self):
+        """Create a minimal ChangeDetector instance for calling instance methods."""
+        return ChangeDetector(MagicMock(), MagicMock())
+
+    def _make_netbox_comp(self, canonical):
+        """Build a mock netbox component with _mappings_canonical."""
+        comp = MagicMock()
+        comp._mappings_canonical = canonical
+        return comp
+
+    def test_identical_mappings_no_change(self):
+        """Same mapping on both sides → no property change."""
+        yaml_comp = {
+            "name": "FP1",
+            "type": "8p8c",
+            "_mappings": [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1}],
+        }
+        netbox_comp = self._make_netbox_comp(
+            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+        )
+        changes = self._cd()._compare_component_properties(
+            yaml_comp, netbox_comp, ["name", "type", "_mappings"], comp_type="front-ports"
+        )
+        mapping_changes = [c for c in changes if c.property_name == "_mappings"]
+        assert mapping_changes == []
+
+    def test_rear_port_name_changed_detected(self):
+        """Mapping to a different rear port → change detected."""
+        yaml_comp = {
+            "name": "FP1",
+            "_mappings": [{"rear_port": "RP2", "front_port_position": 1, "rear_port_position": 1}],
+        }
+        netbox_comp = self._make_netbox_comp(
+            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+        )
+        changes = self._cd()._compare_component_properties(
+            yaml_comp, netbox_comp, ["name", "_mappings"], comp_type="front-ports"
+        )
+        assert any(c.property_name == "_mappings" for c in changes)
+
+    def test_rear_port_position_changed_detected(self):
+        """rear_port_position changed → change detected."""
+        yaml_comp = {
+            "name": "FP1",
+            "_mappings": [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 2}],
+        }
+        netbox_comp = self._make_netbox_comp(
+            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+        )
+        changes = self._cd()._compare_component_properties(
+            yaml_comp, netbox_comp, ["name", "_mappings"], comp_type="front-ports"
+        )
+        assert any(c.property_name == "_mappings" for c in changes)
+
+    def test_multi_mapping_added_detected(self):
+        """Adding a second mapping → change detected."""
+        yaml_comp = {
+            "name": "FP1",
+            "_mappings": [
+                {"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1},
+                {"rear_port": "RP1", "front_port_position": 2, "rear_port_position": 2},
+            ],
+        }
+        netbox_comp = self._make_netbox_comp(
+            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+        )
+        changes = self._cd()._compare_component_properties(
+            yaml_comp, netbox_comp, ["_mappings"], comp_type="front-ports"
+        )
+        assert any(c.property_name == "_mappings" for c in changes)
+
+    def test_no_mappings_key_in_yaml_skips_comparison(self):
+        """When _mappings is absent from YAML, no comparison is done (absent != removal)."""
+        yaml_comp = {"name": "FP1", "type": "8p8c"}  # no _mappings key
+        netbox_comp = self._make_netbox_comp(
+            [{"rear_port_name": "RP1", "front_port_position": 1, "rear_port_position": 1}]
+        )
+        changes = self._cd()._compare_component_properties(
+            yaml_comp, netbox_comp, ["name", "_mappings"], comp_type="front-ports"
+        )
+        assert changes == []
+
+    def test_legacy_path_positions_only_comparison(self):
+        """NetBox < 4.5 records (rear_port_name=None): compare only positions."""
+        yaml_comp = {
+            "name": "FP1",
+            "_mappings": [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1}],
+        }
+        # rear_port_name=None signals < 4.5 path
+        netbox_comp = self._make_netbox_comp(
+            [{"rear_port_name": None, "front_port_position": 1, "rear_port_position": 1}]
+        )
+        changes = self._cd()._compare_component_properties(
+            yaml_comp, netbox_comp, ["_mappings"], comp_type="front-ports"
+        )
+        # Positions match → no change
+        assert changes == []

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -1391,6 +1391,32 @@ class TestGetComponentTemplatesFrontPortFallback:
         with pytest.raises(GraphQLError, match="interface field error"):
             client.get_component_templates("interface_templates")
 
+    def test_primary_fails_no_mappings_field_reraises(self, mock_post):
+        """When primary query fails and schema has no 'mappings' field, re-raise immediately.
+
+        Covers graphql_client.py line 541: 'if not has_mappings: raise'.
+        The guard fires when endpoint_name is front_port_templates but the fields list
+        (COMPONENT_TEMPLATE_FIELDS) has been stripped of the 'mappings' entry — meaning
+        there is no fallback query to attempt.
+        """
+        from core.graphql_client import GraphQLError, COMPONENT_TEMPLATE_FIELDS
+        from unittest.mock import patch
+        import core.graphql_client as gc_module
+
+        # Strip 'mappings' from front_port_templates fields so has_mappings is False
+        stripped = {
+            "front_port_templates": [
+                f for f in COMPONENT_TEMPLATE_FIELDS["front_port_templates"] if "mappings" not in f
+            ]
+        }
+
+        mock_post.return_value = self._make_error_response("some field error")
+
+        with patch.dict(gc_module.COMPONENT_TEMPLATE_FIELDS, stripped):
+            client = self._make_client()
+            with pytest.raises(GraphQLError):
+                client.get_component_templates("front_port_templates")
+
 
 class TestCustomPageSize:
     """Verify that the page_size constructor parameter is respected."""

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -128,7 +128,10 @@ class TestNetBoxGraphQLClient:
 
         client = NetBoxGraphQLClient("http://netbox.local", "abcdef1234567890abcdef1234567890abcdef12")
         client._session.headers.update.assert_called_once_with(
-            {"Authorization": "Token abcdef1234567890abcdef1234567890abcdef12", "Content-Type": "application/json"}
+            {
+                "Authorization": "Token abcdef1234567890abcdef1234567890abcdef12",
+                "Content-Type": "application/json",
+            }
         )
 
     def test_v2_token_uses_bearer_auth(self):
@@ -136,7 +139,10 @@ class TestNetBoxGraphQLClient:
 
         client = NetBoxGraphQLClient("http://netbox.local", "nbt_abc123.secrettoken")
         client._session.headers.update.assert_called_once_with(
-            {"Authorization": "Bearer nbt_abc123.secrettoken", "Content-Type": "application/json"}
+            {
+                "Authorization": "Bearer nbt_abc123.secrettoken",
+                "Content-Type": "application/json",
+            }
         )
 
 
@@ -1251,7 +1257,12 @@ class TestGetComponentTemplatesFrontPortFallback:
     def test_primary_mappings_query_succeeds(self, mock_post):
         """Primary mappings query works (NetBox >= 4.5) — no fallback needed."""
         rp = {"id": "7", "name": "RP1"}
-        mapping = {"id": "9", "front_port_position": 1, "rear_port_position": 1, "rear_port": rp}
+        mapping = {
+            "id": "9",
+            "front_port_position": 1,
+            "rear_port_position": 1,
+            "rear_port": rp,
+        }
         front_ports = [
             {
                 "id": "50",
@@ -1330,11 +1341,12 @@ class TestGetComponentTemplatesFrontPortFallback:
         # rear_port_position is not in the mock response data, so not present in record
         assert "rear_port_position" not in records[0]
 
-    def test_fallback_raises_when_retry_also_fails(self, mock_post):
-        """When both the primary and fallback queries fail, re-raises the fallback GraphQLError."""
+    def test_fallback_raises_when_all_retries_fail(self, mock_post):
+        """When primary, first fallback, and second fallback all fail, raises the last error."""
         from core.graphql_client import GraphQLError
 
         mock_post.side_effect = [
+            self._make_error_response("Cannot query field 'mappings'"),
             self._make_error_response("Cannot query field 'rear_port_position'"),
             self._make_error_response("Some other schema error"),
         ]
@@ -1342,6 +1354,32 @@ class TestGetComponentTemplatesFrontPortFallback:
         client = self._make_client()
         with pytest.raises(GraphQLError, match="Some other schema error"):
             client.get_component_templates("front_port_templates")
+
+    def test_second_fallback_without_any_position_field(self, mock_post):
+        """When first fallback (rear_port_position) also fails, retries without position fields."""
+        front_ports = [
+            {
+                "id": "50",
+                "name": "FP1",
+                "type": "8p8c",
+                "label": "",
+                "device_type": {"id": "1"},
+                "module_type": None,
+            }
+        ]
+        mock_post.side_effect = [
+            self._make_error_response("Cannot query field 'mappings'"),
+            self._make_error_response("Cannot query field 'rear_port_position'"),
+            self._make_response({"front_port_template_list": front_ports}),
+            self._make_response({"front_port_template_list": []}),
+        ]
+
+        client = self._make_client()
+        records = client.get_component_templates("front_port_templates")
+
+        assert len(records) == 1
+        assert records[0].name == "FP1"
+        assert records[0].id == 50
 
     def test_non_front_port_graphql_error_is_reraised(self, mock_post):
         """GraphQLError from a non-front_port endpoint propagates unchanged."""

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -940,6 +940,16 @@ class TestGetComponentTemplates:
         for endpoint in expected_endpoints:
             assert endpoint in COMPONENT_TEMPLATE_FIELDS, f"{endpoint} not in COMPONENT_TEMPLATE_FIELDS"
 
+    def test_front_port_templates_uses_mappings_field(self):
+        """front_port_templates fields include the nested mappings subfield (not rear_port_position)."""
+        from core.graphql_client import COMPONENT_TEMPLATE_FIELDS
+
+        fields = COMPONENT_TEMPLATE_FIELDS["front_port_templates"]
+        has_mappings = any("mappings" in f and "{" in f for f in fields)
+        has_rear_port_position_direct = "rear_port_position" in fields
+        assert has_mappings, "Expected mappings { ... } in front_port_templates fields"
+        assert not has_rear_port_position_direct, "rear_port_position should not be a direct field in >= 4.5 schema"
+
     def test_raises_for_unknown_endpoint(self):
         """An unknown endpoint name should raise ValueError."""
         client = self._make_client()
@@ -1212,7 +1222,12 @@ class TestGetModuleTypeImagesObjectIdConversion:
 
 
 class TestGetComponentTemplatesFrontPortFallback:
-    """Tests for the front_port_templates rear_port_position fallback in get_component_templates()."""
+    """Tests for the front_port_templates mappings/rear_port_position fallback in get_component_templates().
+
+    Primary query uses ``mappings { ... }`` (NetBox >= 4.5).  When that fails the
+    fallback uses ``rear_port_position`` (NetBox < 4.5).  When the old-style
+    ``rear_port_position`` primary fails the fallback drops the field entirely.
+    """
 
     def _make_client(self):
         from core.graphql_client import NetBoxGraphQLClient
@@ -1233,8 +1248,63 @@ class TestGetComponentTemplatesFrontPortFallback:
         r.json.return_value = {"errors": [{"message": message}]}
         return r
 
+    def test_primary_mappings_query_succeeds(self, mock_post):
+        """Primary mappings query works (NetBox >= 4.5) — no fallback needed."""
+        rp = {"id": "7", "name": "RP1"}
+        mapping = {"id": "9", "front_port_position": 1, "rear_port_position": 1, "rear_port": rp}
+        front_ports = [
+            {
+                "id": "50",
+                "name": "FP1",
+                "type": "8p8c",
+                "label": "",
+                "mappings": [mapping],
+                "device_type": {"id": "1"},
+                "module_type": None,
+            }
+        ]
+        mock_post.side_effect = [
+            self._make_response({"front_port_template_list": front_ports}),
+            self._make_response({"front_port_template_list": []}),
+        ]
+
+        client = self._make_client()
+        records = client.get_component_templates("front_port_templates")
+
+        assert len(records) == 1
+        assert records[0].name == "FP1"
+        assert records[0].id == 50
+        assert len(records[0].mappings) == 1
+        assert records[0].mappings[0].rear_port.name == "RP1"
+
+    def test_fallback_to_rear_port_position_on_mappings_error(self, mock_post):
+        """When mappings query fails (< 4.5 schema), retries with rear_port_position."""
+        front_ports = [
+            {
+                "id": "50",
+                "name": "FP1",
+                "type": "8p8c",
+                "label": "",
+                "rear_port_position": 2,
+                "device_type": {"id": "1"},
+                "module_type": None,
+            }
+        ]
+        mock_post.side_effect = [
+            self._make_error_response("Cannot query field 'mappings'"),
+            self._make_response({"front_port_template_list": front_ports}),
+            self._make_response({"front_port_template_list": []}),
+        ]
+
+        client = self._make_client()
+        records = client.get_component_templates("front_port_templates")
+
+        assert len(records) == 1
+        assert records[0].name == "FP1"
+        assert records[0].rear_port_position == 2
+
     def test_fallback_without_rear_port_position_on_graphql_error(self, mock_post):
-        """When the primary query fails, retries without rear_port_position and succeeds."""
+        """When the primary query fails for any front_port reason, retries successfully."""
         front_ports = [
             {
                 "id": "50",
@@ -1257,7 +1327,7 @@ class TestGetComponentTemplatesFrontPortFallback:
         assert len(records) == 1
         assert records[0].name == "FP1"
         assert records[0].id == 50
-        # rear_port_position should not be present in the fallback result
+        # rear_port_position is not in the mock response data, so not present in record
         assert "rear_port_position" not in records[0]
 
     def test_fallback_raises_when_retry_also_fails(self, mock_post):

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -1416,6 +1416,8 @@ class TestGetComponentTemplatesFrontPortFallback:
             client = self._make_client()
             with pytest.raises(GraphQLError):
                 client.get_component_templates("front_port_templates")
+            # Guard must fire immediately — no fallback POST should be attempted.
+            assert mock_post.call_count == 1
 
 
 class TestCustomPageSize:

--- a/tests/test_log_handler.py
+++ b/tests/test_log_handler.py
@@ -75,7 +75,10 @@ class TestEmit:
 
     def test_emit_uses_builtin_print_when_no_console(self):
         handle = LogHandler(SimpleNamespace(verbose=False))
-        with patch.object(handle, "_timestamp", return_value="00:00:00"), patch("builtins.print") as mock_print:
+        with (
+            patch.object(handle, "_timestamp", return_value="00:00:00"),
+            patch("builtins.print") as mock_print,
+        ):
             handle.log("test message")
         mock_print.assert_called_once_with("[00:00:00] test message")
 
@@ -113,7 +116,10 @@ class TestVerboseLog:
 
     def test_verbose_logs_when_enabled(self):
         handle = LogHandler(SimpleNamespace(verbose=True))
-        with patch.object(handle, "_timestamp", return_value="00:00:00"), patch("builtins.print") as mock_print:
+        with (
+            patch.object(handle, "_timestamp", return_value="00:00:00"),
+            patch("builtins.print") as mock_print,
+        ):
             handle.verbose_log("verbose message")
         mock_print.assert_called_once_with("[00:00:00] verbose message")
 
@@ -186,7 +192,10 @@ class TestLogModulePortsCreated:
 def test_progress_group_buffers_logs_until_end():
     handle = LogHandler(SimpleNamespace(verbose=False))
 
-    with patch.object(handle, "_timestamp", return_value="12:00:00"), patch("builtins.print") as print_mock:
+    with (
+        patch.object(handle, "_timestamp", return_value="12:00:00"),
+        patch("builtins.print") as print_mock,
+    ):
         handle.start_progress_group()
         handle.log("Buffered message")
         print_mock.assert_not_called()
@@ -199,7 +208,10 @@ def test_progress_group_buffers_logs_until_end():
 def test_progress_group_supports_nested_blocks():
     handle = LogHandler(SimpleNamespace(verbose=False))
 
-    with patch.object(handle, "_timestamp", return_value="12:00:00"), patch("builtins.print") as print_mock:
+    with (
+        patch.object(handle, "_timestamp", return_value="12:00:00"),
+        patch("builtins.print") as print_mock,
+    ):
         handle.start_progress_group()
         handle.start_progress_group()
         handle.log("Nested message")

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -10,7 +10,11 @@ import pytest
 
 
 def _dt_sort_key(d):
-    return (d.get("manufacturer", {}).get("slug", ""), d.get("model", ""), d.get("slug", ""))
+    return (
+        d.get("manufacturer", {}).get("slug", ""),
+        d.get("model", ""),
+        d.get("slug", ""),
+    )
 
 
 @pytest.fixture(scope="module")
@@ -154,7 +158,9 @@ def test_has_missing_device_images_returns_false_when_no_image_changes(nb_dt_imp
     assert not nb_dt_import.has_missing_device_images(report)
 
 
-def test_select_device_types_for_default_mode_scopes_to_new_and_missing_images(nb_dt_import):
+def test_select_device_types_for_default_mode_scopes_to_new_and_missing_images(
+    nb_dt_import,
+):
     device_types = [
         {"manufacturer": {"slug": "cisco"}, "model": "A", "slug": "a"},
         {"manufacturer": {"slug": "cisco"}, "model": "B", "slug": "b"},
@@ -259,7 +265,9 @@ def test_items_per_second_column_uses_finished_speed_when_available(nb_dt_import
     assert str(rendered) == "5.0 it/s"
 
 
-def test_items_per_second_column_uses_elapsed_fallback_when_finished_speed_missing(nb_dt_import):
+def test_items_per_second_column_uses_elapsed_fallback_when_finished_speed_missing(
+    nb_dt_import,
+):
     column = nb_dt_import.ItemsPerSecondColumn()
 
     rendered = column.render(
@@ -665,7 +673,11 @@ class TestMain:
     def test_vendors_and_slugs_flags_log_lines(self, nb_dt_import):
         """--vendors and --slugs args cause their respective log lines to execute."""
         with (
-            patch.object(sys, "argv", ["nb-dt-import.py", "--vendors", "cisco", "--slugs", "ws-c3750"]),
+            patch.object(
+                sys,
+                "argv",
+                ["nb-dt-import.py", "--vendors", "cisco", "--slugs", "ws-c3750"],
+            ),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
             patch("nb_dt_import.ChangeDetector") as MockDetector,
@@ -748,7 +760,10 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py", "--only-new"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.concurrent.futures.ThreadPoolExecutor", return_value=mock_executor),
+            patch(
+                "nb_dt_import.concurrent.futures.ThreadPoolExecutor",
+                return_value=mock_executor,
+            ),
         ):
             mock_nb = _make_mock_netbox(modules=True)
             MockNetBox.return_value = mock_nb
@@ -766,7 +781,10 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py", "--only-new", "--slugs", "my-slug"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.concurrent.futures.ThreadPoolExecutor", return_value=mock_executor),
+            patch(
+                "nb_dt_import.concurrent.futures.ThreadPoolExecutor",
+                return_value=mock_executor,
+            ),
         ):
             mock_nb = _make_mock_netbox(modules=True)
             MockNetBox.return_value = mock_nb
@@ -837,7 +855,10 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py", "--only-new"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.concurrent.futures.ThreadPoolExecutor", return_value=mock_executor),
+            patch(
+                "nb_dt_import.concurrent.futures.ThreadPoolExecutor",
+                return_value=mock_executor,
+            ),
         ):
             mock_nb = _make_mock_netbox(modules=True)
             MockNetBox.return_value = mock_nb
@@ -920,7 +941,11 @@ class TestProcessRackTypes:
             [str(racks_dir / "apc-ar1300.yaml")],
             [{"name": "APC", "slug": "apc"}],
         )
-        rack_type = {"manufacturer": {"slug": "apc"}, "model": "AR1300", "slug": "apc-ar1300"}
+        rack_type = {
+            "manufacturer": {"slug": "apc"},
+            "model": "AR1300",
+            "slug": "apc-ar1300",
+        }
         dtl_repo.parse_files.return_value = [rack_type]
 
         nb_dt_import._process_rack_types(self._make_args(), netbox, dtl_repo, handle, None, set())
@@ -970,7 +995,10 @@ class TestEntryPoint:
 
     def test_entry_point_calls_main_normally(self):
         """Running the script as __main__ with mocked deps completes without error."""
-        with patch("core.repo.DTLRepo") as MockDTLRepo, patch("core.netbox_api.NetBox") as MockNetBox:
+        with (
+            patch("core.repo.DTLRepo") as MockDTLRepo,
+            patch("core.netbox_api.NetBox") as MockNetBox,
+        ):
             MockDTLRepo.return_value = _make_mock_repo()
             MockNetBox.return_value = _make_mock_netbox()
 

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -794,7 +794,8 @@ def test_update_components_legacy_mapping_two_tuple_warns_and_skips(
 ):
     """On legacy NetBox (<4.5), ChangeDetector emits 2-tuples (fp_pos, rp_pos).
 
-    _apply_mappings_change must warn and skip rather than crash with ValueError.
+    When no YAML _mappings are available, _apply_mappings_change must warn and skip
+    rather than crash with ValueError.
     """
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
@@ -825,10 +826,71 @@ def test_update_components_legacy_mapping_two_tuple_warns_and_skips(
 
     endpoint = mock_nb_api.dcim.front_port_templates
     mock_settings.handle.log.reset_mock()
+    # Pass {} (no front-ports in yaml_data) → yaml_mappings is [] → warn and skip
     dt.update_components({}, 1, changes, parent_type="device")
 
     endpoint.update.assert_not_called()
     assert any("NetBox < 4.5" in str(c) for c in mock_settings.handle.log.call_args_list)
+
+
+def test_update_components_legacy_mapping_two_tuple_uses_yaml_fallback(
+    mock_settings, mock_pynetbox, graphql_client, make_device_types
+):
+    """On legacy NetBox (<4.5), 2-tuple ChangeDetector output uses YAML _mappings fallback.
+
+    When ChangeDetector gives 2-tuples but YAML has _mappings, use the rear port
+    name from the YAML entry as a fallback.
+    """
+    from core.change_detector import ChangeType, ComponentChange, PropertyChange
+
+    mock_nb_api = MagicMock()
+    dt = make_device_types(nb_api=mock_nb_api)
+    dt.m2m_front_ports = False
+
+    existing_fp = MagicMock()
+    existing_fp.id = 10
+    existing_fp.name = "FP1"
+
+    rp = MagicMock()
+    rp.id = 99
+
+    dt.cached_components = {
+        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
+        "rear_port_templates": {("device", 1): {"RP1": rp}},
+    }
+
+    # 2-tuple: legacy ChangeDetector cannot include rp_name
+    new_mappings_set = frozenset({(1, 3)})
+    old_mappings_set = frozenset({(1, 1)})
+
+    changes = [
+        ComponentChange(
+            component_type="front-ports",
+            component_name="FP1",
+            change_type=ChangeType.COMPONENT_CHANGED,
+            property_changes=[PropertyChange("_mappings", old_mappings_set, new_mappings_set)],
+        ),
+    ]
+
+    yaml_data = {
+        "front-ports": [
+            {
+                "name": "FP1",
+                "_mappings": [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 3}],
+            }
+        ]
+    }
+
+    endpoint = mock_nb_api.dcim.front_port_templates
+    dt.update_components(yaml_data, 1, changes, parent_type="device")
+
+    endpoint.update.assert_called_once()
+    update_payload = endpoint.update.call_args[0][0][0]
+    assert update_payload["id"] == 10
+    assert "_mappings" not in update_payload
+    assert "rear_ports" not in update_payload
+    assert update_payload["rear_port"] == 99
+    assert update_payload["rear_port_position"] == 3
 
 
 def test_update_components_legacy_mapping_empty_clears_rear_port(

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -1,7 +1,7 @@
 import queue
 import pytest
 from unittest.mock import MagicMock, patch
-from core.netbox_api import NetBox, DeviceTypes, _FrontPortRecord45, _values_equal
+from core.netbox_api import NetBox, DeviceTypes, _FrontPortRecordWithMappings, _values_equal
 from helpers import paginate_dispatch
 
 
@@ -577,38 +577,37 @@ def test_filter_actionable_module_types_includes_module_with_missing_component(
     assert actionable == [module_type]
 
 
-def test_update_components_m2m_front_port_position(mock_settings, mock_pynetbox, graphql_client):
-    """On NetBox 4.5+, rear_port_position updates should use the M2M rear_ports array format."""
+def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox, graphql_client):
+    """On NetBox 4.5+, _mappings updates should rebuild the full M2M rear_ports array."""
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
     dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
     dt.m2m_front_ports = True
 
-    # Simulate an existing front port with M2M mapping.
-    # Delete _record so getattr(comp, "_record", comp) falls through to comp itself.
     existing_fp = MagicMock()
     existing_fp.id = 10
     existing_fp.name = "FP1"
-    del existing_fp._record
-    mapping = MagicMock()
-    mapping.position = 1
-    mapping.rear_port_position = 1
+
     rp = MagicMock()
     rp.id = 99
-    mapping.rear_port = rp
-    existing_fp.rear_ports = [mapping]
 
+    # Cache both front port templates and rear port templates
     dt.cached_components = {
         "front_port_templates": {("device", 1): {"FP1": existing_fp}},
+        "rear_port_templates": {("device", 1): {"RP1": rp}},
     }
+
+    # new_value is a frozenset of (rear_port_name, fp_pos, rp_pos) tuples
+    new_mappings_set = frozenset({("RP1", 1, 2)})
+    old_mappings_set = frozenset({("RP1", 1, 1)})
 
     changes = [
         ComponentChange(
             component_type="front-ports",
             component_name="FP1",
             change_type=ChangeType.COMPONENT_CHANGED,
-            property_changes=[PropertyChange("rear_port_position", 1, 2)],
+            property_changes=[PropertyChange("_mappings", old_mappings_set, new_mappings_set)],
         ),
     ]
 
@@ -618,12 +617,12 @@ def test_update_components_m2m_front_port_position(mock_settings, mock_pynetbox,
     endpoint.update.assert_called_once()
     update_payload = endpoint.update.call_args[0][0][0]
     assert update_payload["id"] == 10
-    assert "rear_port_position" not in update_payload, "Should not have flat rear_port_position"
+    assert "_mappings" not in update_payload, "Should not have raw _mappings key"
     assert update_payload["rear_ports"] == [{"position": 1, "rear_port": 99, "rear_port_position": 2}]
 
 
 def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, graphql_client):
-    """On NetBox 4.5+, a rear_port_position update with no existing M2M mapping should warn, not update."""
+    """On NetBox 4.5+, a _mappings update referencing unknown rear port should warn, not update."""
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
@@ -633,19 +632,21 @@ def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, gr
     existing_fp = MagicMock()
     existing_fp.id = 10
     existing_fp.name = "FP1"
-    del existing_fp._record
-    existing_fp.rear_ports = []  # No M2M mapping
 
     dt.cached_components = {
         "front_port_templates": {("device", 1): {"FP1": existing_fp}},
+        "rear_port_templates": {("device", 1): {}},  # Empty: rear port missing
     }
+
+    new_mappings_set = frozenset({("MISSING_RP", 1, 1)})
+    old_mappings_set = frozenset()
 
     changes = [
         ComponentChange(
             component_type="front-ports",
             component_name="FP1",
             change_type=ChangeType.COMPONENT_CHANGED,
-            property_changes=[PropertyChange("rear_port_position", 1, 2)],
+            property_changes=[PropertyChange("_mappings", old_mappings_set, new_mappings_set)],
         ),
     ]
 
@@ -654,9 +655,7 @@ def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, gr
     dt.update_components({}, 1, changes, parent_type="device")
 
     endpoint.update.assert_not_called()
-    mock_settings.handle.log.assert_any_call(
-        'Cannot update rear_port_position for "FP1" — no existing M2M mapping found.'
-    )
+    assert any("MISSING_RP" in str(c) for c in mock_settings.handle.log.call_args_list)
 
 
 class TestNetBoxConnectApi:
@@ -697,29 +696,51 @@ class TestCreateManufacturersError:
         mock_settings.handle.log.assert_called()
 
 
-class TestFrontPortRecord45:
-    """Tests for TestFrontPortRecord45."""
+class TestFrontPortRecordWithMappings:
+    """Tests for _FrontPortRecordWithMappings."""
 
-    def test_exposes_rear_port_position_from_mapping(self):
-        record = MagicMock()
-        mapping = MagicMock()
-        mapping.rear_port_position = 3
-        record.rear_ports = [mapping]
-        wrapped = _FrontPortRecord45(record)
-        assert wrapped.rear_port_position == 3
+    def test_45_path_builds_canonical_from_mappings(self):
+        """NetBox >= 4.5: canonical list is built from the mappings attribute."""
+        from core.graphql_client import DotDict
 
-    def test_none_when_no_mappings(self):
-        record = MagicMock()
-        record.rear_ports = []
-        wrapped = _FrontPortRecord45(record)
-        assert wrapped.rear_port_position is None
+        rp = DotDict({"id": 7, "name": "RP1"})
+        mapping = DotDict({"id": 9, "front_port_position": 2, "rear_port_position": 3, "rear_port": rp})
+        record = DotDict({"id": 1, "name": "FP1", "type": "8p8c", "mappings": [mapping]})
+        wrapped = _FrontPortRecordWithMappings(record)
+        assert wrapped._mappings_canonical == [
+            {"rear_port_name": "RP1", "front_port_position": 2, "rear_port_position": 3}
+        ]
+
+    def test_45_path_empty_mappings_gives_empty_canonical(self):
+        """NetBox >= 4.5: empty mappings list → empty canonical."""
+        from core.graphql_client import DotDict
+
+        record = DotDict({"id": 1, "name": "FP1", "mappings": []})
+        wrapped = _FrontPortRecordWithMappings(record)
+        assert wrapped._mappings_canonical == []
+
+    def test_legacy_path_uses_rear_port_position_scalar(self):
+        """NetBox < 4.5: rear_port_position scalar → single canonical entry with rear_port_name=None."""
+        record = MagicMock(spec=[])  # no mappings attr
+        record.rear_port_position = 3
+        wrapped = _FrontPortRecordWithMappings(record)
+        assert wrapped._mappings_canonical == [
+            {"rear_port_name": None, "front_port_position": 1, "rear_port_position": 3}
+        ]
+
+    def test_legacy_path_no_rear_port_position_gives_empty_canonical(self):
+        """NetBox < 4.5 with no rear_port_position → empty canonical."""
+        record = MagicMock(spec=[])
+        wrapped = _FrontPortRecordWithMappings(record)
+        assert wrapped._mappings_canonical == []
 
     def test_delegates_unknown_attr_to_record(self):
-        record = MagicMock()
-        record.name = "fp1"
-        record.rear_ports = []
-        wrapped = _FrontPortRecord45(record)
-        assert wrapped.name == "fp1"
+        """Attribute access falls through to the underlying record."""
+        from core.graphql_client import DotDict
+
+        record = DotDict({"id": 1, "name": "FP1", "type": "8p8c", "mappings": []})
+        wrapped = _FrontPortRecordWithMappings(record)
+        assert wrapped.name == "FP1"
 
 
 class TestStopComponentPreload:
@@ -1116,19 +1137,38 @@ class TestUpdateComponentsAdditions:
 class TestFetchGlobalEndpointRestPath:
     """Tests for TestFetchGlobalEndpointRestPath."""
 
-    def test_m2m_front_ports_uses_rest(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_front_port_templates_uses_graphql_and_wraps(
+        self, mock_settings, mock_pynetbox, graphql_client, mock_graphql_requests
+    ):
+        """front_port_templates always uses GraphQL and wraps records with _FrontPortRecordWithMappings."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
-        dt.m2m_front_ports = True
+        dt.m2m_front_ports = True  # no longer affects front_port_templates path
 
-        raw_fp = MagicMock()
-        raw_fp.rear_ports = []
-        mock_nb_api.dcim.front_port_templates.all.return_value = [raw_fp]
+        fp_record = {
+            "id": "1",
+            "name": "FP1",
+            "type": "8p8c",
+            "label": "",
+            "mappings": [],
+            "device_type": {"id": "42"},
+            "module_type": None,
+        }
+
+        # First call returns one record; second call returns empty to stop pagination.
+        resp1 = MagicMock()
+        resp1.raise_for_status = MagicMock()
+        resp1.json.return_value = {"data": {"front_port_template_list": [fp_record]}}
+        resp2 = MagicMock()
+        resp2.raise_for_status = MagicMock()
+        resp2.json.return_value = {"data": {"front_port_template_list": []}}
+        mock_graphql_requests.side_effect = [resp1, resp2]
 
         records = dt._fetch_global_endpoint_records("front_port_templates")
-        mock_nb_api.dcim.front_port_templates.all.assert_called_once()
+        # REST endpoint should NOT be called
+        mock_nb_api.dcim.front_port_templates.all.assert_not_called()
         assert len(records) == 1
-        assert isinstance(records[0], _FrontPortRecord45)
+        assert isinstance(records[0], _FrontPortRecordWithMappings)
 
     def test_rest_only_endpoint_with_progress_callback(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -110,6 +110,24 @@ def mock_settings():
     return settings
 
 
+@pytest.fixture
+def make_device_types(mock_settings, graphql_client):
+    """Create DeviceTypes test instances with standard defaults."""
+
+    def _factory(nb_api=None, handle=None, counter=None, **kwargs):
+        return DeviceTypes(
+            nb_api if nb_api is not None else MagicMock(),
+            handle if handle is not None else mock_settings.handle,
+            counter if counter is not None else MagicMock(),
+            False,
+            False,
+            graphql=kwargs.pop("graphql", graphql_client),
+            **kwargs,
+        )
+
+    return _factory
+
+
 def test_netbox_init(mock_settings, mock_pynetbox):
     # Mock api call
     mock_pynetbox.api.return_value.version = "3.5"
@@ -172,20 +190,13 @@ def test_create_manufacturers_no_new_is_verbose_only(mock_settings, mock_pynetbo
     mock_settings.handle.log.assert_not_called()
 
 
-def test_device_types_create_interfaces(mock_settings, mock_pynetbox, graphql_client):
+def test_device_types_create_interfaces(mock_settings, mock_pynetbox, graphql_client, make_device_types):
     # Setup
     mock_nb_api = mock_pynetbox.api.return_value
     mock_settings.handle = MagicMock()
     mock_counter = MagicMock()
 
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        mock_counter,
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api, counter=mock_counter)
 
     # Mock existing interfaces returns empty list
     mock_nb_api.dcim.interface_templates.filter.return_value = []
@@ -239,7 +250,9 @@ def test_redundant_image_upload(mock_settings, mock_pynetbox):
     nb.device_types.upload_images.assert_not_called()
 
 
-def test_preload_global_builds_component_cache(mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client):
+def test_preload_global_builds_component_cache(
+    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
+):
     mock_nb_api = mock_pynetbox.api.return_value
 
     mock_graphql_requests.side_effect = _make_graphql_dispatch(
@@ -283,14 +296,7 @@ def test_preload_global_builds_component_cache(mock_settings, mock_pynetbox, moc
         }
     )
 
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     dt.preload_all_components(progress_wrapper=None)
 
     assert "interface_templates" in dt.cached_components
@@ -299,7 +305,7 @@ def test_preload_global_builds_component_cache(mock_settings, mock_pynetbox, moc
 
 
 def test_fetch_global_endpoint_records_uses_graphql(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
 ):
     mock_nb_api = mock_pynetbox.api.return_value
 
@@ -351,14 +357,7 @@ def test_fetch_global_endpoint_records_uses_graphql(
         }
     )
 
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     updates = []
 
     records = dt._fetch_global_endpoint_records(
@@ -375,7 +374,7 @@ def test_fetch_global_endpoint_records_uses_graphql(
 
 
 def test_fetch_global_endpoint_records_progress_skipped_when_empty(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
 ):
     mock_nb_api = mock_pynetbox.api.return_value
 
@@ -386,14 +385,7 @@ def test_fetch_global_endpoint_records_progress_skipped_when_empty(
         }
     )
 
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     updates = []
 
     fetched = dt._fetch_global_endpoint_records(
@@ -406,7 +398,9 @@ def test_fetch_global_endpoint_records_progress_skipped_when_empty(
     assert updates == []
 
 
-def test_preload_always_global_caches_all_vendors(mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client):
+def test_preload_always_global_caches_all_vendors(
+    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
+):
     """Preload always fetches all components globally, regardless of vendor filter."""
     mock_nb_api = mock_pynetbox.api.return_value
 
@@ -475,14 +469,7 @@ def test_preload_always_global_caches_all_vendors(mock_settings, mock_pynetbox, 
         }
     )
 
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     dt.preload_all_components(progress_wrapper=None)
 
     # Both vendors are cached because global fetch returns everything
@@ -490,17 +477,12 @@ def test_preload_always_global_caches_all_vendors(mock_settings, mock_pynetbox, 
     assert ("device", 2) in dt.cached_components["interface_templates"]
 
 
-def test_start_component_preload_global_job_can_be_consumed(mock_settings, mock_pynetbox, graphql_client):
+def test_start_component_preload_global_job_can_be_consumed(
+    mock_settings, mock_pynetbox, graphql_client, make_device_types
+):
     mock_nb_api = mock_pynetbox.api.return_value
 
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     preload_job = dt.start_component_preload()
 
     assert preload_job["mode"] == "global"
@@ -508,20 +490,15 @@ def test_start_component_preload_global_job_can_be_consumed(mock_settings, mock_
     assert preload_job["executor"] is None
 
 
-def test_upload_images_success_logs_verbose_only(mock_settings, mock_pynetbox, graphql_client, tmp_path):
+def test_upload_images_success_logs_verbose_only(
+    mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+):
     mock_nb_api = mock_pynetbox.api.return_value
 
     image_file = tmp_path / "front.jpg"
     image_file.write_bytes(b"fake")
 
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     mock_settings.handle.log.reset_mock()
     mock_settings.handle.verbose_log.reset_mock()
 
@@ -643,19 +620,12 @@ def test_filter_actionable_module_types_includes_module_with_missing_component(
     assert actionable == [module_type]
 
 
-def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox, graphql_client):
+def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox, graphql_client, make_device_types):
     """On NetBox 4.5+, _mappings updates should rebuild the full M2M rear_ports array."""
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     dt.m2m_front_ports = True
 
     existing_fp = MagicMock()
@@ -697,19 +667,12 @@ def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox,
     ]
 
 
-def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, graphql_client):
+def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, graphql_client, make_device_types):
     """On NetBox 4.5+, a _mappings update referencing unknown rear port should warn, not update."""
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     dt.m2m_front_ports = True
 
     existing_fp = MagicMock()
@@ -741,19 +704,14 @@ def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, gr
     assert any("MISSING_RP" in str(c) for c in mock_settings.handle.log.call_args_list)
 
 
-def test_update_components_legacy_mapping_translates_to_fields(mock_settings, mock_pynetbox, graphql_client):
+def test_update_components_legacy_mapping_translates_to_fields(
+    mock_settings, mock_pynetbox, graphql_client, make_device_types
+):
     """On legacy NetBox (<4.5), _mappings update should send rear_port + rear_port_position."""
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     dt.m2m_front_ports = False  # Legacy path
 
     existing_fp = MagicMock()
@@ -792,19 +750,14 @@ def test_update_components_legacy_mapping_translates_to_fields(mock_settings, mo
     assert update_payload["rear_port_position"] == 3
 
 
-def test_update_components_legacy_mapping_missing_rear_port_warns(mock_settings, mock_pynetbox, graphql_client):
+def test_update_components_legacy_mapping_missing_rear_port_warns(
+    mock_settings, mock_pynetbox, graphql_client, make_device_types
+):
     """On legacy NetBox (<4.5), _mappings update with missing rear port warns and skips."""
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     dt.m2m_front_ports = False
 
     existing_fp = MagicMock()
@@ -836,7 +789,9 @@ def test_update_components_legacy_mapping_missing_rear_port_warns(mock_settings,
     assert any("MISSING_RP" in str(c) for c in mock_settings.handle.log.call_args_list)
 
 
-def test_update_components_legacy_mapping_two_tuple_warns_and_skips(mock_settings, mock_pynetbox, graphql_client):
+def test_update_components_legacy_mapping_two_tuple_warns_and_skips(
+    mock_settings, mock_pynetbox, graphql_client, make_device_types
+):
     """On legacy NetBox (<4.5), ChangeDetector emits 2-tuples (fp_pos, rp_pos).
 
     _apply_mappings_change must warn and skip rather than crash with ValueError.
@@ -844,14 +799,7 @@ def test_update_components_legacy_mapping_two_tuple_warns_and_skips(mock_setting
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
-    dt = DeviceTypes(
-        mock_nb_api,
-        mock_settings.handle,
-        MagicMock(),
-        False,
-        False,
-        graphql=graphql_client,
-    )
+    dt = make_device_types(nb_api=mock_nb_api)
     dt.m2m_front_ports = False
 
     existing_fp = MagicMock()
@@ -881,6 +829,42 @@ def test_update_components_legacy_mapping_two_tuple_warns_and_skips(mock_setting
 
     endpoint.update.assert_not_called()
     assert any("NetBox < 4.5" in str(c) for c in mock_settings.handle.log.call_args_list)
+
+
+def test_update_components_legacy_mapping_empty_clears_rear_port(
+    mock_settings, mock_pynetbox, graphql_client, make_device_types
+):
+    """On legacy NetBox (<4.5), empty _mappings frozenset should clear rear_port/rear_port_position."""
+    from core.change_detector import ChangeType, ComponentChange, PropertyChange
+
+    mock_nb_api = MagicMock()
+    dt = make_device_types(nb_api=mock_nb_api)
+    dt.m2m_front_ports = False
+
+    existing_fp = MagicMock()
+    existing_fp.id = 10
+    existing_fp.name = "FP1"
+    dt.cached_components = {
+        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
+    }
+
+    changes = [
+        ComponentChange(
+            component_type="front-ports",
+            component_name="FP1",
+            change_type=ChangeType.COMPONENT_CHANGED,
+            property_changes=[PropertyChange("_mappings", frozenset({("RP1", 1, 1)}), frozenset())],
+        ),
+    ]
+
+    endpoint = mock_nb_api.dcim.front_port_templates
+    dt.update_components({}, 1, changes, parent_type="device")
+
+    endpoint.update.assert_called_once()
+    update_payload = endpoint.update.call_args[0][0][0]
+    assert update_payload["id"] == 10
+    assert update_payload["rear_port"] is None
+    assert update_payload["rear_port_position"] is None
 
 
 class TestNetBoxConnectApi:
@@ -981,16 +965,11 @@ class TestStopComponentPreload:
     def test_noop_on_none(self):
         DeviceTypes.stop_component_preload(None)  # should not raise
 
-    def test_cancels_pending_futures_and_shuts_down(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_cancels_pending_futures_and_shuts_down(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         future.done.return_value = False
@@ -1063,55 +1042,27 @@ class TestBuildComponentCache:
 class TestGetFilterKwargs:
     """Tests for TestGetFilterKwargs."""
 
-    def test_device_old_filter(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_device_old_filter(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.new_filters = False
         assert dt._get_filter_kwargs(1, "device") == {"devicetype_id": 1}
 
-    def test_device_new_filter(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_device_new_filter(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.new_filters = True
         assert dt._get_filter_kwargs(1, "device") == {"device_type_id": 1}
 
-    def test_module_new_filter(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_module_new_filter(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.new_filters = True
         assert dt._get_filter_kwargs(5, "module") == {"module_type_id": 5}
 
-    def test_module_old_filter(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_module_old_filter(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.new_filters = False
         assert dt._get_filter_kwargs(5, "module") == {"moduletype_id": 5}
 
@@ -1119,19 +1070,12 @@ class TestGetFilterKwargs:
 class TestCreateGenericError:
     """Tests for TestCreateGenericError."""
 
-    def test_list_error_logs_each_item(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_list_error_logs_each_item(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         import pynetbox as real_pynb
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         endpoint = MagicMock()
@@ -1149,19 +1093,12 @@ class TestCreateGenericError:
         )
         mock_settings.handle.log.assert_called()
 
-    def test_string_error_logs_failed_items(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_string_error_logs_failed_items(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         import pynetbox as real_pynb
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         endpoint = MagicMock()
@@ -1183,16 +1120,9 @@ class TestCreateGenericError:
 class TestRemoveComponents:
     """Tests for TestRemoveComponents."""
 
-    def test_removes_existing_component(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_removes_existing_component(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_comp = MagicMock()
         existing_comp.id = 99
@@ -1206,16 +1136,9 @@ class TestRemoveComponents:
         mock_nb_api.dcim.interface_templates.delete.assert_called_once_with([99])
         mock_settings.handle.log.assert_called()
 
-    def test_skips_component_not_in_cache(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_skips_component_not_in_cache(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         from core.change_detector import ChangeType, ComponentChange
@@ -1225,16 +1148,9 @@ class TestRemoveComponents:
 
         mock_nb_api.dcim.interface_templates.delete.assert_not_called()
 
-    def test_no_changes_is_noop(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_changes_is_noop(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.remove_components(1, [])
         mock_nb_api.dcim.interface_templates.delete.assert_not_called()
 
@@ -1242,58 +1158,38 @@ class TestRemoveComponents:
 class TestCreatePowerConsolePorts:
     """Tests for TestCreatePowerConsolePorts."""
 
-    def test_create_power_ports_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_power_ports_calls_create_generic(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"power_port_templates": {("device", 1): {}}}
         dt.create_power_ports([{"name": "PSU1"}], 1)
         mock_nb_api.dcim.power_port_templates.create.assert_called_once()
 
-    def test_create_console_ports_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_console_ports_calls_create_generic(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"console_port_templates": {("device", 1): {}}}
         dt.create_console_ports([{"name": "Con1"}], 1)
         mock_nb_api.dcim.console_port_templates.create.assert_called_once()
 
-    def test_create_rear_ports_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_rear_ports_calls_create_generic(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"rear_port_templates": {("device", 1): {}}}
         dt.create_rear_ports([{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
         mock_nb_api.dcim.rear_port_templates.create.assert_called_once()
 
-    def test_create_device_bays_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_device_bays_calls_create_generic(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"device_bay_templates": {("device", 1): {}}}
         dt.create_device_bays([{"name": "Bay1"}], 1)
         mock_nb_api.dcim.device_bay_templates.create.assert_called_once()
@@ -1302,19 +1198,14 @@ class TestCreatePowerConsolePorts:
 class TestCreateDeviceTypesNewDT:
     """Tests for TestCreateDeviceTypesNewDT."""
 
-    def test_creates_new_device_type_with_components(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_creates_new_device_type_with_components(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
         mock_nb_api.version = "3.5"
 
         mock_settings.handle = MagicMock()
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         created_dt = MagicMock()
         created_dt.id = 1
@@ -1348,16 +1239,9 @@ class TestCreateDeviceTypesNewDT:
 class TestUploadImageAttachment:
     """Tests for TestUploadImageAttachment."""
 
-    def test_success_returns_true(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_success_returns_true(self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         img_path = tmp_path / "img.png"
         img_path.write_bytes(b"fake")
@@ -1371,18 +1255,13 @@ class TestUploadImageAttachment:
 
         assert result is True
 
-    def test_request_error_returns_false(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_request_error_returns_false(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         import requests as req_lib
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         img_path = tmp_path / "img.png"
         img_path.write_bytes(b"fake")
@@ -1393,16 +1272,9 @@ class TestUploadImageAttachment:
 
         assert result is False
 
-    def test_os_error_returns_false(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_os_error_returns_false(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         result = dt.upload_image_attachment("http://nb", "token", "/nonexistent/img.png", "dcim.moduletype", 42)
         assert result is False
 
@@ -1478,18 +1350,11 @@ class TestCreateModuleTypes:
 class TestUpdateComponentsAdditions:
     """Tests for TestUpdateComponentsAdditions."""
 
-    def test_adds_new_interface_via_create(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_adds_new_interface_via_create(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_ADDED)]
@@ -1503,18 +1368,11 @@ class TestFetchGlobalEndpointRestPath:
     """Tests for TestFetchGlobalEndpointRestPath."""
 
     def test_front_port_templates_uses_graphql_and_wraps(
-        self, mock_settings, mock_pynetbox, graphql_client, mock_graphql_requests
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_graphql_requests
     ):
         """front_port_templates always uses GraphQL and wraps records with _FrontPortRecordWithMappings."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.m2m_front_ports = True  # no longer affects front_port_templates path
 
         fp_record = {
@@ -1542,16 +1400,11 @@ class TestFetchGlobalEndpointRestPath:
         assert len(records) == 1
         assert isinstance(records[0], _FrontPortRecordWithMappings)
 
-    def test_rest_only_endpoint_with_progress_callback(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_rest_only_endpoint_with_progress_callback(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.REST_ONLY_ENDPOINTS = frozenset(["interface_templates"])
 
         raw = MagicMock()
@@ -1568,16 +1421,11 @@ class TestFetchGlobalEndpointRestPath:
 class TestCountDeviceTypeImages:
     """Tests for TestCountDeviceTypeImages."""
 
-    def test_counts_new_image_when_no_existing_dt(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_counts_new_image_when_no_existing_dt(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         # Create a temporary directory structure mimicking device-types
         dev_types_dir = tmp_path / "device-types" / "cisco"
@@ -1604,20 +1452,15 @@ class TestCountDeviceTypeImages:
             count = nb.count_device_type_images(device_types)
         assert count == 1
 
-    def test_skips_existing_dt_with_image(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_skips_existing_dt_with_image(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
 
         existing_dt = MagicMock()
         existing_dt.front_image = "http://netbox/media/front.jpg"
 
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {("cisco", "MySwitch"): existing_dt}
         dt.existing_device_types_by_slug = {}
 
@@ -1644,16 +1487,9 @@ class TestCountDeviceTypeImages:
             count = nb.count_device_type_images(device_types)
         assert count == 0
 
-    def test_no_src_skipped(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_src_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         nb = NetBox(mock_settings, mock_settings.handle)
         nb.device_types = dt
         count = nb.count_device_type_images([{"manufacturer": {"slug": "cisco"}, "model": "X", "slug": "x"}])
@@ -1767,72 +1603,37 @@ class TestCreateModuleTypesBody:
 class TestCreateModuleComponents:
     """Tests for TestCreateModuleComponents."""
 
-    def test_create_module_interfaces(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_module_interfaces(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"interface_templates": {("module", 1): {}}}
         dt.create_module_interfaces([{"name": "xe-0"}], 1)
         mock_nb_api.dcim.interface_templates.create.assert_called_once()
 
-    def test_create_module_power_ports(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_module_power_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"power_port_templates": {("module", 1): {}}}
         dt.create_module_power_ports([{"name": "PSU1"}], 1)
         mock_nb_api.dcim.power_port_templates.create.assert_called_once()
 
-    def test_create_module_console_ports(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_module_console_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"console_port_templates": {("module", 1): {}}}
         dt.create_module_console_ports([{"name": "Con1"}], 1)
         mock_nb_api.dcim.console_port_templates.create.assert_called_once()
 
-    def test_create_module_console_server_ports(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_module_console_server_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"console_server_port_templates": {("module", 1): {}}}
         dt.create_module_console_server_ports([{"name": "CSP1"}], 1)
         mock_nb_api.dcim.console_server_port_templates.create.assert_called_once()
 
-    def test_create_module_rear_ports(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_module_rear_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"rear_port_templates": {("module", 1): {}}}
         dt.create_module_rear_ports([{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
         mock_nb_api.dcim.rear_port_templates.create.assert_called_once()
@@ -1841,17 +1642,12 @@ class TestCreateModuleComponents:
 class TestCreateDeviceTypesImagePaths:
     """Tests for TestCreateDeviceTypesImagePaths."""
 
-    def test_existing_dt_with_image_not_reuploaded(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_existing_dt_with_image_not_reuploaded(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
         mock_settings.handle = MagicMock()
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -1891,16 +1687,11 @@ class TestCreateDeviceTypesImagePaths:
 class TestUploadImagesProgress:
     """Tests for TestUploadImagesProgress."""
 
-    def test_image_progress_callback_called(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_image_progress_callback_called(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         img_path = tmp_path / "front.jpg"
         img_path.write_bytes(b"fake")
@@ -1917,16 +1708,9 @@ class TestUploadImagesProgress:
 
         assert progress_calls == [1]
 
-    def test_upload_images_os_error_logged(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_upload_images_os_error_logged(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.upload_images("http://nb", "token", {"front_image": "/nonexistent/img.jpg"}, 1)
         mock_settings.handle.log.assert_called()
 
@@ -1934,16 +1718,11 @@ class TestUploadImagesProgress:
 class TestCountDeviceTypeImagesEdge:
     """Tests for TestCountDeviceTypeImagesEdge."""
 
-    def test_no_device_types_path_skipped(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_no_device_types_path_skipped(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         nb = NetBox(mock_settings, mock_settings.handle)
         nb.device_types = dt
         # src path that doesn't contain "device-types" → triggers ValueError → continue
@@ -2015,16 +1794,11 @@ class TestCountModuleTypeImages:
 class TestCreateConsoleServerPorts:
     """Tests for TestCreateConsoleServerPorts."""
 
-    def test_create_console_server_ports_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_console_server_ports_calls_create_generic(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"console_server_port_templates": {("device", 1): {}}}
         dt.create_console_server_ports([{"name": "CSP1"}], 1)
         mock_nb_api.dcim.console_server_port_templates.create.assert_called_once()
@@ -2033,16 +1807,11 @@ class TestCreateConsoleServerPorts:
 class TestCreateModuleBays:
     """Tests for TestCreateModuleBays."""
 
-    def test_create_module_bays_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_create_module_bays_calls_create_generic(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"module_bay_templates": {("device", 1): {}}}
         dt.create_module_bays([{"name": "MB1"}], 1)
         mock_nb_api.dcim.module_bay_templates.create.assert_called_once()
@@ -2104,17 +1873,12 @@ class TestCreateManufacturersSuccessLog:
 class TestCreateDeviceTypesImagePaths2:
     """Tests for image discovery/upload branches in create_device_types."""
 
-    def test_no_device_types_in_src_path_sets_image_base_none(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_device_types_in_src_path_sets_image_base_none(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Source path without 'device-types' → image_base = None; no image lookup."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -2137,17 +1901,12 @@ class TestCreateDeviceTypesImagePaths2:
         # Should complete without error; image lookup skipped
         mock_nb_api.dcim.device_types.create.assert_called_once()
 
-    def test_image_base_none_with_front_image_flag_logs_verbose(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_image_base_none_with_front_image_flag_logs_verbose(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """When image_base is None but front_image flag is set, verbose_log is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -2171,17 +1930,10 @@ class TestCreateDeviceTypesImagePaths2:
         nb.create_device_types([device_type])
         assert any("Skipping image discovery" in str(call) for call in mock_settings.handle.verbose_log.call_args_list)
 
-    def test_slug_fallback_verbose_log(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_slug_fallback_verbose_log(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """When model lookup fails but slug lookup succeeds, verbose_log is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -2204,17 +1956,12 @@ class TestCreateDeviceTypesImagePaths2:
         nb.create_device_types([device_type])
         assert any("Device Type found by slug" in str(call) for call in mock_settings.handle.verbose_log.call_args_list)
 
-    def test_rear_image_already_exists_skips_upload(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_rear_image_already_exists_skips_upload(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         """Rear image already present on existing DT → verbose_log + skip upload."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.upload_images = MagicMock()
 
         existing_dt = MagicMock()
@@ -2251,18 +1998,11 @@ class TestCreateDeviceTypesImagePaths2:
         dt.upload_images.assert_not_called()
 
     def test_saved_images_uploaded_for_existing_dt_when_not_present(
-        self, mock_settings, mock_pynetbox, graphql_client, tmp_path
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
     ):
         """When existing DT has no image and a local image is found, upload_images is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.upload_images = MagicMock()
 
         existing_dt = MagicMock()
@@ -2295,17 +2035,12 @@ class TestCreateDeviceTypesImagePaths2:
 
         dt.upload_images.assert_called_once()
 
-    def test_only_new_existing_dt_verbose_log_and_skip(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_only_new_existing_dt_verbose_log_and_skip(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """only_new=True with existing DT → verbose_log containing 'Cached' and skip."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -2342,19 +2077,12 @@ class TestCreateDeviceTypesUpdatePath:
         nb.device_types = dt
         return nb
 
-    def test_update_applies_property_changes(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_update_applies_property_changes(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """update=True with a matching change_report entry applies property changes."""
         from core.change_detector import ChangeReport, DeviceTypeChange, PropertyChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -2384,21 +2112,16 @@ class TestCreateDeviceTypesUpdatePath:
         nb.create_device_types([device_type], update=True, change_report=report)
         mock_nb_api.dcim.device_types.update.assert_called()
 
-    def test_update_property_change_request_error_logged(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_update_property_change_request_error_logged(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """RequestError during property update is caught and logged."""
         import pynetbox as real_pynb2
         from core.change_detector import ChangeReport, DeviceTypeChange, PropertyChange
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -2431,7 +2154,7 @@ class TestCreateDeviceTypesUpdatePath:
         nb.create_device_types([device_type], update=True, change_report=report)
         mock_settings.handle.log.assert_called()
 
-    def test_update_applies_component_changes(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_update_applies_component_changes(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """update=True with component_changes calls update_components (and optionally remove_components)."""
         from core.change_detector import (
             ChangeReport,
@@ -2441,14 +2164,7 @@ class TestCreateDeviceTypesUpdatePath:
         )
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.update_components = MagicMock()
         dt.remove_components = MagicMock()
 
@@ -2480,19 +2196,14 @@ class TestCreateDeviceTypesUpdatePath:
         dt.update_components.assert_called()
         dt.remove_components.assert_called()
 
-    def test_update_verbose_log_when_change_applied(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_update_verbose_log_when_change_applied(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """verbose_log with 'Device Type Updated' when dt_change is not None."""
         from core.change_detector import ChangeReport, DeviceTypeChange, PropertyChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -2525,19 +2236,14 @@ class TestCreateDeviceTypesUpdatePath:
             for call in mock_settings.handle.verbose_log.call_args_list
         )
 
-    def test_no_change_entry_logs_cached_no_pending_updates(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_change_entry_logs_cached_no_pending_updates(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """When update=True but no change_report entry, logs 'No pending updates'."""
         from core.change_detector import ChangeReport
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -2571,20 +2277,13 @@ class TestCreateDeviceTypesUpdatePath:
 class TestCreateDeviceTypesRequestErrorAndComponents:
     """Tests for RequestError on create and all component creation branches."""
 
-    def test_request_error_logs_and_continues(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_request_error_logs_and_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """RequestError on device_types.create is logged and the DT is skipped."""
         import pynetbox as real_pynb2
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -2604,7 +2303,7 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
         nb.create_device_types([device_type])
         mock_settings.handle.log.assert_called()
 
-    def test_creates_all_component_types(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_creates_all_component_types(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """All component type branches are called.
 
         Covers power-port alias, console-ports, power-outlets,
@@ -2612,14 +2311,7 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
         and module-bays.
         """
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
         # Patch all create_* methods on dt
@@ -2671,17 +2363,12 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
         dt.create_device_bays.assert_called()
         dt.create_module_bays.assert_called()
 
-    def test_upload_images_called_for_new_dt(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_upload_images_called_for_new_dt(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         """upload_images is called for newly created DT when saved_images is populated."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
         dt.upload_images = MagicMock()
@@ -2844,18 +2531,13 @@ class TestCreateModuleTypesEdge:
         )
         assert any("Module Type Cached" in str(c) for c in mock_settings.handle.verbose_log.call_args_list)
 
-    def test_only_new_skips_existing_module_component_creation(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_only_new_skips_existing_module_component_creation(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """only_new=True + existing module → skip component creation."""
         mock_pynetbox.api.return_value.version = "3.5"
         nb = NetBox(mock_settings, mock_settings.handle)
-        nb.device_types = DeviceTypes(
-            mock_pynetbox.api.return_value,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         nb.device_types.create_module_interfaces = MagicMock()
 
         existing_mt = MagicMock()
@@ -2879,19 +2561,12 @@ class TestCreateModuleTypesEdge:
         nb.device_types.create_module_interfaces.assert_not_called()
 
     def test_creates_module_type_with_power_outlets_console_server_ports_front_ports(
-        self, mock_settings, mock_pynetbox, graphql_client
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
     ):
         """power-outlets, console-server-ports, front-ports branches in create_module_types."""
         mock_pynetbox.api.return_value.version = "3.5"
         nb = NetBox(mock_settings, mock_settings.handle)
-        nb.device_types = DeviceTypes(
-            mock_pynetbox.api.return_value,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         nb.device_types.create_module_power_outlets = MagicMock()
         nb.device_types.create_module_console_server_ports = MagicMock()
         nb.device_types.create_module_front_ports = MagicMock()
@@ -3026,17 +2701,10 @@ class TestUploadModuleTypeImages:
 class TestStartComponentPreloadProgress:
     """Tests for start_component_preload with a progress object."""
 
-    def test_with_progress_creates_task_ids(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_with_progress_creates_task_ids(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """start_component_preload with a progress object creates task IDs."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         progress = MagicMock()
         progress.add_task.return_value = 1
@@ -3046,17 +2714,10 @@ class TestStartComponentPreloadProgress:
         progress.add_task.assert_called()
         dt.stop_component_preload(preload_job)
 
-    def test_exception_shuts_down_executor(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_exception_shuts_down_executor(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """If _get_endpoint_totals raises, executor is shut down and exception re-raised."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         with patch.object(dt, "_get_endpoint_totals", side_effect=RuntimeError("oops")):
             with pytest.raises(RuntimeError, match="oops"):
@@ -3071,30 +2732,16 @@ class TestStartComponentPreloadProgress:
 class TestPumpPreloadProgress:
     """Tests for pump_preload_progress."""
 
-    def test_returns_false_when_no_preload_job(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_returns_false_when_no_preload_job(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """pump_preload_progress returns False when preload_job is None."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         assert dt.pump_preload_progress(None, MagicMock()) is False
 
-    def test_marks_done_futures(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_marks_done_futures(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Completed futures are moved to finished_endpoints and advanced=True returned."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         future.done.return_value = True
@@ -3113,17 +2760,10 @@ class TestPumpPreloadProgress:
         assert "interface_templates" in preload_job["finished_endpoints"]
         progress.stop_task.assert_called_with(task_id)
 
-    def test_future_exception_sets_final_total_1(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_future_exception_sets_final_total_1(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """When future.result() raises, final_total defaults to 1."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         future.done.return_value = True
@@ -3149,7 +2789,9 @@ class TestPumpPreloadProgress:
 class TestPreloadGlobalWithProgress:
     """Tests for _preload_global with various progress/preload_job configurations."""
 
-    def test_own_executor_with_progress(self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client):
+    def test_own_executor_with_progress(
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
+    ):
         """_preload_global with progress and no preload_job (own executor path)."""
         mock_nb_api = mock_pynetbox.api.return_value
         mock_graphql_requests.side_effect = _make_graphql_dispatch(
@@ -3158,14 +2800,7 @@ class TestPreloadGlobalWithProgress:
                 "interface_template_list": {"data": {"interface_template_list": []}},
             }
         )
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         progress = MagicMock()
         progress.add_task.return_value = 1
@@ -3175,18 +2810,11 @@ class TestPreloadGlobalWithProgress:
         progress.add_task.assert_called()
 
     def test_preload_global_no_progress_future_failure(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """When no progress and a future raises, log is called and result is []."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         broken_future = MagicMock()
         broken_future.result.side_effect = RuntimeError("network error")
@@ -3209,21 +2837,14 @@ class TestPreloadGlobalWithProgress:
         mock_settings.handle.log.assert_any_call("Preload failed for Interface Templates: network error")
 
     def test_preload_global_with_preload_job_already_finished(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """_preload_global with preload_job that has already-finished endpoints."""
         mock_nb_api = mock_pynetbox.api.return_value
         mock_graphql_requests.side_effect = _make_graphql_dispatch(
             {"device_type_list": {"data": {"device_type_list": []}}}
         )
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         future.done.return_value = True
@@ -3254,31 +2875,17 @@ class TestPreloadGlobalWithProgress:
 class TestPreloadModuleTypeComponents:
     """Tests for preload_module_type_components edge cases."""
 
-    def test_empty_ids_returns_immediately(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_empty_ids_returns_immediately(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Empty module_type_ids → return immediately."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.preload_module_type_components(set(), ["interfaces"])
         mock_nb_api.dcim.interface_templates.filter.assert_not_called()
 
-    def test_duplicate_endpoint_skipped(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_duplicate_endpoint_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Same endpoint_attr from two keys is only fetched once."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         mock_nb_api.dcim.power_port_templates.filter.return_value = []
 
         # Both "power-ports" and "power-port" map to the same endpoint_attr
@@ -3286,17 +2893,10 @@ class TestPreloadModuleTypeComponents:
         # Should only call filter once (deduplicated)
         assert mock_nb_api.dcim.power_port_templates.filter.call_count == 1
 
-    def test_item_with_no_module_type_skipped(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_item_with_no_module_type_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Items where item.module_type is None are skipped."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         item_no_mt = MagicMock()
         item_no_mt.module_type = None
@@ -3316,17 +2916,10 @@ class TestPreloadModuleTypeComponents:
 class TestCreateGenericPostProcess:
     """Tests for _create_generic post_process callback."""
 
-    def test_post_process_is_called(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_post_process_is_called(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """post_process callback is invoked before endpoint.create."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"power_outlet_templates": {("device", 1): {}}}
 
         post_calls = []
@@ -3356,19 +2949,12 @@ class TestCreateGenericPostProcess:
 class TestUpdateComponentsMiscBranches:
     """Tests for miscellaneous branches in update_components."""
 
-    def test_no_mapping_for_comp_type_continues(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_mapping_for_comp_type_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Unknown comp_type (no ENDPOINT_CACHE_MAP entry) is silently skipped."""
         from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         changes = [
             ComponentChange(
@@ -3381,20 +2967,13 @@ class TestUpdateComponentsMiscBranches:
         # Should not raise
         dt.update_components({}, 1, changes, parent_type="device")
 
-    def test_no_endpoint_attr_continues(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_endpoint_attr_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """If dcim has no attribute for endpoint_attr, the update loop is skipped."""
         from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
         mock_nb_api = MagicMock(spec=[])  # no attributes on dcim
         mock_nb_api.dcim = MagicMock(spec=[])
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         changes = [
             ComponentChange(
@@ -3407,21 +2986,16 @@ class TestUpdateComponentsMiscBranches:
         # Should not raise
         dt.update_components({}, 1, changes, parent_type="device")
 
-    def test_property_update_success_counter_incremented(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_property_update_success_counter_incremented(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Successful property update increments components_updated counter."""
         from collections import Counter as _Counter
         from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
         mock_nb_api = mock_pynetbox.api.return_value
         counter = _Counter(components_updated=0)
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            counter,
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api, counter=counter)
         dt.m2m_front_ports = False
 
         existing = MagicMock()
@@ -3440,21 +3014,16 @@ class TestUpdateComponentsMiscBranches:
         mock_nb_api.dcim.interface_templates.update.assert_called()
         assert counter["components_updated"] >= 1
 
-    def test_property_update_request_error_logged(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_property_update_request_error_logged(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """RequestError during property update is caught and logged."""
         import pynetbox as real_pynb2
         from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.m2m_front_ports = False
 
         existing = MagicMock()
@@ -3487,19 +3056,12 @@ class TestUpdateComponentsMiscBranches:
 class TestUpdateComponentsAdditionsBranches:
     """Tests for component-addition branches inside update_components."""
 
-    def test_alias_resolution_power_port(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_alias_resolution_power_port(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """'power-port' alias resolves to 'power-ports' component type addition."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"power_port_templates": {("device", 1): {}}}
 
         changes = [ComponentChange("power-ports", "PSU1", ChangeType.COMPONENT_ADDED)]
@@ -3508,57 +3070,36 @@ class TestUpdateComponentsAdditionsBranches:
         dt.update_components(yaml_data, 1, changes, parent_type="device")
         mock_nb_api.dcim.power_port_templates.create.assert_called()
 
-    def test_yaml_key_none_continues(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_yaml_key_none_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """If component_type not in yaml_data (neither canonical nor alias), skip."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_ADDED)]
         # yaml_data has no "interfaces" key
         dt.update_components({}, 1, changes, parent_type="device")
         mock_nb_api.dcim.interface_templates.create.assert_not_called()
 
-    def test_no_mapping_for_added_comp_type(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_mapping_for_added_comp_type(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Unknown comp_type in addition changes is skipped."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         changes = [ComponentChange("nonexistent-type", "x", ChangeType.COMPONENT_ADDED)]
         yaml_data = {"nonexistent-type": [{"name": "x"}]}
         # Should not raise
         dt.update_components(yaml_data, 1, changes)
 
-    def test_no_components_to_add_continues(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_components_to_add_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """If no components in yaml match the change names, skip."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         # yaml has "interfaces" but the name doesn't match the change
@@ -3567,19 +3108,14 @@ class TestUpdateComponentsAdditionsBranches:
         dt.update_components(yaml_data, 1, changes)
         mock_nb_api.dcim.interface_templates.create.assert_not_called()
 
-    def test_front_ports_addition_delegates_to_create_front_ports(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_front_ports_addition_delegates_to_create_front_ports(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """front-ports COMPONENT_ADDED delegates to create_front_ports."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.create_front_ports = MagicMock()
         dt.cached_components = {"front_port_templates": {("device", 1): {}}}
 
@@ -3589,20 +3125,13 @@ class TestUpdateComponentsAdditionsBranches:
         dt.create_front_ports.assert_called_once()
 
     def test_front_ports_addition_module_delegates_to_create_module_front_ports(
-        self, mock_settings, mock_pynetbox, graphql_client
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
     ):
         """front-ports COMPONENT_ADDED for module delegates to create_module_front_ports."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.create_module_front_ports = MagicMock()
         dt.cached_components = {"front_port_templates": {("module", 1): {}}}
 
@@ -3620,57 +3149,36 @@ class TestUpdateComponentsAdditionsBranches:
 class TestRemoveComponentsBranches:
     """Tests for missing branches in remove_components."""
 
-    def test_unknown_comp_type_skipped(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_unknown_comp_type_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """comp_type with no ENDPOINT_CACHE_MAP entry is silently skipped."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         changes = [ComponentChange("nonexistent-type", "x", ChangeType.COMPONENT_REMOVED)]
         dt.remove_components(1, changes)
         # No exception; no delete called
 
-    def test_missing_endpoint_attr_skipped(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_missing_endpoint_attr_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """If dcim has no attribute for endpoint_attr, deletion is skipped."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = MagicMock(spec=[])
         mock_nb_api.dcim = MagicMock(spec=[])
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_REMOVED)]
         dt.remove_components(1, changes)
 
-    def test_request_error_on_delete_is_logged(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_request_error_on_delete_is_logged(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """RequestError during component deletion is caught and logged."""
         import pynetbox as real_pynb2
         from core.change_detector import ChangeType, ComponentChange
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         existing_comp = MagicMock()
         existing_comp.id = 99
@@ -3693,17 +3201,12 @@ class TestRemoveComponentsBranches:
 class TestCreateInterfacesBridge:
     """Tests for bridge-related code paths in create_interfaces."""
 
-    def test_bridge_interface_not_found_logs_error(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_bridge_interface_not_found_logs_error(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """If bridge target interface is not found, handle.log is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         # The created interface will be in cache; bridge target will not be.
@@ -3720,17 +3223,12 @@ class TestCreateInterfacesBridge:
         mock_settings.handle.log.assert_called()
         assert any("Error bridging" in str(c) for c in mock_settings.handle.log.call_args_list)
 
-    def test_bridge_extracts_and_removes_from_interface(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_bridge_extracts_and_removes_from_interface(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Bridge key is extracted before _create_generic and removed from the dict."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         mock_nb_api.dcim.interface_templates.create.return_value = []
@@ -3741,17 +3239,10 @@ class TestCreateInterfacesBridge:
         # "bridge" key should have been removed from the dict
         assert "bridge" not in iface
 
-    def test_bridge_update_success(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_bridge_update_success(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Successful bridge update calls verbose_log."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         eth0 = MagicMock()
         eth0.id = 10
@@ -3770,20 +3261,13 @@ class TestCreateInterfacesBridge:
         mock_nb_api.dcim.interface_templates.update.assert_called_once_with([{"id": 10, "bridge": 20}])
         assert any("Bridged" in str(c) for c in mock_settings.handle.verbose_log.call_args_list)
 
-    def test_bridge_update_request_error_logged(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_bridge_update_request_error_logged(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """RequestError during bridge update is caught and logged."""
         import pynetbox as real_pynb2
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         eth0 = MagicMock()
         eth0.id = 10
@@ -3813,17 +3297,12 @@ class TestCreateInterfacesBridge:
 class TestCreatePowerOutletsInvalidPort:
     """Tests for power outlet creation with missing power_port reference."""
 
-    def test_invalid_power_port_logged_and_outlet_skipped(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_invalid_power_port_logged_and_outlet_skipped(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Power outlet referencing unknown power_port is logged and skipped."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {
             "power_port_templates": {("device", 1): {}},  # no power ports
             "power_outlet_templates": {("device", 1): {}},
@@ -3836,17 +3315,12 @@ class TestCreatePowerOutletsInvalidPort:
         mock_settings.handle.log.assert_called()
         assert any("Could not find Power Port" in str(c) for c in mock_settings.handle.log.call_args_list)
 
-    def test_multiple_outlets_one_invalid_skips_bad_only(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_multiple_outlets_one_invalid_skips_bad_only(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Only the outlet with an invalid power_port is removed; valid one proceeds."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         psu1 = MagicMock()
         psu1.id = 99
@@ -3873,17 +3347,10 @@ class TestCreatePowerOutletsInvalidPort:
 class TestBuildLinkRearPorts:
     """Tests for _build_link_rear_ports and create_front_ports."""
 
-    def test_rear_port_not_found_logs_and_skips(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_rear_port_not_found_logs_and_skips(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Front port whose rear_port cannot be resolved is removed and logged."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {
             "rear_port_templates": {("device", 1): {}},  # no rear ports
             "front_port_templates": {("device", 1): {}},
@@ -3895,17 +3362,10 @@ class TestBuildLinkRearPorts:
         dt.create_front_ports(front_ports, 1, context="test.yaml")
         assert any("Could not find Rear Port" in str(c) for c in mock_settings.handle.log.call_args_list)
 
-    def test_rear_port_found_non_m2m(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_rear_port_found_non_m2m(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Non-M2M path: rear_port is replaced with its ID."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.m2m_front_ports = False
 
         rp = MagicMock()
@@ -3921,17 +3381,10 @@ class TestBuildLinkRearPorts:
         call_args = mock_nb_api.dcim.front_port_templates.create.call_args[0][0]
         assert call_args[0]["rear_port"] == 77
 
-    def test_rear_port_found_m2m(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_rear_port_found_m2m(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """M2M path: rear_ports list is built with position and rear_port_position."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.m2m_front_ports = True
 
         rp = MagicMock()
@@ -3948,17 +3401,10 @@ class TestBuildLinkRearPorts:
         assert call_args[0]["rear_ports"] == [{"position": 1, "rear_port": 77, "rear_port_position": 2}]
         assert "rear_port" not in call_args[0]
 
-    def test_multiple_front_ports_one_invalid(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_multiple_front_ports_one_invalid(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Only invalid front port is skipped; valid one is created."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.m2m_front_ports = False
 
         rp = MagicMock()
@@ -3990,17 +3436,10 @@ class TestBuildLinkRearPorts:
 class TestCreateModuleFrontPorts:
     """Tests for create_module_front_ports."""
 
-    def test_delegates_to_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_delegates_to_create_generic(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """create_module_front_ports calls _create_generic with module parent_type."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.m2m_front_ports = False
 
         rp = MagicMock()
@@ -4025,17 +3464,12 @@ class TestCreateModuleFrontPorts:
 class TestCreateModulePowerOutletsInvalidPort:
     """Tests for module power outlet creation with missing power_port."""
 
-    def test_invalid_power_port_logged_and_skipped(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_invalid_power_port_logged_and_skipped(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Module power outlet with unknown power_port is logged and skipped."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {
             "power_port_templates": {("module", 1): {}},
             "power_outlet_templates": {("module", 1): {}},
@@ -4047,17 +3481,10 @@ class TestCreateModulePowerOutletsInvalidPort:
         dt.create_module_power_outlets(power_outlets, 1, context="test.yaml")
         assert any("Could not find Power Port" in str(c) for c in mock_settings.handle.log.call_args_list)
 
-    def test_multiple_outlets_one_invalid(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_multiple_outlets_one_invalid(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Only the module outlet with an invalid power_port is removed."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         psu1 = MagicMock()
         psu1.id = 88
@@ -4083,17 +3510,12 @@ class TestCreateModulePowerOutletsInvalidPort:
 class TestCreateModuleRearPorts:
     """Tests for create_module_rear_ports."""
 
-    def test_calls_create_generic_with_module_parent(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_calls_create_generic_with_module_parent(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """create_module_rear_ports creates rear ports with module_type parent."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {"rear_port_templates": {("module", 3): {}}}
 
         rear_ports = [{"name": "RP1", "type": "8p8c", "positions": 8}]
@@ -4110,19 +3532,12 @@ class TestCreateModuleRearPorts:
 class TestUploadImagesErrors:
     """Tests for error branches in upload_images."""
 
-    def test_request_exception_logged(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_request_exception_logged(self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path):
         """requests.RequestException during upload is caught and logged."""
         import requests as _req2
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         img = tmp_path / "front.jpg"
         img.write_bytes(b"fake")
@@ -4135,19 +3550,14 @@ class TestUploadImagesErrors:
 
         assert mock_settings.handle.log.called
 
-    def test_file_close_exception_swallowed(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_file_close_exception_swallowed(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         """Exception from fh.close() in the finally block is silently swallowed."""
         import requests as _req2
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         img = tmp_path / "front.jpg"
         img.write_bytes(b"fake")
@@ -4176,17 +3586,12 @@ class TestUploadImagesErrors:
 class TestUploadImageAttachmentProgress:
     """Tests for upload_image_attachment _image_progress and error paths."""
 
-    def test_image_progress_callback_called_on_success(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_image_progress_callback_called_on_success(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         """_image_progress is called with 1 on a successful upload."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         img = tmp_path / "img.png"
         img.write_bytes(b"fake")
@@ -4213,17 +3618,12 @@ class TestUploadImageAttachmentProgress:
 class TestCreateDeviceTypesCornerCases:
     """Corner-case tests for create_device_types (cognitive complexity 35)."""
 
-    def test_progress_iterator_used_when_provided(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_progress_iterator_used_when_provided(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """When a progress object is supplied, iteration goes through it."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -4248,17 +3648,12 @@ class TestCreateDeviceTypesCornerCases:
         nb.create_device_types(device_types, progress=iter(device_types))
         # No assertion needed — just verify no exception
 
-    def test_image_file_not_found_logs_error(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_image_file_not_found_logs_error(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         """When glob finds no image file, handle.log is called with an error."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -4286,17 +3681,12 @@ class TestCreateDeviceTypesCornerCases:
             nb.create_device_types([device_type])
         assert any("Error locating image file" in str(c) for c in mock_settings.handle.log.call_args_list)
 
-    def test_module_bays_not_created_when_modules_false(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_module_bays_not_created_when_modules_false(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """module-bays are only created when self.modules is True."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
         dt.create_module_bays = MagicMock()
@@ -4402,18 +3792,11 @@ class TestPreloadGlobalCornerCases:
     """Corner-case tests for _preload_global (cognitive complexity 26)."""
 
     def test_wait_fallback_when_no_progress_updates_queue(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """When progress_updates is None and futures are pending, concurrent.futures.wait is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         # future that is initially not done, then done on second call
         future = MagicMock()
@@ -4439,18 +3822,11 @@ class TestPreloadGlobalCornerCases:
         mock_wait.assert_called()
 
     def test_already_done_endpoint_has_task_stopped(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """Endpoint in finished_endpoints has its progress task stopped without double-processing."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         future.done.return_value = True
@@ -4472,18 +3848,11 @@ class TestPreloadGlobalCornerCases:
         progress.stop_task.assert_called_with(1)
 
     def test_progress_update_dropped_for_finished_endpoint(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """Progress updates for already-finished endpoints are dropped when getting from queue."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         # First call: not done; second call: done
@@ -4520,19 +3889,12 @@ class TestPreloadGlobalCornerCases:
 class TestUpdateComponentsAdditionsNoEndpoint:
     """Tests for additions branch with missing endpoint in update_components."""
 
-    def test_no_endpoint_for_addition_continues(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_no_endpoint_for_addition_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         """Addition branch: endpoint returns None → continue (line 1550)."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         # Make dcim.interface_templates return None (falsy)
         dt.netbox.dcim.interface_templates = None
 
@@ -4545,17 +3907,12 @@ class TestUpdateComponentsAdditionsNoEndpoint:
 class TestPowerOutletWithoutPowerPortKey:
     """Test that power outlets without 'power_port' key use the continue path."""
 
-    def test_outlet_without_power_port_key_skips_link(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_outlet_without_power_port_key_skips_link(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Power outlet that has no 'power_port' key hits the continue at line 1723."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {
             "power_outlet_templates": {("device", 1): {}},
             "power_port_templates": {("device", 1): {}},
@@ -4570,17 +3927,12 @@ class TestPowerOutletWithoutPowerPortKey:
 class TestFrontPortWithoutRearPortKey:
     """Test that front ports without 'rear_port' key hit the continue at line 1808."""
 
-    def test_front_port_without_rear_port_key_skips_link(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_front_port_without_rear_port_key_skips_link(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Front port without 'rear_port' key hits the continue at line 1808."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {
             "rear_port_templates": {("device", 1): {}},
             "front_port_templates": {("device", 1): {}},
@@ -4595,17 +3947,12 @@ class TestFrontPortWithoutRearPortKey:
 class TestModulePowerOutletWithoutPowerPortKey:
     """Test module power outlets without 'power_port' key."""
 
-    def test_module_outlet_without_power_port_key_skips_link(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_module_outlet_without_power_port_key_skips_link(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """Module power outlet without 'power_port' key hits the continue at line 1925."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
         dt.cached_components = {
             "power_outlet_templates": {("module", 1): {}},
             "power_port_templates": {("module", 1): {}},
@@ -4619,19 +3966,14 @@ class TestModulePowerOutletWithoutPowerPortKey:
 class TestUploadImageAttachmentExceptions:
     """Tests for exception paths in upload_image_attachment."""
 
-    def test_request_exception_returns_false(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
+    def test_request_exception_returns_false(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
         """requests.RequestException during POST returns False (lines 2095-2097)."""
         import requests as _req3
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         img = tmp_path / "img.png"
         img.write_bytes(b"fake")
@@ -4648,17 +3990,12 @@ class TestUploadImageAttachmentExceptions:
 class TestPumpPreloadProgressFutureNotDone:
     """Tests for pump_preload_progress when futures are still running."""
 
-    def test_pending_future_returns_false_when_no_updates(self, mock_settings, mock_pynetbox, graphql_client):
+    def test_pending_future_returns_false_when_no_updates(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
         """When future is not done and no progress updates, returns False (line 1013)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         future.done.return_value = False  # not done yet
@@ -4680,18 +4017,11 @@ class TestPreloadGlobalMissingLines:
     """Targeted tests for remaining missing lines in _preload_global."""
 
     def test_already_done_endpoint_with_future_exception(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """already_done endpoint whose future raises → log + empty records (lines 1119-1121)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         future.done.return_value = True
@@ -4714,18 +4044,11 @@ class TestPreloadGlobalMissingLines:
         mock_settings.handle.log.assert_any_call("Preload failed for interface_templates: fetch failed")
 
     def test_already_done_endpoint_progress_update_exception_swallowed(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """progress.stop_task raising for already_done endpoint is swallowed (1135-1136)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         future.done.return_value = True
@@ -4747,17 +4070,12 @@ class TestPreloadGlobalMissingLines:
         # Should not raise
         dt._preload_global(components, preload_job=preload_job, progress=progress)
 
-    def test_pending_future_exception_logged(self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client):
+    def test_pending_future_exception_logged(
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
+    ):
         """Future raising while pending logs error and stores empty records (1153-1155)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         future = MagicMock()
         done_seq = [False, True]
@@ -4781,18 +4099,11 @@ class TestPreloadGlobalMissingLines:
         mock_settings.handle.log.assert_any_call("Preload failed for interface_templates: network error")
 
     def test_progress_updates_get_with_timeout_advances_task(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """progress_updates.get(timeout=0.1) returns item and updates progress (1172-1177)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         # First call: not done (triggers the timeout-get path); second: done
         done_seq = [False, True]
@@ -4826,18 +4137,11 @@ class TestPreloadGlobalMissingLines:
         progress.update.assert_called()
 
     def test_progress_updates_get_drops_finished_endpoint(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """progress_updates.get returns item for finished endpoint → dropped (line 1172-1174)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         # future not done first, then done
         done_seq = [False, True]
@@ -4871,7 +4175,7 @@ class TestStartComponentPreloadProgressCallback:
     """Tests for the update_progress closure in start_component_preload (line 901)."""
 
     def test_update_progress_called_when_records_available(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """update_progress callback is triggered when _fetch_global_endpoint_records has records."""
         mock_nb_api = mock_pynetbox.api.return_value
@@ -4883,14 +4187,7 @@ class TestStartComponentPreloadProgressCallback:
                 progress_callback(endpoint_name, len(records))
             return records
 
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         progress = MagicMock()
         progress.add_task.return_value = 1
@@ -4909,7 +4206,7 @@ class TestPreloadGlobalOwnExecutorProgressCallback:
     """Tests for _preload_global own-executor progress callback (line 1079)."""
 
     def test_update_progress_callback_triggered(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
         """The update_progress closure in _preload_global is called when records exist."""
         mock_nb_api = mock_pynetbox.api.return_value
@@ -4920,14 +4217,7 @@ class TestPreloadGlobalOwnExecutorProgressCallback:
                 progress_callback(endpoint_name, len(records))
             return records
 
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         progress = MagicMock()
         progress.add_task.return_value = 1
@@ -4944,20 +4234,13 @@ class TestUploadImagesRequestException:
     """Dedicated tests to ensure upload_images RequestException path is covered."""
 
     def test_upload_images_request_exception_lines_covered(
-        self, mock_settings, mock_pynetbox, graphql_client, tmp_path
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
     ):
         """Verify lines 2039-2040 (RequestException catch in upload_images) are executed."""
         import requests as _req4
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(
-            mock_nb_api,
-            mock_settings.handle,
-            MagicMock(),
-            False,
-            False,
-            graphql=graphql_client,
-        )
+        dt = make_device_types(nb_api=mock_nb_api)
 
         img = tmp_path / "front2.jpg"
         img.write_bytes(b"data")

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -46,6 +46,25 @@ class TestValuesEqual:
         assert _values_equal(True, True)
         assert not _values_equal(True, False)
 
+    def test_type_error_in_coercion_returns_false(self):
+        """Regression: _values_equal must return False (not raise) on non-numeric coercions.
+
+        Covers netbox_api.py lines 65-66: the except (ValueError, TypeError) branch.
+        """
+
+        class Uncoercible:
+            def __eq__(self, other):
+                return NotImplemented
+
+            def __float__(self):
+                raise TypeError("cannot convert")
+
+        assert _values_equal(Uncoercible(), "anything") is False
+        assert _values_equal("1.0", Uncoercible()) is False
+        # Standard numeric coercion: "1" == 1 (yaml int vs netbox string)
+        assert _values_equal(1, "1") is True
+        assert _values_equal(1, "1.5") is False
+
 
 # All component list keys used by the GraphQL client for empty-response fallback.
 _ALL_COMPONENT_KEYS = [
@@ -4508,3 +4527,237 @@ class TestCreateRackTypes:
         nb.create_rack_types([rack_type], progress=iter(progress_items), all_rack_types={})
 
         mock_pynetbox.api.return_value.dcim.rack_types.create.assert_called_once()
+
+
+# ============================================================
+# NetBox version detection tests
+# ============================================================
+
+
+class TestVerifyCompatibility:
+    """Tests for NetBox.verify_compatibility() version thresholds."""
+
+    @pytest.mark.parametrize(
+        "version_str, expected_modules, expected_new_filters, expected_rack_types, expected_m2m",
+        [
+            ("3.1", False, False, False, False),
+            ("3.2", True, False, False, False),
+            ("4.0", True, False, False, False),
+            ("4.1", True, True, True, False),
+            ("4.4", True, True, True, False),
+            ("4.5", True, True, True, True),
+            ("4.6", True, True, True, True),
+            # Version strings with non-numeric suffixes
+            ("4.5-beta", True, True, True, True),
+            ("4.1.0", True, True, True, False),
+        ],
+    )
+    def test_version_thresholds(
+        self,
+        version_str,
+        expected_modules,
+        expected_new_filters,
+        expected_rack_types,
+        expected_m2m,
+        mock_settings,
+        mock_pynetbox,
+    ):
+        mock_pynetbox.api.return_value.version = version_str
+        nb = NetBox(mock_settings, mock_settings.handle)
+        assert nb.modules == expected_modules, f"modules mismatch for {version_str}"
+        assert nb.new_filters == expected_new_filters, f"new_filters mismatch for {version_str}"
+        assert nb.rack_types == expected_rack_types, f"rack_types mismatch for {version_str}"
+        assert nb.m2m_front_ports == expected_m2m, f"m2m_front_ports mismatch for {version_str}"
+
+    def test_single_component_version_string(self, mock_settings, mock_pynetbox):
+        """Version string with only major component (e.g. '4') does not crash."""
+        mock_pynetbox.api.return_value.version = "4"
+        nb = NetBox(mock_settings, mock_settings.handle)
+        assert nb.new_filters is False  # 4.0 → no new filters
+
+    def test_version_42_enables_new_filters_not_m2m(self, mock_settings, mock_pynetbox):
+        mock_pynetbox.api.return_value.version = "4.2"
+        nb = NetBox(mock_settings, mock_settings.handle)
+        assert nb.new_filters is True
+        assert nb.m2m_front_ports is False
+
+
+# ============================================================
+# Regression tests for bugs fixed during port-mappings work
+# ============================================================
+
+
+class TestRegressionPortMappings:
+    """Regression tests for bugs found and fixed during the port-mappings PR."""
+
+    def test_build_mappings_patch_returns_none_for_two_tuple(self, make_device_types, mock_pynetbox):
+        """Regression: _build_mappings_patch must return None (not crash) for legacy 2-tuples.
+
+        Bug: When ChangeDetector emitted 2-tuple (fp_pos, rp_pos) on legacy NetBox but
+        _apply_mappings_change was called in M2M mode, the code crashed unpacking the tuple.
+        Fix: _build_mappings_patch returns None when len(tup) != 3.
+
+        Covers netbox_api.py line 1816.
+        """
+        dt = make_device_types()
+        dt.m2m_front_ports = True
+        dt.cached_components = {"rear_port_templates": {("device", 1): {"RP1": MagicMock(id=99)}}}
+
+        # 2-tuple: legacy ChangeDetector format — should return None, not crash
+        result = dt._build_mappings_patch("FP1", frozenset({(1, 2)}), 1, "device")
+        assert result is None
+
+    def test_legacy_empty_mappings_clears_rear_port(self, make_device_types, mock_pynetbox):
+        """Regression: empty new_mappings frozenset must clear rear_port=None on legacy NetBox.
+
+        Bug: The 'if new_mappings:' guard silently did nothing when mappings were removed.
+        Fix: Added explicit 'if not new_mappings: rear_port=None; return' branch.
+        """
+        from core.change_detector import ChangeType, ComponentChange, PropertyChange
+
+        dt = make_device_types()
+        dt.m2m_front_ports = False
+
+        existing_fp = MagicMock(id=10, name="FP1")
+        dt.cached_components = {"front_port_templates": {("device", 1): {"FP1": existing_fp}}}
+
+        changes = [
+            ComponentChange(
+                component_type="front-ports",
+                component_name="FP1",
+                change_type=ChangeType.COMPONENT_CHANGED,
+                property_changes=[PropertyChange("_mappings", frozenset({("RP1", 1, 1)}), frozenset())],
+            )
+        ]
+        endpoint = dt.netbox.dcim.front_port_templates
+        dt.update_components({}, 1, changes, parent_type="device")
+
+        endpoint.update.assert_called_once()
+        payload = endpoint.update.call_args[0][0][0]
+        assert payload["rear_port"] is None
+        assert payload["rear_port_position"] is None
+
+    def test_legacy_two_tuple_uses_yaml_fallback(self, make_device_types, mock_pynetbox):
+        """Regression: 2-tuple _mappings on legacy NetBox must use YAML for rear port name.
+
+        Bug: When ChangeDetector emitted 2-tuples (no rear port names), the code always
+        warned and skipped — even when YAML data contained the rear port name.
+        Fix: _apply_mappings_change falls back to yaml_mappings[0]["rear_port"] when len(first)!=3.
+        """
+        from core.change_detector import ChangeType, ComponentChange, PropertyChange
+
+        dt = make_device_types()
+        dt.m2m_front_ports = False
+
+        existing_fp = MagicMock(id=10, name="FP1")
+        mock_rp = MagicMock(id=99, name="RP1")
+        dt.cached_components = {
+            "front_port_templates": {("device", 1): {"FP1": existing_fp}},
+            "rear_port_templates": {("device", 1): {"RP1": mock_rp}},
+        }
+
+        yaml_data = {
+            "front-ports": [
+                {"name": "FP1", "_mappings": [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 2}]}
+            ]
+        }
+        changes = [
+            ComponentChange(
+                component_type="front-ports",
+                component_name="FP1",
+                change_type=ChangeType.COMPONENT_CHANGED,
+                property_changes=[PropertyChange("_mappings", frozenset({("RP1", 1, 1)}), frozenset({(1, 2)}))],
+            )
+        ]
+        endpoint = dt.netbox.dcim.front_port_templates
+        dt.update_components(yaml_data, 1, changes, parent_type="device")
+
+        endpoint.update.assert_called_once()
+        payload = endpoint.update.call_args[0][0][0]
+        assert payload["rear_port"] == 99
+        assert payload["rear_port_position"] == 2
+
+    def test_legacy_two_tuple_without_yaml_warns_and_skips(self, make_device_types, mock_settings, mock_pynetbox):
+        """Regression: 2-tuple _mappings without YAML fallback must warn+skip (not crash).
+
+        Bug: Before len(first)!=3 guard, the code crashed with ValueError unpacking 2-tuples.
+        Fix: Guard added. Without YAML fallback, still warn and skip gracefully.
+        """
+        from core.change_detector import ChangeType, ComponentChange, PropertyChange
+
+        dt = make_device_types()
+        dt.m2m_front_ports = False
+
+        existing_fp = MagicMock(id=10, name="FP1")
+        dt.cached_components = {"front_port_templates": {("device", 1): {"FP1": existing_fp}}}
+
+        changes = [
+            ComponentChange(
+                component_type="front-ports",
+                component_name="FP1",
+                change_type=ChangeType.COMPONENT_CHANGED,
+                property_changes=[PropertyChange("_mappings", frozenset(), frozenset({(1, 2)}))],
+            )
+        ]
+        endpoint = dt.netbox.dcim.front_port_templates
+        mock_settings.handle.log.reset_mock()
+        dt.update_components({}, 1, changes, parent_type="device")
+
+        endpoint.update.assert_not_called()
+        assert any("NetBox < 4.5" in str(c) for c in mock_settings.handle.log.call_args_list)
+
+
+# ============================================================
+# _build_link_rear_ports edge cases (covering uncovered lines)
+# ============================================================
+
+
+class TestBuildLinkRearPortsEdgeCases:
+    """Edge cases in _build_link_rear_ports not covered by existing tests."""
+
+    def test_port_with_no_mappings_and_no_rear_port_is_skipped(self, make_device_types, mock_pynetbox):
+        """Port with no _mappings key and no rear_port key is silently skipped.
+
+        Covers netbox_api.py lines 2301-2302.
+        """
+        dt = make_device_types()
+        mock_rp = MagicMock(id=99, name="RP1")
+        dt.cached_components = {"rear_port_templates": {("device", 1): {"RP1": mock_rp}}}
+
+        post_process = dt._build_link_rear_ports("device", "Front Port")
+        # Port with neither _mappings nor rear_port key
+        items = [{"name": "FP1", "type": "8p8c"}]
+        post_process(items, 1)
+        assert items == [{"name": "FP1", "type": "8p8c"}]  # unchanged
+
+    def test_multiple_legacy_mappings_logs_warning_with_context(self, make_device_types, mock_settings, mock_pynetbox):
+        """Multiple _mappings on legacy NetBox logs warning including context string.
+
+        Covers netbox_api.py lines 2344-2345.
+        """
+        dt = make_device_types()
+        dt.m2m_front_ports = False
+
+        mock_rp1 = MagicMock(id=99)
+        mock_rp2 = MagicMock(id=100)
+        dt.cached_components = {
+            "rear_port_templates": {("device", 1): {"RP1": mock_rp1, "RP2": mock_rp2}},
+        }
+
+        post_process = dt._build_link_rear_ports("device", "Front Port", context="MyDevice")
+        items = [
+            {
+                "name": "FP1",
+                "type": "8p8c",
+                "_mappings": [
+                    {"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1},
+                    {"rear_port": "RP2", "front_port_position": 1, "rear_port_position": 1},
+                ],
+            }
+        ]
+        mock_settings.handle.log.reset_mock()
+        post_process(items, 1)
+
+        log_calls = [str(c) for c in mock_settings.handle.log.call_args_list]
+        assert any("only first mapping applied" in c for c in log_calls)
+        assert any("MyDevice" in c for c in log_calls)

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -1,7 +1,12 @@
 import queue
 import pytest
 from unittest.mock import MagicMock, patch
-from core.netbox_api import NetBox, DeviceTypes, _FrontPortRecordWithMappings, _values_equal
+from core.netbox_api import (
+    NetBox,
+    DeviceTypes,
+    _FrontPortRecordWithMappings,
+    _values_equal,
+)
 from helpers import paginate_dispatch
 
 
@@ -173,7 +178,14 @@ def test_device_types_create_interfaces(mock_settings, mock_pynetbox, graphql_cl
     mock_settings.handle = MagicMock()
     mock_counter = MagicMock()
 
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, mock_counter, False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        mock_counter,
+        False,
+        False,
+        graphql=graphql_client,
+    )
 
     # Mock existing interfaces returns empty list
     mock_nb_api.dcim.interface_templates.filter.return_value = []
@@ -239,7 +251,11 @@ def test_preload_global_builds_component_cache(mock_settings, mock_pynetbox, moc
                             "id": "1",
                             "model": "ModelA",
                             "slug": "model-a",
-                            "manufacturer": {"id": "10", "name": "Cisco", "slug": "cisco"},
+                            "manufacturer": {
+                                "id": "10",
+                                "name": "Cisco",
+                                "slug": "cisco",
+                            },
                             "front_image": None,
                             "rear_image": None,
                         }
@@ -267,7 +283,14 @@ def test_preload_global_builds_component_cache(mock_settings, mock_pynetbox, moc
         }
     )
 
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
     dt.preload_all_components(progress_wrapper=None)
 
     assert "interface_templates" in dt.cached_components
@@ -328,7 +351,14 @@ def test_fetch_global_endpoint_records_uses_graphql(
         }
     )
 
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
     updates = []
 
     records = dt._fetch_global_endpoint_records(
@@ -356,7 +386,14 @@ def test_fetch_global_endpoint_records_progress_skipped_when_empty(
         }
     )
 
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
     updates = []
 
     fetched = dt._fetch_global_endpoint_records(
@@ -382,7 +419,11 @@ def test_preload_always_global_caches_all_vendors(mock_settings, mock_pynetbox, 
                             "id": "1",
                             "model": "ModelA",
                             "slug": "model-a",
-                            "manufacturer": {"id": "10", "name": "Cisco", "slug": "cisco"},
+                            "manufacturer": {
+                                "id": "10",
+                                "name": "Cisco",
+                                "slug": "cisco",
+                            },
                             "front_image": None,
                             "rear_image": None,
                         },
@@ -390,7 +431,11 @@ def test_preload_always_global_caches_all_vendors(mock_settings, mock_pynetbox, 
                             "id": "2",
                             "model": "ModelB",
                             "slug": "model-b",
-                            "manufacturer": {"id": "20", "name": "Juniper", "slug": "juniper"},
+                            "manufacturer": {
+                                "id": "20",
+                                "name": "Juniper",
+                                "slug": "juniper",
+                            },
                             "front_image": None,
                             "rear_image": None,
                         },
@@ -430,7 +475,14 @@ def test_preload_always_global_caches_all_vendors(mock_settings, mock_pynetbox, 
         }
     )
 
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
     dt.preload_all_components(progress_wrapper=None)
 
     # Both vendors are cached because global fetch returns everything
@@ -441,7 +493,14 @@ def test_preload_always_global_caches_all_vendors(mock_settings, mock_pynetbox, 
 def test_start_component_preload_global_job_can_be_consumed(mock_settings, mock_pynetbox, graphql_client):
     mock_nb_api = mock_pynetbox.api.return_value
 
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
     preload_job = dt.start_component_preload()
 
     assert preload_job["mode"] == "global"
@@ -455,7 +514,14 @@ def test_upload_images_success_logs_verbose_only(mock_settings, mock_pynetbox, g
     image_file = tmp_path / "front.jpg"
     image_file.write_bytes(b"fake")
 
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
     mock_settings.handle.log.reset_mock()
     mock_settings.handle.verbose_log.reset_mock()
 
@@ -582,7 +648,14 @@ def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox,
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
     dt.m2m_front_ports = True
 
     existing_fp = MagicMock()
@@ -599,7 +672,7 @@ def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox,
     }
 
     # new_value is a frozenset of (rear_port_name, fp_pos, rp_pos) tuples
-    new_mappings_set = frozenset({("RP1", 1, 2)})
+    new_mappings_set = frozenset({("RP1", 1, 2), ("RP1", 2, 1)})
     old_mappings_set = frozenset({("RP1", 1, 1)})
 
     changes = [
@@ -618,7 +691,10 @@ def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox,
     update_payload = endpoint.update.call_args[0][0][0]
     assert update_payload["id"] == 10
     assert "_mappings" not in update_payload, "Should not have raw _mappings key"
-    assert update_payload["rear_ports"] == [{"position": 1, "rear_port": 99, "rear_port_position": 2}]
+    assert sorted(update_payload["rear_ports"], key=lambda item: item["position"]) == [
+        {"position": 1, "rear_port": 99, "rear_port_position": 2},
+        {"position": 2, "rear_port": 99, "rear_port_position": 1},
+    ]
 
 
 def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, graphql_client):
@@ -626,7 +702,14 @@ def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, gr
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
     mock_nb_api = MagicMock()
-    dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
     dt.m2m_front_ports = True
 
     existing_fp = MagicMock()
@@ -636,6 +719,101 @@ def test_update_components_m2m_no_mapping_warns(mock_settings, mock_pynetbox, gr
     dt.cached_components = {
         "front_port_templates": {("device", 1): {"FP1": existing_fp}},
         "rear_port_templates": {("device", 1): {}},  # Empty: rear port missing
+    }
+
+    new_mappings_set = frozenset({("MISSING_RP", 1, 1)})
+    old_mappings_set = frozenset()
+
+    changes = [
+        ComponentChange(
+            component_type="front-ports",
+            component_name="FP1",
+            change_type=ChangeType.COMPONENT_CHANGED,
+            property_changes=[PropertyChange("_mappings", old_mappings_set, new_mappings_set)],
+        ),
+    ]
+
+    endpoint = mock_nb_api.dcim.front_port_templates
+    mock_settings.handle.log.reset_mock()
+    dt.update_components({}, 1, changes, parent_type="device")
+
+    endpoint.update.assert_not_called()
+    assert any("MISSING_RP" in str(c) for c in mock_settings.handle.log.call_args_list)
+
+
+def test_update_components_legacy_mapping_translates_to_fields(mock_settings, mock_pynetbox, graphql_client):
+    """On legacy NetBox (<4.5), _mappings update should send rear_port + rear_port_position."""
+    from core.change_detector import ChangeType, ComponentChange, PropertyChange
+
+    mock_nb_api = MagicMock()
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
+    dt.m2m_front_ports = False  # Legacy path
+
+    existing_fp = MagicMock()
+    existing_fp.id = 10
+    existing_fp.name = "FP1"
+
+    rp = MagicMock()
+    rp.id = 99
+
+    dt.cached_components = {
+        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
+        "rear_port_templates": {("device", 1): {"RP1": rp}},
+    }
+
+    new_mappings_set = frozenset({("RP1", 1, 3)})
+    old_mappings_set = frozenset({("RP1", 1, 1)})
+
+    changes = [
+        ComponentChange(
+            component_type="front-ports",
+            component_name="FP1",
+            change_type=ChangeType.COMPONENT_CHANGED,
+            property_changes=[PropertyChange("_mappings", old_mappings_set, new_mappings_set)],
+        ),
+    ]
+
+    endpoint = mock_nb_api.dcim.front_port_templates
+    dt.update_components({}, 1, changes, parent_type="device")
+
+    endpoint.update.assert_called_once()
+    update_payload = endpoint.update.call_args[0][0][0]
+    assert update_payload["id"] == 10
+    assert "_mappings" not in update_payload
+    assert "rear_ports" not in update_payload  # Not the M2M key
+    assert update_payload["rear_port"] == 99
+    assert update_payload["rear_port_position"] == 3
+
+
+def test_update_components_legacy_mapping_missing_rear_port_warns(mock_settings, mock_pynetbox, graphql_client):
+    """On legacy NetBox (<4.5), _mappings update with missing rear port warns and skips."""
+    from core.change_detector import ChangeType, ComponentChange, PropertyChange
+
+    mock_nb_api = MagicMock()
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
+    dt.m2m_front_ports = False
+
+    existing_fp = MagicMock()
+    existing_fp.id = 10
+    existing_fp.name = "FP1"
+
+    dt.cached_components = {
+        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
+        "rear_port_templates": {("device", 1): {}},  # Empty cache
     }
 
     new_mappings_set = frozenset({("MISSING_RP", 1, 1)})
@@ -704,7 +882,14 @@ class TestFrontPortRecordWithMappings:
         from core.graphql_client import DotDict
 
         rp = DotDict({"id": 7, "name": "RP1"})
-        mapping = DotDict({"id": 9, "front_port_position": 2, "rear_port_position": 3, "rear_port": rp})
+        mapping = DotDict(
+            {
+                "id": 9,
+                "front_port_position": 2,
+                "rear_port_position": 3,
+                "rear_port": rp,
+            }
+        )
         record = DotDict({"id": 1, "name": "FP1", "type": "8p8c", "mappings": [mapping]})
         wrapped = _FrontPortRecordWithMappings(record)
         assert wrapped._mappings_canonical == [
@@ -751,7 +936,14 @@ class TestStopComponentPreload:
 
     def test_cancels_pending_futures_and_shuts_down(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         future.done.return_value = False
@@ -826,25 +1018,53 @@ class TestGetFilterKwargs:
 
     def test_device_old_filter(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.new_filters = False
         assert dt._get_filter_kwargs(1, "device") == {"devicetype_id": 1}
 
     def test_device_new_filter(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.new_filters = True
         assert dt._get_filter_kwargs(1, "device") == {"device_type_id": 1}
 
     def test_module_new_filter(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.new_filters = True
         assert dt._get_filter_kwargs(5, "module") == {"module_type_id": 5}
 
     def test_module_old_filter(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.new_filters = False
         assert dt._get_filter_kwargs(5, "module") == {"moduletype_id": 5}
 
@@ -857,7 +1077,14 @@ class TestCreateGenericError:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         endpoint = MagicMock()
@@ -880,7 +1107,14 @@ class TestCreateGenericError:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         endpoint = MagicMock()
@@ -904,7 +1138,14 @@ class TestRemoveComponents:
 
     def test_removes_existing_component(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_comp = MagicMock()
         existing_comp.id = 99
@@ -920,7 +1161,14 @@ class TestRemoveComponents:
 
     def test_skips_component_not_in_cache(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         from core.change_detector import ChangeType, ComponentChange
@@ -932,7 +1180,14 @@ class TestRemoveComponents:
 
     def test_no_changes_is_noop(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.remove_components(1, [])
         mock_nb_api.dcim.interface_templates.delete.assert_not_called()
 
@@ -942,28 +1197,56 @@ class TestCreatePowerConsolePorts:
 
     def test_create_power_ports_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"power_port_templates": {("device", 1): {}}}
         dt.create_power_ports([{"name": "PSU1"}], 1)
         mock_nb_api.dcim.power_port_templates.create.assert_called_once()
 
     def test_create_console_ports_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"console_port_templates": {("device", 1): {}}}
         dt.create_console_ports([{"name": "Con1"}], 1)
         mock_nb_api.dcim.console_port_templates.create.assert_called_once()
 
     def test_create_rear_ports_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"rear_port_templates": {("device", 1): {}}}
         dt.create_rear_ports([{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
         mock_nb_api.dcim.rear_port_templates.create.assert_called_once()
 
     def test_create_device_bays_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"device_bay_templates": {("device", 1): {}}}
         dt.create_device_bays([{"name": "Bay1"}], 1)
         mock_nb_api.dcim.device_bay_templates.create.assert_called_once()
@@ -977,7 +1260,14 @@ class TestCreateDeviceTypesNewDT:
         mock_nb_api.version = "3.5"
 
         mock_settings.handle = MagicMock()
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         created_dt = MagicMock()
         created_dt.id = 1
@@ -1013,7 +1303,14 @@ class TestUploadImageAttachment:
 
     def test_success_returns_true(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         img_path = tmp_path / "img.png"
         img_path.write_bytes(b"fake")
@@ -1031,7 +1328,14 @@ class TestUploadImageAttachment:
         import requests as req_lib
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         img_path = tmp_path / "img.png"
         img_path.write_bytes(b"fake")
@@ -1044,7 +1348,14 @@ class TestUploadImageAttachment:
 
     def test_os_error_returns_false(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         result = dt.upload_image_attachment("http://nb", "token", "/nonexistent/img.png", "dcim.moduletype", 42)
         assert result is False
 
@@ -1124,7 +1435,14 @@ class TestUpdateComponentsAdditions:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_ADDED)]
@@ -1142,7 +1460,14 @@ class TestFetchGlobalEndpointRestPath:
     ):
         """front_port_templates always uses GraphQL and wraps records with _FrontPortRecordWithMappings."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.m2m_front_ports = True  # no longer affects front_port_templates path
 
         fp_record = {
@@ -1172,7 +1497,14 @@ class TestFetchGlobalEndpointRestPath:
 
     def test_rest_only_endpoint_with_progress_callback(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.REST_ONLY_ENDPOINTS = frozenset(["interface_templates"])
 
         raw = MagicMock()
@@ -1191,7 +1523,14 @@ class TestCountDeviceTypeImages:
 
     def test_counts_new_image_when_no_existing_dt(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         # Create a temporary directory structure mimicking device-types
         dev_types_dir = tmp_path / "device-types" / "cisco"
@@ -1224,7 +1563,14 @@ class TestCountDeviceTypeImages:
         existing_dt = MagicMock()
         existing_dt.front_image = "http://netbox/media/front.jpg"
 
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {("cisco", "MySwitch"): existing_dt}
         dt.existing_device_types_by_slug = {}
 
@@ -1244,13 +1590,23 @@ class TestCountDeviceTypeImages:
             }
         ]
 
-        with patch("glob.glob", return_value=[str(tmp_path / "elevation-images" / "cisco" / "myswitch.front.png")]):
+        with patch(
+            "glob.glob",
+            return_value=[str(tmp_path / "elevation-images" / "cisco" / "myswitch.front.png")],
+        ):
             count = nb.count_device_type_images(device_types)
         assert count == 0
 
     def test_no_src_skipped(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         nb = NetBox(mock_settings, mock_settings.handle)
         nb.device_types = dt
         count = nb.count_device_type_images([{"manufacturer": {"slug": "cisco"}, "model": "X", "slug": "x"}])
@@ -1283,7 +1639,11 @@ class TestCreateModuleTypesBody:
             "model": "LC",
             "src": "/repo/module-types/cisco/lc.yaml",
         }
-        nb.create_module_types([module_type], all_module_types=all_module_types, module_type_existing_images={})
+        nb.create_module_types(
+            [module_type],
+            all_module_types=all_module_types,
+            module_type_existing_images={},
+        )
         nb.netbox.dcim.module_types.create.assert_not_called()
 
     def test_create_module_type_request_error_logged(self, mock_settings, mock_pynetbox, mock_graphql_requests):
@@ -1362,35 +1722,70 @@ class TestCreateModuleComponents:
 
     def test_create_module_interfaces(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"interface_templates": {("module", 1): {}}}
         dt.create_module_interfaces([{"name": "xe-0"}], 1)
         mock_nb_api.dcim.interface_templates.create.assert_called_once()
 
     def test_create_module_power_ports(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"power_port_templates": {("module", 1): {}}}
         dt.create_module_power_ports([{"name": "PSU1"}], 1)
         mock_nb_api.dcim.power_port_templates.create.assert_called_once()
 
     def test_create_module_console_ports(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"console_port_templates": {("module", 1): {}}}
         dt.create_module_console_ports([{"name": "Con1"}], 1)
         mock_nb_api.dcim.console_port_templates.create.assert_called_once()
 
     def test_create_module_console_server_ports(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"console_server_port_templates": {("module", 1): {}}}
         dt.create_module_console_server_ports([{"name": "CSP1"}], 1)
         mock_nb_api.dcim.console_server_port_templates.create.assert_called_once()
 
     def test_create_module_rear_ports(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"rear_port_templates": {("module", 1): {}}}
         dt.create_module_rear_ports([{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
         mock_nb_api.dcim.rear_port_templates.create.assert_called_once()
@@ -1402,7 +1797,14 @@ class TestCreateDeviceTypesImagePaths:
     def test_existing_dt_with_image_not_reuploaded(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         mock_nb_api = mock_pynetbox.api.return_value
         mock_settings.handle = MagicMock()
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -1444,7 +1846,14 @@ class TestUploadImagesProgress:
 
     def test_image_progress_callback_called(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         img_path = tmp_path / "front.jpg"
         img_path.write_bytes(b"fake")
@@ -1463,7 +1872,14 @@ class TestUploadImagesProgress:
 
     def test_upload_images_os_error_logged(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.upload_images("http://nb", "token", {"front_image": "/nonexistent/img.jpg"}, 1)
         mock_settings.handle.log.assert_called()
 
@@ -1473,7 +1889,14 @@ class TestCountDeviceTypeImagesEdge:
 
     def test_no_device_types_path_skipped(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         nb = NetBox(mock_settings, mock_settings.handle)
         nb.device_types = dt
         # src path that doesn't contain "device-types" → triggers ValueError → continue
@@ -1547,7 +1970,14 @@ class TestCreateConsoleServerPorts:
 
     def test_create_console_server_ports_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"console_server_port_templates": {("device", 1): {}}}
         dt.create_console_server_ports([{"name": "CSP1"}], 1)
         mock_nb_api.dcim.console_server_port_templates.create.assert_called_once()
@@ -1558,7 +1988,14 @@ class TestCreateModuleBays:
 
     def test_create_module_bays_calls_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"module_bay_templates": {("device", 1): {}}}
         dt.create_module_bays([{"name": "MB1"}], 1)
         mock_nb_api.dcim.module_bay_templates.create.assert_called_once()
@@ -1623,7 +2060,14 @@ class TestCreateDeviceTypesImagePaths2:
     def test_no_device_types_in_src_path_sets_image_base_none(self, mock_settings, mock_pynetbox, graphql_client):
         """Source path without 'device-types' → image_base = None; no image lookup."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -1649,7 +2093,14 @@ class TestCreateDeviceTypesImagePaths2:
     def test_image_base_none_with_front_image_flag_logs_verbose(self, mock_settings, mock_pynetbox, graphql_client):
         """When image_base is None but front_image flag is set, verbose_log is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -1676,7 +2127,14 @@ class TestCreateDeviceTypesImagePaths2:
     def test_slug_fallback_verbose_log(self, mock_settings, mock_pynetbox, graphql_client):
         """When model lookup fails but slug lookup succeeds, verbose_log is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -1702,7 +2160,14 @@ class TestCreateDeviceTypesImagePaths2:
     def test_rear_image_already_exists_skips_upload(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         """Rear image already present on existing DT → verbose_log + skip upload."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.upload_images = MagicMock()
 
         existing_dt = MagicMock()
@@ -1743,7 +2208,14 @@ class TestCreateDeviceTypesImagePaths2:
     ):
         """When existing DT has no image and a local image is found, upload_images is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.upload_images = MagicMock()
 
         existing_dt = MagicMock()
@@ -1779,7 +2251,14 @@ class TestCreateDeviceTypesImagePaths2:
     def test_only_new_existing_dt_verbose_log_and_skip(self, mock_settings, mock_pynetbox, graphql_client):
         """only_new=True with existing DT → verbose_log containing 'Cached' and skip."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -1821,7 +2300,14 @@ class TestCreateDeviceTypesUpdatePath:
         from core.change_detector import ChangeReport, DeviceTypeChange, PropertyChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -1858,7 +2344,14 @@ class TestCreateDeviceTypesUpdatePath:
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -1893,10 +2386,22 @@ class TestCreateDeviceTypesUpdatePath:
 
     def test_update_applies_component_changes(self, mock_settings, mock_pynetbox, graphql_client):
         """update=True with component_changes calls update_components (and optionally remove_components)."""
-        from core.change_detector import ChangeReport, ChangeType, ComponentChange, DeviceTypeChange
+        from core.change_detector import (
+            ChangeReport,
+            ChangeType,
+            ComponentChange,
+            DeviceTypeChange,
+        )
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.update_components = MagicMock()
         dt.remove_components = MagicMock()
 
@@ -1933,7 +2438,14 @@ class TestCreateDeviceTypesUpdatePath:
         from core.change_detector import ChangeReport, DeviceTypeChange, PropertyChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -1971,7 +2483,14 @@ class TestCreateDeviceTypesUpdatePath:
         from core.change_detector import ChangeReport
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_dt = MagicMock()
         existing_dt.id = 1
@@ -2011,7 +2530,14 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -2039,7 +2565,14 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
         and module-bays.
         """
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
         # Patch all create_* methods on dt
@@ -2094,7 +2627,14 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
     def test_upload_images_called_for_new_dt(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         """upload_images is called for newly created DT when saved_images is populated."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
         dt.upload_images = MagicMock()
@@ -2162,7 +2702,12 @@ class TestFilterActionableModuleTypesEdge:
         """Module type not in all_module_types is added to actionable."""
         mock_pynetbox.api.return_value.version = "3.5"
         mock_graphql_requests.side_effect = paginate_dispatch(
-            {"manufacturer_list": [], "device_type_list": [], "module_type_list": [], "image_attachment_list": []}
+            {
+                "manufacturer_list": [],
+                "device_type_list": [],
+                "module_type_list": [],
+                "image_attachment_list": [],
+            }
         )
         nb = NetBox(mock_settings, mock_settings.handle)
         module_type = {
@@ -2180,7 +2725,12 @@ class TestFilterActionableModuleTypesEdge:
         """Existing module type with an image not yet in NetBox is actionable."""
         mock_pynetbox.api.return_value.version = "3.5"
         mock_graphql_requests.side_effect = paginate_dispatch(
-            {"manufacturer_list": [], "device_type_list": [], "module_type_list": [], "image_attachment_list": []}
+            {
+                "manufacturer_list": [],
+                "device_type_list": [],
+                "module_type_list": [],
+                "image_attachment_list": [],
+            }
         )
         nb = NetBox(mock_settings, mock_settings.handle)
 
@@ -2240,7 +2790,11 @@ class TestCreateModuleTypesEdge:
             "model": "LC",
             "src": "/repo/module-types/cisco/lc.yaml",
         }
-        nb.create_module_types([module_type], all_module_types=all_module_types, module_type_existing_images={})
+        nb.create_module_types(
+            [module_type],
+            all_module_types=all_module_types,
+            module_type_existing_images={},
+        )
         assert any("Module Type Cached" in str(c) for c in mock_settings.handle.verbose_log.call_args_list)
 
     def test_only_new_skips_existing_module_component_creation(self, mock_settings, mock_pynetbox, graphql_client):
@@ -2428,7 +2982,14 @@ class TestStartComponentPreloadProgress:
     def test_with_progress_creates_task_ids(self, mock_settings, mock_pynetbox, graphql_client):
         """start_component_preload with a progress object creates task IDs."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         progress = MagicMock()
         progress.add_task.return_value = 1
@@ -2441,7 +3002,14 @@ class TestStartComponentPreloadProgress:
     def test_exception_shuts_down_executor(self, mock_settings, mock_pynetbox, graphql_client):
         """If _get_endpoint_totals raises, executor is shut down and exception re-raised."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         with patch.object(dt, "_get_endpoint_totals", side_effect=RuntimeError("oops")):
             with pytest.raises(RuntimeError, match="oops"):
@@ -2459,13 +3027,27 @@ class TestPumpPreloadProgress:
     def test_returns_false_when_no_preload_job(self, mock_settings, mock_pynetbox, graphql_client):
         """pump_preload_progress returns False when preload_job is None."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         assert dt.pump_preload_progress(None, MagicMock()) is False
 
     def test_marks_done_futures(self, mock_settings, mock_pynetbox, graphql_client):
         """Completed futures are moved to finished_endpoints and advanced=True returned."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         future.done.return_value = True
@@ -2487,7 +3069,14 @@ class TestPumpPreloadProgress:
     def test_future_exception_sets_final_total_1(self, mock_settings, mock_pynetbox, graphql_client):
         """When future.result() raises, final_total defaults to 1."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         future.done.return_value = True
@@ -2522,7 +3111,14 @@ class TestPreloadGlobalWithProgress:
                 "interface_template_list": {"data": {"interface_template_list": []}},
             }
         )
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         progress = MagicMock()
         progress.add_task.return_value = 1
@@ -2536,7 +3132,14 @@ class TestPreloadGlobalWithProgress:
     ):
         """When no progress and a future raises, log is called and result is []."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         broken_future = MagicMock()
         broken_future.result.side_effect = RuntimeError("network error")
@@ -2566,7 +3169,14 @@ class TestPreloadGlobalWithProgress:
         mock_graphql_requests.side_effect = _make_graphql_dispatch(
             {"device_type_list": {"data": {"device_type_list": []}}}
         )
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         future.done.return_value = True
@@ -2600,14 +3210,28 @@ class TestPreloadModuleTypeComponents:
     def test_empty_ids_returns_immediately(self, mock_settings, mock_pynetbox, graphql_client):
         """Empty module_type_ids → return immediately."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.preload_module_type_components(set(), ["interfaces"])
         mock_nb_api.dcim.interface_templates.filter.assert_not_called()
 
     def test_duplicate_endpoint_skipped(self, mock_settings, mock_pynetbox, graphql_client):
         """Same endpoint_attr from two keys is only fetched once."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         mock_nb_api.dcim.power_port_templates.filter.return_value = []
 
         # Both "power-ports" and "power-port" map to the same endpoint_attr
@@ -2618,7 +3242,14 @@ class TestPreloadModuleTypeComponents:
     def test_item_with_no_module_type_skipped(self, mock_settings, mock_pynetbox, graphql_client):
         """Items where item.module_type is None are skipped."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         item_no_mt = MagicMock()
         item_no_mt.module_type = None
@@ -2641,7 +3272,14 @@ class TestCreateGenericPostProcess:
     def test_post_process_is_called(self, mock_settings, mock_pynetbox, graphql_client):
         """post_process callback is invoked before endpoint.create."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"power_outlet_templates": {("device", 1): {}}}
 
         post_calls = []
@@ -2676,7 +3314,14 @@ class TestUpdateComponentsMiscBranches:
         from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         changes = [
             ComponentChange(
@@ -2695,7 +3340,14 @@ class TestUpdateComponentsMiscBranches:
 
         mock_nb_api = MagicMock(spec=[])  # no attributes on dcim
         mock_nb_api.dcim = MagicMock(spec=[])
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         changes = [
             ComponentChange(
@@ -2715,7 +3367,14 @@ class TestUpdateComponentsMiscBranches:
 
         mock_nb_api = mock_pynetbox.api.return_value
         counter = _Counter(components_updated=0)
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, counter, False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            counter,
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.m2m_front_ports = False
 
         existing = MagicMock()
@@ -2741,7 +3400,14 @@ class TestUpdateComponentsMiscBranches:
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.m2m_front_ports = False
 
         existing = MagicMock()
@@ -2779,7 +3445,14 @@ class TestUpdateComponentsAdditionsBranches:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"power_port_templates": {("device", 1): {}}}
 
         changes = [ComponentChange("power-ports", "PSU1", ChangeType.COMPONENT_ADDED)]
@@ -2793,7 +3466,14 @@ class TestUpdateComponentsAdditionsBranches:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_ADDED)]
         # yaml_data has no "interfaces" key
@@ -2805,7 +3485,14 @@ class TestUpdateComponentsAdditionsBranches:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         changes = [ComponentChange("nonexistent-type", "x", ChangeType.COMPONENT_ADDED)]
         yaml_data = {"nonexistent-type": [{"name": "x"}]}
@@ -2817,7 +3504,14 @@ class TestUpdateComponentsAdditionsBranches:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         # yaml has "interfaces" but the name doesn't match the change
@@ -2831,7 +3525,14 @@ class TestUpdateComponentsAdditionsBranches:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.create_front_ports = MagicMock()
         dt.cached_components = {"front_port_templates": {("device", 1): {}}}
 
@@ -2847,7 +3548,14 @@ class TestUpdateComponentsAdditionsBranches:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.create_module_front_ports = MagicMock()
         dt.cached_components = {"front_port_templates": {("module", 1): {}}}
 
@@ -2870,7 +3578,14 @@ class TestRemoveComponentsBranches:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         changes = [ComponentChange("nonexistent-type", "x", ChangeType.COMPONENT_REMOVED)]
         dt.remove_components(1, changes)
@@ -2882,7 +3597,14 @@ class TestRemoveComponentsBranches:
 
         mock_nb_api = MagicMock(spec=[])
         mock_nb_api.dcim = MagicMock(spec=[])
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_REMOVED)]
         dt.remove_components(1, changes)
@@ -2894,7 +3616,14 @@ class TestRemoveComponentsBranches:
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         existing_comp = MagicMock()
         existing_comp.id = 99
@@ -2920,7 +3649,14 @@ class TestCreateInterfacesBridge:
     def test_bridge_interface_not_found_logs_error(self, mock_settings, mock_pynetbox, graphql_client):
         """If bridge target interface is not found, handle.log is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         # The created interface will be in cache; bridge target will not be.
@@ -2940,7 +3676,14 @@ class TestCreateInterfacesBridge:
     def test_bridge_extracts_and_removes_from_interface(self, mock_settings, mock_pynetbox, graphql_client):
         """Bridge key is extracted before _create_generic and removed from the dict."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"interface_templates": {("device", 1): {}}}
 
         mock_nb_api.dcim.interface_templates.create.return_value = []
@@ -2954,7 +3697,14 @@ class TestCreateInterfacesBridge:
     def test_bridge_update_success(self, mock_settings, mock_pynetbox, graphql_client):
         """Successful bridge update calls verbose_log."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         eth0 = MagicMock()
         eth0.id = 10
@@ -2979,7 +3729,14 @@ class TestCreateInterfacesBridge:
 
         mock_pynetbox.RequestError = real_pynb2.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         eth0 = MagicMock()
         eth0.id = 10
@@ -3012,7 +3769,14 @@ class TestCreatePowerOutletsInvalidPort:
     def test_invalid_power_port_logged_and_outlet_skipped(self, mock_settings, mock_pynetbox, graphql_client):
         """Power outlet referencing unknown power_port is logged and skipped."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {
             "power_port_templates": {("device", 1): {}},  # no power ports
             "power_outlet_templates": {("device", 1): {}},
@@ -3028,7 +3792,14 @@ class TestCreatePowerOutletsInvalidPort:
     def test_multiple_outlets_one_invalid_skips_bad_only(self, mock_settings, mock_pynetbox, graphql_client):
         """Only the outlet with an invalid power_port is removed; valid one proceeds."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         psu1 = MagicMock()
         psu1.id = 99
@@ -3058,7 +3829,14 @@ class TestBuildLinkRearPorts:
     def test_rear_port_not_found_logs_and_skips(self, mock_settings, mock_pynetbox, graphql_client):
         """Front port whose rear_port cannot be resolved is removed and logged."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {
             "rear_port_templates": {("device", 1): {}},  # no rear ports
             "front_port_templates": {("device", 1): {}},
@@ -3073,7 +3851,14 @@ class TestBuildLinkRearPorts:
     def test_rear_port_found_non_m2m(self, mock_settings, mock_pynetbox, graphql_client):
         """Non-M2M path: rear_port is replaced with its ID."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.m2m_front_ports = False
 
         rp = MagicMock()
@@ -3092,7 +3877,14 @@ class TestBuildLinkRearPorts:
     def test_rear_port_found_m2m(self, mock_settings, mock_pynetbox, graphql_client):
         """M2M path: rear_ports list is built with position and rear_port_position."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.m2m_front_ports = True
 
         rp = MagicMock()
@@ -3112,7 +3904,14 @@ class TestBuildLinkRearPorts:
     def test_multiple_front_ports_one_invalid(self, mock_settings, mock_pynetbox, graphql_client):
         """Only invalid front port is skipped; valid one is created."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.m2m_front_ports = False
 
         rp = MagicMock()
@@ -3147,7 +3946,14 @@ class TestCreateModuleFrontPorts:
     def test_delegates_to_create_generic(self, mock_settings, mock_pynetbox, graphql_client):
         """create_module_front_ports calls _create_generic with module parent_type."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.m2m_front_ports = False
 
         rp = MagicMock()
@@ -3175,7 +3981,14 @@ class TestCreateModulePowerOutletsInvalidPort:
     def test_invalid_power_port_logged_and_skipped(self, mock_settings, mock_pynetbox, graphql_client):
         """Module power outlet with unknown power_port is logged and skipped."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {
             "power_port_templates": {("module", 1): {}},
             "power_outlet_templates": {("module", 1): {}},
@@ -3190,7 +4003,14 @@ class TestCreateModulePowerOutletsInvalidPort:
     def test_multiple_outlets_one_invalid(self, mock_settings, mock_pynetbox, graphql_client):
         """Only the module outlet with an invalid power_port is removed."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         psu1 = MagicMock()
         psu1.id = 88
@@ -3219,7 +4039,14 @@ class TestCreateModuleRearPorts:
     def test_calls_create_generic_with_module_parent(self, mock_settings, mock_pynetbox, graphql_client):
         """create_module_rear_ports creates rear ports with module_type parent."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {"rear_port_templates": {("module", 3): {}}}
 
         rear_ports = [{"name": "RP1", "type": "8p8c", "positions": 8}]
@@ -3241,7 +4068,14 @@ class TestUploadImagesErrors:
         import requests as _req2
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         img = tmp_path / "front.jpg"
         img.write_bytes(b"fake")
@@ -3259,7 +4093,14 @@ class TestUploadImagesErrors:
         import requests as _req2
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         img = tmp_path / "front.jpg"
         img.write_bytes(b"fake")
@@ -3291,7 +4132,14 @@ class TestUploadImageAttachmentProgress:
     def test_image_progress_callback_called_on_success(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         """_image_progress is called with 1 on a successful upload."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         img = tmp_path / "img.png"
         img.write_bytes(b"fake")
@@ -3321,7 +4169,14 @@ class TestCreateDeviceTypesCornerCases:
     def test_progress_iterator_used_when_provided(self, mock_settings, mock_pynetbox, graphql_client):
         """When a progress object is supplied, iteration goes through it."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -3349,7 +4204,14 @@ class TestCreateDeviceTypesCornerCases:
     def test_image_file_not_found_logs_error(self, mock_settings, mock_pynetbox, graphql_client, tmp_path):
         """When glob finds no image file, handle.log is called with an error."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
 
@@ -3380,7 +4242,14 @@ class TestCreateDeviceTypesCornerCases:
     def test_module_bays_not_created_when_modules_false(self, mock_settings, mock_pynetbox, graphql_client):
         """module-bays are only created when self.modules is True."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
         dt.create_module_bays = MagicMock()
@@ -3420,7 +4289,13 @@ class TestCreateModuleTypesCornerCases:
         created_mt.model = "LC"
         nb.netbox.dcim.module_types.create.return_value = created_mt
 
-        module_types = [{"manufacturer": {"slug": "cisco"}, "model": "LC", "src": "/repo/module-types/cisco/lc.yaml"}]
+        module_types = [
+            {
+                "manufacturer": {"slug": "cisco"},
+                "model": "LC",
+                "src": "/repo/module-types/cisco/lc.yaml",
+            }
+        ]
         nb.create_module_types(
             module_types,
             progress=iter(module_types),
@@ -3484,7 +4359,14 @@ class TestPreloadGlobalCornerCases:
     ):
         """When progress_updates is None and futures are pending, concurrent.futures.wait is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         # future that is initially not done, then done on second call
         future = MagicMock()
@@ -3514,7 +4396,14 @@ class TestPreloadGlobalCornerCases:
     ):
         """Endpoint in finished_endpoints has its progress task stopped without double-processing."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         future.done.return_value = True
@@ -3540,7 +4429,14 @@ class TestPreloadGlobalCornerCases:
     ):
         """Progress updates for already-finished endpoints are dropped when getting from queue."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         # First call: not done; second call: done
@@ -3582,7 +4478,14 @@ class TestUpdateComponentsAdditionsNoEndpoint:
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         # Make dcim.interface_templates return None (falsy)
         dt.netbox.dcim.interface_templates = None
 
@@ -3598,7 +4501,14 @@ class TestPowerOutletWithoutPowerPortKey:
     def test_outlet_without_power_port_key_skips_link(self, mock_settings, mock_pynetbox, graphql_client):
         """Power outlet that has no 'power_port' key hits the continue at line 1723."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {
             "power_outlet_templates": {("device", 1): {}},
             "power_port_templates": {("device", 1): {}},
@@ -3616,7 +4526,14 @@ class TestFrontPortWithoutRearPortKey:
     def test_front_port_without_rear_port_key_skips_link(self, mock_settings, mock_pynetbox, graphql_client):
         """Front port without 'rear_port' key hits the continue at line 1808."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {
             "rear_port_templates": {("device", 1): {}},
             "front_port_templates": {("device", 1): {}},
@@ -3634,7 +4551,14 @@ class TestModulePowerOutletWithoutPowerPortKey:
     def test_module_outlet_without_power_port_key_skips_link(self, mock_settings, mock_pynetbox, graphql_client):
         """Module power outlet without 'power_port' key hits the continue at line 1925."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
         dt.cached_components = {
             "power_outlet_templates": {("module", 1): {}},
             "power_port_templates": {("module", 1): {}},
@@ -3653,7 +4577,14 @@ class TestUploadImageAttachmentExceptions:
         import requests as _req3
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         img = tmp_path / "img.png"
         img.write_bytes(b"fake")
@@ -3673,7 +4604,14 @@ class TestPumpPreloadProgressFutureNotDone:
     def test_pending_future_returns_false_when_no_updates(self, mock_settings, mock_pynetbox, graphql_client):
         """When future is not done and no progress updates, returns False (line 1013)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         future.done.return_value = False  # not done yet
@@ -3699,7 +4637,14 @@ class TestPreloadGlobalMissingLines:
     ):
         """already_done endpoint whose future raises → log + empty records (lines 1119-1121)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         future.done.return_value = True
@@ -3726,7 +4671,14 @@ class TestPreloadGlobalMissingLines:
     ):
         """progress.stop_task raising for already_done endpoint is swallowed (1135-1136)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         future.done.return_value = True
@@ -3751,7 +4703,14 @@ class TestPreloadGlobalMissingLines:
     def test_pending_future_exception_logged(self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client):
         """Future raising while pending logs error and stores empty records (1153-1155)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         future = MagicMock()
         done_seq = [False, True]
@@ -3779,7 +4738,14 @@ class TestPreloadGlobalMissingLines:
     ):
         """progress_updates.get(timeout=0.1) returns item and updates progress (1172-1177)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         # First call: not done (triggers the timeout-get path); second: done
         done_seq = [False, True]
@@ -3817,7 +4783,14 @@ class TestPreloadGlobalMissingLines:
     ):
         """progress_updates.get returns item for finished endpoint → dropped (line 1172-1174)."""
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         # future not done first, then done
         done_seq = [False, True]
@@ -3863,7 +4836,14 @@ class TestStartComponentPreloadProgressCallback:
                 progress_callback(endpoint_name, len(records))
             return records
 
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         progress = MagicMock()
         progress.add_task.return_value = 1
@@ -3893,7 +4873,14 @@ class TestPreloadGlobalOwnExecutorProgressCallback:
                 progress_callback(endpoint_name, len(records))
             return records
 
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         progress = MagicMock()
         progress.add_task.return_value = 1
@@ -3916,7 +4903,14 @@ class TestUploadImagesRequestException:
         import requests as _req4
 
         mock_nb_api = mock_pynetbox.api.return_value
-        dt = DeviceTypes(mock_nb_api, mock_settings.handle, MagicMock(), False, False, graphql=graphql_client)
+        dt = DeviceTypes(
+            mock_nb_api,
+            mock_settings.handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=graphql_client,
+        )
 
         img = tmp_path / "front2.jpg"
         img.write_bytes(b"data")
@@ -3978,7 +4972,11 @@ class TestCreateRackTypes:
         existing = DotDict({"id": 1, "model": "AR1300", "slug": "apc-ar1300"})
         all_rack_types = {"apc": {"AR1300": existing}}
 
-        rack_type = {"manufacturer": {"slug": "apc"}, "model": "AR1300", "slug": "apc-ar1300"}
+        rack_type = {
+            "manufacturer": {"slug": "apc"},
+            "model": "AR1300",
+            "slug": "apc-ar1300",
+        }
         nb.create_rack_types([rack_type], only_new=True, all_rack_types=all_rack_types)
 
         mock_settings.handle.verbose_log.assert_called()

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -836,6 +836,53 @@ def test_update_components_legacy_mapping_missing_rear_port_warns(mock_settings,
     assert any("MISSING_RP" in str(c) for c in mock_settings.handle.log.call_args_list)
 
 
+def test_update_components_legacy_mapping_two_tuple_warns_and_skips(mock_settings, mock_pynetbox, graphql_client):
+    """On legacy NetBox (<4.5), ChangeDetector emits 2-tuples (fp_pos, rp_pos).
+
+    _apply_mappings_change must warn and skip rather than crash with ValueError.
+    """
+    from core.change_detector import ChangeType, ComponentChange, PropertyChange
+
+    mock_nb_api = MagicMock()
+    dt = DeviceTypes(
+        mock_nb_api,
+        mock_settings.handle,
+        MagicMock(),
+        False,
+        False,
+        graphql=graphql_client,
+    )
+    dt.m2m_front_ports = False
+
+    existing_fp = MagicMock()
+    existing_fp.id = 10
+    existing_fp.name = "FP1"
+    dt.cached_components = {
+        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
+        "rear_port_templates": {("device", 1): {}},
+    }
+
+    # 2-tuple: legacy ChangeDetector cannot include rp_name
+    new_mappings_set = frozenset({(1, 3)})
+    old_mappings_set = frozenset({(1, 1)})
+
+    changes = [
+        ComponentChange(
+            component_type="front-ports",
+            component_name="FP1",
+            change_type=ChangeType.COMPONENT_CHANGED,
+            property_changes=[PropertyChange("_mappings", old_mappings_set, new_mappings_set)],
+        ),
+    ]
+
+    endpoint = mock_nb_api.dcim.front_port_templates
+    mock_settings.handle.log.reset_mock()
+    dt.update_components({}, 1, changes, parent_type="device")
+
+    endpoint.update.assert_not_called()
+    assert any("NetBox < 4.5" in str(c) for c in mock_settings.handle.log.call_args_list)
+
+
 class TestNetBoxConnectApi:
     """Tests for TestNetBoxConnectApi."""
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, mock_open, patch
 from git import exc as git_exc
-from core.repo import DTLRepo, validate_git_url
+from core.repo import DTLRepo, validate_git_url, normalize_port_mappings
 
 
 class TestValidateGitUrl:
@@ -345,3 +345,177 @@ model: AP4431-Module
             # Non-matching filter should skip without raising KeyError
             results_filtered_out = repo.parse_files(files, slugs=["juniper"])
             assert len(results_filtered_out) == 0
+
+
+# ---------------------------------------------------------------------------
+# normalize_port_mappings tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePortMappings:
+    """Tests for normalize_port_mappings."""
+
+    # ── Old inline format ────────────────────────────────────────────────
+
+    def test_inline_single_mapping(self):
+        """Old inline rear_port/rear_port_position is converted to _mappings."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 2}],
+            "rear-ports": [{"name": "RP1"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        fp = data["front-ports"][0]
+        assert "rear_port" not in fp
+        assert "rear_port_position" not in fp
+        assert fp["_mappings"] == [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 2}]
+
+    def test_inline_default_rear_port_position(self):
+        """rear_port_position defaults to 1 when omitted."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "RP1"}],
+            "rear-ports": [{"name": "RP1"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert data["front-ports"][0]["_mappings"] == [
+            {"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1}
+        ]
+
+    def test_inline_multiple_front_ports(self):
+        """Each inline front port gets its own _mappings list."""
+        data = {
+            "front-ports": [
+                {"name": "FP1", "type": "8p8c", "rear_port": "RP1"},
+                {"name": "FP2", "type": "8p8c", "rear_port": "RP2"},
+            ],
+            "rear-ports": [{"name": "RP1"}, {"name": "RP2"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert data["front-ports"][0]["_mappings"][0]["rear_port"] == "RP1"
+        assert data["front-ports"][1]["_mappings"][0]["rear_port"] == "RP2"
+
+    def test_no_front_ports_noop(self):
+        """No front-ports and no port-mappings stanza returns None and doesn't modify data."""
+        data = {"interfaces": [{"name": "eth0"}]}
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert "interfaces" in data
+
+    def test_front_ports_without_rear_port_key_noop(self):
+        """Front ports without rear_port inline key are left unchanged."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert "_mappings" not in data["front-ports"][0]
+
+    # ── New port-mappings stanza ─────────────────────────────────────────
+
+    def test_stanza_single_mapping(self):
+        """New port-mappings stanza is converted to _mappings on front port."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c"}],
+            "rear-ports": [{"name": "RP1"}],
+            "port-mappings": [{"front_port": "FP1", "rear_port": "RP1"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert "port-mappings" not in data
+        assert data["front-ports"][0]["_mappings"] == [
+            {"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1}
+        ]
+
+    def test_stanza_explicit_positions(self):
+        """Explicit front_port_position and rear_port_position are preserved."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c"}],
+            "rear-ports": [{"name": "RP1", "positions": 4}],
+            "port-mappings": [
+                {"front_port": "FP1", "rear_port": "RP1", "front_port_position": 2, "rear_port_position": 3}
+            ],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert data["front-ports"][0]["_mappings"] == [
+            {"rear_port": "RP1", "front_port_position": 2, "rear_port_position": 3}
+        ]
+
+    def test_stanza_multi_mapping_one_front_port(self):
+        """Multiple port-mappings for the same front port produce a list."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c"}],
+            "rear-ports": [{"name": "RP1", "positions": 2}],
+            "port-mappings": [
+                {"front_port": "FP1", "rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1},
+                {"front_port": "FP1", "rear_port": "RP1", "front_port_position": 2, "rear_port_position": 2},
+            ],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert len(data["front-ports"][0]["_mappings"]) == 2
+
+    def test_stanza_missing_front_port_key_returns_error(self):
+        """Missing front_port in a stanza entry returns an error string."""
+        data = {
+            "front-ports": [{"name": "FP1"}],
+            "rear-ports": [{"name": "RP1"}],
+            "port-mappings": [{"rear_port": "RP1"}],  # no front_port
+        }
+        err = normalize_port_mappings(data)
+        assert err is not None
+        assert err.startswith("Error:")
+
+    def test_stanza_unknown_front_port_returns_error(self):
+        """Stanza referencing a front port not in front-ports list returns error."""
+        data = {
+            "front-ports": [{"name": "FP1"}],
+            "rear-ports": [{"name": "RP1"}],
+            "port-mappings": [{"front_port": "UNKNOWN", "rear_port": "RP1"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is not None
+        assert "UNKNOWN" in err
+
+    def test_stanza_unknown_rear_port_returns_error(self):
+        """Stanza referencing a rear port not in rear-ports list returns error."""
+        data = {
+            "front-ports": [{"name": "FP1"}],
+            "rear-ports": [{"name": "RP1"}],
+            "port-mappings": [{"front_port": "FP1", "rear_port": "MISSING"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is not None
+        assert "MISSING" in err
+
+    # ── Conflict detection ───────────────────────────────────────────────
+
+    def test_both_formats_identical_is_accepted(self):
+        """Both inline and stanza present with identical content is accepted."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 1}],
+            "rear-ports": [{"name": "RP1"}],
+            "port-mappings": [
+                {
+                    "front_port": "FP1",
+                    "rear_port": "RP1",
+                    "front_port_position": 1,
+                    "rear_port_position": 1,
+                }
+            ],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+
+    def test_both_formats_conflicting_returns_error(self):
+        """Both inline and stanza present with different mappings returns error."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 1}],
+            "rear-ports": [{"name": "RP1"}, {"name": "RP2"}],
+            "port-mappings": [{"front_port": "FP1", "rear_port": "RP2"}],  # different rear port
+        }
+        err = normalize_port_mappings(data)
+        assert err is not None
+        assert "conflict" in err.lower() or "Error" in err

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, call, mock_open, patch
 from git import exc as git_exc
 from core.repo import DTLRepo, validate_git_url, normalize_port_mappings
 
@@ -210,8 +210,10 @@ class TestPullRepo:
             mock_git_repo.remotes.origin.refs = [ref]
             MockRepo.return_value = mock_git_repo
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
-        mock_git_repo.remotes.origin.set_url.assert_called_with("https://github.com/new-org/repo.git")
-        mock_git_repo.remotes.origin.fetch.assert_called_once()
+        assert mock_git_repo.remotes.origin.method_calls[:2] == [
+            call.set_url("https://github.com/new-org/repo.git"),
+            call.fetch(),
+        ]
 
     def test_pull_repo_branch_not_found_calls_exception(self):
         """When the configured branch does not exist on the remote, GitBranchNotFound is reported."""
@@ -720,3 +722,24 @@ class TestNormalizePortMappings:
         err = normalize_port_mappings(data)
         assert err is None
         assert data["front-ports"][0]["_mappings"][0]["rear_port"] == "ANY_NAME"
+
+    def test_inline_empty_rear_ports_list_validates(self):
+        """Inline rear_port reference fails when rear-ports: [] is declared (empty but present)."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "MISSING"}],
+            "rear-ports": [],
+        }
+        err = normalize_port_mappings(data)
+        assert err is not None
+        assert "MISSING" in err
+
+    def test_stanza_empty_rear_ports_list_validates(self):
+        """Stanza rear_port reference fails when rear-ports: [] is declared (empty but present)."""
+        data = {
+            "front-ports": [{"name": "FP1"}],
+            "rear-ports": [],
+            "port-mappings": [{"front_port": "FP1", "rear_port": "MISSING"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is not None
+        assert "MISSING" in err

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -62,7 +62,10 @@ class TestDTLRepoInit:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=isdir), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=isdir),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             if mock_repo:
                 MockRepo.return_value = mock_repo
                 MockRepo.clone_from.return_value = mock_repo
@@ -74,7 +77,10 @@ class TestDTLRepoInit:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             ref = MagicMock()
@@ -90,7 +96,10 @@ class TestDTLRepoInit:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=False), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=False),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_cloned = MagicMock()
             MockRepo.clone_from.return_value = mock_cloned
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
@@ -104,7 +113,9 @@ class TestDTLRepoInit:
         with patch("os.path.isdir", return_value=False), patch("core.repo.Repo"):
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         mock_handle.exception.assert_called_with(
-            "InvalidGitURL", "ftp://bad.url", "URL must use HTTPS, SSH, or file protocol"
+            "InvalidGitURL",
+            "ftp://bad.url",
+            "URL must use HTTPS, SSH, or file protocol",
         )
 
 
@@ -116,7 +127,10 @@ class TestDTLRepoPathMethods:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             ref = MagicMock()
@@ -148,7 +162,10 @@ class TestPullRepo:
         mock_args.url = "ftp://bad"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             # origin URL matches configured URL → validate origin path
             mock_git_repo.remotes.origin.url = "ftp://bad"
@@ -162,13 +179,18 @@ class TestPullRepo:
         mock_args.url = "ftp://bad-config"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             MockRepo.return_value = mock_git_repo
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         mock_handle.exception.assert_any_call(
-            "InvalidGitURL", "ftp://bad-config", "URL must use HTTPS, SSH, or file protocol"
+            "InvalidGitURL",
+            "ftp://bad-config",
+            "URL must use HTTPS, SSH, or file protocol",
         )
 
     def test_pull_repo_updates_remote_url_when_different(self):
@@ -177,7 +199,10 @@ class TestPullRepo:
         mock_args.url = "https://github.com/new-org/repo.git"
         mock_args.branch = "main"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/old-org/repo.git"
             ref = MagicMock()
@@ -194,7 +219,10 @@ class TestPullRepo:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "missing-branch"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             ref = MagicMock()
@@ -209,7 +237,10 @@ class TestPullRepo:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             mock_git_repo.remotes.origin.fetch.side_effect = git_exc.GitCommandError("fetch", 1)
@@ -222,7 +253,10 @@ class TestPullRepo:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             mock_git_repo.remotes.origin.fetch.side_effect = RuntimeError("network error")
@@ -239,7 +273,10 @@ class TestCloneRepo:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=False), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=False),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             MockRepo.clone_from.side_effect = git_exc.GitCommandError("clone", 128)
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         mock_handle.exception.assert_called()
@@ -249,7 +286,10 @@ class TestCloneRepo:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=False), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=False),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             MockRepo.clone_from.side_effect = RuntimeError("failed")
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         mock_handle.exception.assert_called()
@@ -263,7 +303,10 @@ class TestGetDevices:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             ref = MagicMock()
@@ -275,21 +318,30 @@ class TestGetDevices:
 
     def test_get_devices_all_vendors(self):
         repo = self._make_repo()
-        with patch("os.listdir", return_value=["Cisco", "Juniper"]), patch("glob.glob", return_value=[]):
+        with (
+            patch("os.listdir", return_value=["Cisco", "Juniper"]),
+            patch("glob.glob", return_value=[]),
+        ):
             files, vendors = repo.get_devices("/base/path")
         assert len(vendors) == 2
         assert any(v["name"] == "Cisco" for v in vendors)
 
     def test_get_devices_filters_vendors(self):
         repo = self._make_repo()
-        with patch("os.listdir", return_value=["Cisco", "Juniper"]), patch("glob.glob", return_value=[]):
+        with (
+            patch("os.listdir", return_value=["Cisco", "Juniper"]),
+            patch("glob.glob", return_value=[]),
+        ):
             files, vendors = repo.get_devices("/base/path", vendors=["cisco"])
         assert len(vendors) == 1
         assert vendors[0]["name"] == "Cisco"
 
     def test_get_devices_skips_testing_folder(self):
         repo = self._make_repo()
-        with patch("os.listdir", return_value=["Cisco", "testing"]), patch("glob.glob", return_value=[]):
+        with (
+            patch("os.listdir", return_value=["Cisco", "testing"]),
+            patch("glob.glob", return_value=[]),
+        ):
             files, vendors = repo.get_devices("/base/path")
         assert not any(v["name"] == "testing" for v in vendors)
 
@@ -302,7 +354,10 @@ class TestParseFilesExtended:
         mock_args.url = "https://github.com/org/repo.git"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+        with (
+            patch("os.path.isdir", return_value=True),
+            patch("core.repo.Repo") as MockRepo,
+        ):
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             ref = MagicMock()
@@ -423,7 +478,14 @@ class TestNormalizePortMappings:
     def test_inline_single_mapping(self):
         """Old inline rear_port/rear_port_position is converted to _mappings."""
         data = {
-            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 2}],
+            "front-ports": [
+                {
+                    "name": "FP1",
+                    "type": "8p8c",
+                    "rear_port": "RP1",
+                    "rear_port_position": 2,
+                }
+            ],
             "rear-ports": [{"name": "RP1"}],
         }
         err = normalize_port_mappings(data)
@@ -497,7 +559,12 @@ class TestNormalizePortMappings:
             "front-ports": [{"name": "FP1", "type": "8p8c"}],
             "rear-ports": [{"name": "RP1", "positions": 4}],
             "port-mappings": [
-                {"front_port": "FP1", "rear_port": "RP1", "front_port_position": 2, "rear_port_position": 3}
+                {
+                    "front_port": "FP1",
+                    "rear_port": "RP1",
+                    "front_port_position": 2,
+                    "rear_port_position": 3,
+                }
             ],
         }
         err = normalize_port_mappings(data)
@@ -512,13 +579,29 @@ class TestNormalizePortMappings:
             "front-ports": [{"name": "FP1", "type": "8p8c"}],
             "rear-ports": [{"name": "RP1", "positions": 2}],
             "port-mappings": [
-                {"front_port": "FP1", "rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1},
-                {"front_port": "FP1", "rear_port": "RP1", "front_port_position": 2, "rear_port_position": 2},
+                {
+                    "front_port": "FP1",
+                    "rear_port": "RP1",
+                    "front_port_position": 1,
+                    "rear_port_position": 1,
+                },
+                {
+                    "front_port": "FP1",
+                    "rear_port": "RP1",
+                    "front_port_position": 2,
+                    "rear_port_position": 2,
+                },
             ],
         }
         err = normalize_port_mappings(data)
         assert err is None
-        assert len(data["front-ports"][0]["_mappings"]) == 2
+        assert sorted(
+            data["front-ports"][0]["_mappings"],
+            key=lambda m: (m["front_port_position"], m["rear_port_position"]),
+        ) == [
+            {"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 1},
+            {"rear_port": "RP1", "front_port_position": 2, "rear_port_position": 2},
+        ]
 
     def test_stanza_missing_front_port_key_returns_error(self):
         """Missing front_port in a stanza entry returns an error string."""
@@ -558,7 +641,14 @@ class TestNormalizePortMappings:
     def test_both_formats_identical_is_accepted(self):
         """Both inline and stanza present with identical content is accepted."""
         data = {
-            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 1}],
+            "front-ports": [
+                {
+                    "name": "FP1",
+                    "type": "8p8c",
+                    "rear_port": "RP1",
+                    "rear_port_position": 1,
+                }
+            ],
             "rear-ports": [{"name": "RP1"}],
             "port-mappings": [
                 {
@@ -575,10 +665,58 @@ class TestNormalizePortMappings:
     def test_both_formats_conflicting_returns_error(self):
         """Both inline and stanza present with different mappings returns error."""
         data = {
-            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 1}],
+            "front-ports": [
+                {
+                    "name": "FP1",
+                    "type": "8p8c",
+                    "rear_port": "RP1",
+                    "rear_port_position": 1,
+                }
+            ],
             "rear-ports": [{"name": "RP1"}, {"name": "RP2"}],
             "port-mappings": [{"front_port": "FP1", "rear_port": "RP2"}],  # different rear port
         }
         err = normalize_port_mappings(data)
         assert err is not None
         assert "conflict" in err.lower() or "Error" in err
+
+    def test_empty_stanza_is_deleted(self):
+        """An explicit empty port-mappings list is removed and produces no error."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c"}],
+            "rear-ports": [{"name": "RP1"}],
+            "port-mappings": [],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert "port-mappings" not in data
+
+    def test_null_stanza_is_deleted(self):
+        """An explicit null port-mappings value is removed and produces no error."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c"}],
+            "rear-ports": [{"name": "RP1"}],
+            "port-mappings": None,
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert "port-mappings" not in data
+
+    def test_inline_unknown_rear_port_returns_error(self):
+        """Inline rear_port reference to unknown rear port returns an error."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "MISSING"}],
+            "rear-ports": [{"name": "RP1"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is not None
+        assert "MISSING" in err
+
+    def test_inline_no_rear_ports_list_skips_validation(self):
+        """Inline rear_port reference is accepted when rear-ports list is absent."""
+        data = {
+            "front-ports": [{"name": "FP1", "type": "8p8c", "rear_port": "ANY_NAME"}],
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert data["front-ports"][0]["_mappings"][0]["rear_port"] == "ANY_NAME"

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -88,7 +88,7 @@ class TestDTLRepoInit:
             mock_git_repo.remotes.origin.refs = [ref]
             MockRepo.return_value = mock_git_repo
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
-        mock_git_repo.remotes.origin.fetch.assert_called_once()
+        mock_git_repo.remotes.origin.fetch.assert_called_once_with(prune=True)
         mock_git_repo.git.checkout.assert_called_with("-B", "master", "origin/master")
 
     def test_clones_when_dir_missing(self):
@@ -212,7 +212,7 @@ class TestPullRepo:
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         assert mock_git_repo.remotes.origin.method_calls[:2] == [
             call.set_url("https://github.com/new-org/repo.git"),
-            call.fetch(),
+            call.fetch(prune=True),
         ]
 
     def test_pull_repo_branch_not_found_calls_exception(self):
@@ -322,7 +322,7 @@ class TestGetDevices:
         repo = self._make_repo()
         with (
             patch("os.listdir", return_value=["Cisco", "Juniper"]),
-            patch("glob.glob", return_value=[]),
+            patch("core.repo.glob", return_value=[]),
         ):
             files, vendors = repo.get_devices("/base/path")
         assert len(vendors) == 2
@@ -332,7 +332,7 @@ class TestGetDevices:
         repo = self._make_repo()
         with (
             patch("os.listdir", return_value=["Cisco", "Juniper"]),
-            patch("glob.glob", return_value=[]),
+            patch("core.repo.glob", return_value=[]),
         ):
             files, vendors = repo.get_devices("/base/path", vendors=["cisco"])
         assert len(vendors) == 1
@@ -342,7 +342,7 @@ class TestGetDevices:
         repo = self._make_repo()
         with (
             patch("os.listdir", return_value=["Cisco", "testing"]),
-            patch("glob.glob", return_value=[]),
+            patch("core.repo.glob", return_value=[]),
         ):
             files, vendors = repo.get_devices("/base/path")
         assert not any(v["name"] == "testing" for v in vendors)
@@ -699,6 +699,15 @@ class TestNormalizePortMappings:
             "front-ports": [{"name": "FP1", "type": "8p8c"}],
             "rear-ports": [{"name": "RP1"}],
             "port-mappings": None,
+        }
+        err = normalize_port_mappings(data)
+        assert err is None
+        assert "port-mappings" not in data
+
+    def test_empty_stanza_no_front_ports_still_deleted(self):
+        """Empty port-mappings stanza with no front-ports is cleaned up (not silently skipped)."""
+        data = {
+            "port-mappings": [],
         }
         err = normalize_port_mappings(data)
         assert err is None

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -77,9 +77,13 @@ class TestDTLRepoInit:
         with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
+            ref = MagicMock()
+            ref.name = "origin/master"
+            mock_git_repo.remotes.origin.refs = [ref]
             MockRepo.return_value = mock_git_repo
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
-        mock_git_repo.remotes.origin.pull.assert_called_once()
+        mock_git_repo.remotes.origin.fetch.assert_called_once()
+        mock_git_repo.git.checkout.assert_called_with("-B", "master", "origin/master")
 
     def test_clones_when_dir_missing(self):
         mock_args = MagicMock()
@@ -115,6 +119,9 @@ class TestDTLRepoPathMethods:
         with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
+            ref = MagicMock()
+            ref.name = "origin/master"
+            mock_git_repo.remotes.origin.refs = [ref]
             MockRepo.return_value = mock_git_repo
             repo = DTLRepo(mock_args, "/tmp/repo", mock_handle)
         return repo
@@ -136,16 +143,66 @@ class TestPullRepo:
     """Tests for DTLRepo.pull_repo(): origin URL validation, pull success, and error handling."""
 
     def test_pull_repo_invalid_origin_calls_exception(self):
+        """When origin URL equals configured URL and both are invalid, exception is called."""
         mock_args = MagicMock()
-        mock_args.url = "https://github.com/org/repo.git"
+        mock_args.url = "ftp://bad"
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
             mock_git_repo = MagicMock()
+            # origin URL matches configured URL → validate origin path
             mock_git_repo.remotes.origin.url = "ftp://bad"
             MockRepo.return_value = mock_git_repo
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         mock_handle.exception.assert_called()
+
+    def test_pull_repo_invalid_configured_url_calls_exception(self):
+        """When configured REPO_URL differs from origin and is invalid, exception is called."""
+        mock_args = MagicMock()
+        mock_args.url = "ftp://bad-config"
+        mock_args.branch = "master"
+        mock_handle = MagicMock()
+        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+            mock_git_repo = MagicMock()
+            mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
+            MockRepo.return_value = mock_git_repo
+            DTLRepo(mock_args, "/tmp/repo", mock_handle)
+        mock_handle.exception.assert_any_call(
+            "InvalidGitURL", "ftp://bad-config", "URL must use HTTPS, SSH, or file protocol"
+        )
+
+    def test_pull_repo_updates_remote_url_when_different(self):
+        """When REPO_URL differs from origin URL, the remote is updated before fetching."""
+        mock_args = MagicMock()
+        mock_args.url = "https://github.com/new-org/repo.git"
+        mock_args.branch = "main"
+        mock_handle = MagicMock()
+        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+            mock_git_repo = MagicMock()
+            mock_git_repo.remotes.origin.url = "https://github.com/old-org/repo.git"
+            ref = MagicMock()
+            ref.name = "origin/main"
+            mock_git_repo.remotes.origin.refs = [ref]
+            MockRepo.return_value = mock_git_repo
+            DTLRepo(mock_args, "/tmp/repo", mock_handle)
+        mock_git_repo.remotes.origin.set_url.assert_called_with("https://github.com/new-org/repo.git")
+        mock_git_repo.remotes.origin.fetch.assert_called_once()
+
+    def test_pull_repo_branch_not_found_calls_exception(self):
+        """When the configured branch does not exist on the remote, GitBranchNotFound is reported."""
+        mock_args = MagicMock()
+        mock_args.url = "https://github.com/org/repo.git"
+        mock_args.branch = "missing-branch"
+        mock_handle = MagicMock()
+        with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
+            mock_git_repo = MagicMock()
+            mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
+            ref = MagicMock()
+            ref.name = "origin/master"
+            mock_git_repo.remotes.origin.refs = [ref]
+            MockRepo.return_value = mock_git_repo
+            DTLRepo(mock_args, "/tmp/repo", mock_handle)
+        mock_handle.exception.assert_called_with("GitBranchNotFound", "missing-branch")
 
     def test_pull_repo_git_command_error_calls_exception(self):
         mock_args = MagicMock()
@@ -155,7 +212,7 @@ class TestPullRepo:
         with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
-            mock_git_repo.remotes.origin.pull.side_effect = git_exc.GitCommandError("pull", 1)
+            mock_git_repo.remotes.origin.fetch.side_effect = git_exc.GitCommandError("fetch", 1)
             MockRepo.return_value = mock_git_repo
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         mock_handle.exception.assert_called()
@@ -168,7 +225,7 @@ class TestPullRepo:
         with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
-            mock_git_repo.remotes.origin.pull.side_effect = RuntimeError("network error")
+            mock_git_repo.remotes.origin.fetch.side_effect = RuntimeError("network error")
             MockRepo.return_value = mock_git_repo
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         mock_handle.exception.assert_called()
@@ -209,6 +266,9 @@ class TestGetDevices:
         with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
+            ref = MagicMock()
+            ref.name = "origin/master"
+            mock_git_repo.remotes.origin.refs = [ref]
             MockRepo.return_value = mock_git_repo
             repo = DTLRepo(mock_args, "/tmp/repo", mock_handle)
         return repo
@@ -245,6 +305,9 @@ class TestParseFilesExtended:
         with patch("os.path.isdir", return_value=True), patch("core.repo.Repo") as MockRepo:
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
+            ref = MagicMock()
+            ref.name = "origin/master"
+            mock_git_repo.remotes.origin.refs = [ref]
             MockRepo.return_value = mock_git_repo
             repo = DTLRepo(mock_args, "/tmp/repo", mock_handle)
         return repo, mock_handle

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -752,3 +752,88 @@ class TestNormalizePortMappings:
         err = normalize_port_mappings(data)
         assert err is not None
         assert "MISSING" in err
+
+
+# ============================================================
+# validate_repo_path tests
+# ============================================================
+
+
+class TestValidateRepoPath:
+    """Tests for the validate_repo_path() helper."""
+
+    def test_path_exists_is_file_returns_false(self, tmp_path):
+        """Existing path that is a file (not directory) returns False."""
+        from core.repo import validate_repo_path
+
+        f = tmp_path / "not_a_dir.txt"
+        f.write_text("x")
+        ok, msg = validate_repo_path(str(f))
+        assert ok is False
+        assert "not a directory" in msg
+
+    def test_path_exists_not_writable_returns_false(self, tmp_path):
+        """Existing directory without write permission returns False."""
+        from core.repo import validate_repo_path
+
+        d = tmp_path / "readonly"
+        d.mkdir()
+        d.chmod(0o555)
+        try:
+            ok, msg = validate_repo_path(str(d))
+            assert ok is False
+            assert "not writable" in msg
+        finally:
+            d.chmod(0o755)
+
+    def test_parent_not_writable_returns_false(self, tmp_path):
+        """Non-existent path whose parent is not writable returns False."""
+        from core.repo import validate_repo_path
+
+        parent = tmp_path / "readonly_parent"
+        parent.mkdir()
+        parent.chmod(0o555)
+        target = str(parent / "new_repo")
+        try:
+            ok, msg = validate_repo_path(target)
+            assert ok is False
+            assert "not writable" in msg
+        finally:
+            parent.chmod(0o755)
+
+    def test_valid_new_path_returns_true(self, tmp_path):
+        """Non-existent path with writable parent returns True."""
+        from core.repo import validate_repo_path
+
+        target = str(tmp_path / "new_repo")
+        ok, msg = validate_repo_path(target)
+        assert ok is True
+        assert msg == ""
+
+    def test_valid_existing_dir_returns_true(self, tmp_path):
+        """Existing writable directory returns True."""
+        from core.repo import validate_repo_path
+
+        ok, msg = validate_repo_path(str(tmp_path))
+        assert ok is True
+
+
+# ============================================================
+# parse_single_file error path tests
+# ============================================================
+
+
+def test_parse_device_type_returns_error_when_normalize_fails(tmp_path):
+    """normalize_port_mappings returning an error propagates as return value.
+
+    Covers repo.py lines 225-226: 'if err: return err'.
+    """
+    from unittest.mock import patch
+    from core.repo import parse_single_file
+
+    yaml_file = tmp_path / "test.yaml"
+    yaml_file.write_text("manufacturer: Test\nmodel: M1\nslug: m1\n")
+
+    with patch("core.repo.normalize_port_mappings", return_value="Error: invalid mapping"):
+        result = parse_single_file(str(yaml_file))
+    assert result == "Error: invalid mapping"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mappings-first front-port comparison with multi-step fallbacks for older NetBox schemas
  * YAML normalization for multiple port-mapping formats and mapping-aware update payloads
  * Improved handling of front/rear port relationships across NetBox versions

* **Bug Fixes**
  * Clearer Git error/branch messages and more robust remote fetch/checkout behavior

* **Tests**
  * Expanded coverage for mappings comparison, GraphQL fallbacks, normalization, and repo pull flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->