### PR TITLE
feat: resolve module type profile string to name dict for NetBox API

### DIFF
--- a/core/repo.py
+++ b/core/repo.py
@@ -219,6 +219,8 @@ def parse_single_file(file):
             # Use only slug for manufacturer lookup - more resilient to case mismatches
             # (e.g., RuggedCOM vs RuggedCom in upstream data)
             data["manufacturer"] = {"slug": re_sub(r"\W+", "-", manufacturer.lower())}
+            if "profile" in data and isinstance(data["profile"], str):
+                data["profile"] = {"name": data["profile"]}
             data["src"] = file
             err = normalize_port_mappings(data)
             if err:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -859,3 +859,25 @@ def test_parse_single_file_without_profile(tmp_path):
 
     result = parse_single_file(str(yaml_file))
     assert "profile" not in result
+
+
+def test_parse_single_file_profile_already_dict(tmp_path):
+    """Profile that is already a dict should pass through unchanged."""
+    from core.repo import parse_single_file
+
+    yaml_file = tmp_path / "test.yaml"
+    yaml_file.write_text("manufacturer: Test\nmodel: M1\nprofile:\n  name: Fan\n")
+
+    result = parse_single_file(str(yaml_file))
+    assert result["profile"] == {"name": "Fan"}
+
+
+def test_parse_single_file_profile_null(tmp_path):
+    """Profile set to null should pass through as None."""
+    from core.repo import parse_single_file
+
+    yaml_file = tmp_path / "test.yaml"
+    yaml_file.write_text("manufacturer: Test\nmodel: M1\nprofile: null\n")
+
+    result = parse_single_file(str(yaml_file))
+    assert result["profile"] is None

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -837,3 +837,25 @@ def test_parse_device_type_returns_error_when_normalize_fails(tmp_path):
     with patch("core.repo.normalize_port_mappings", return_value="Error: invalid mapping"):
         result = parse_single_file(str(yaml_file))
     assert result == "Error: invalid mapping"
+
+
+def test_parse_single_file_converts_profile_to_dict(tmp_path):
+    """Profile string should be converted to a name-based dict for pynetbox."""
+    from core.repo import parse_single_file
+
+    yaml_file = tmp_path / "test.yaml"
+    yaml_file.write_text("manufacturer: Test\nmodel: M1\nprofile: Power supply\n")
+
+    result = parse_single_file(str(yaml_file))
+    assert result["profile"] == {"name": "Power supply"}
+
+
+def test_parse_single_file_without_profile(tmp_path):
+    """Files without a profile field should parse without error."""
+    from core.repo import parse_single_file
+
+    yaml_file = tmp_path / "test.yaml"
+    yaml_file.write_text("manufacturer: Test\nmodel: M1\n")
+
+    result = parse_single_file(str(yaml_file))
+    assert "profile" not in result


### PR DESCRIPTION
The device-type library now includes a profile field on module types (e.g. "Power supply", "Fan"). NetBox requires this as a reference dict, not a plain string. Convert it during YAML parsing, matching the existing manufacturer slug pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile field parsing to properly normalize string-based values into a structured format.

* **Tests**
  * Added test coverage for profile field transformation and validation of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->