### PR TITLE
chore: Add info about v1 vs v2 tokens in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ and device, creating anything that is missing from NetBox while skipping entries
 | `GRAPHQL_PAGE_SIZE` | | `5000` | Items per GraphQL page |
 | `PRELOAD_THREADS` | | `8` | Threads for concurrent component preloading |
 
-> ⚠️ **Tokens** Please note there is a difference in setting the token based on wether you are using v1 or v2 tokens
+> ⚠️ **Tokens:** Please note there is a difference in setting the token based on whether you are using v1 or v2 tokens
 >
 > For v1, your token will simply be the secret part generated when you create the api token in netbox:
 >
 > `NETBOX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
 >
-> For v2 tokens, you also need to include the bearer key (represented here by capital X-es):
+> For v2 tokens, you need to include prefix "nbt_", the bearer key (represented here by capital X-es), a dot, and finally the secret token (represented by lowercase x-es):
 >
 >`NETBOX_TOKEN=nbt_XXXXXXXXXXXX.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ and device, creating anything that is missing from NetBox while skipping entries
 | `GRAPHQL_PAGE_SIZE` | | `5000` | Items per GraphQL page |
 | `PRELOAD_THREADS` | | `8` | Threads for concurrent component preloading |
 
+> ⚠️ **Tokens** Please note there is a difference in setting the token based on wether you are using v1 or v2 tokens
+>
+> For v1, your token will simply be the secret part generated when you create the api token in netbox:
+>
+> `NETBOX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+>
+> For v2 tokens, you also need to include the bearer key (represented here by capital X-es):
+>
+>`NETBOX_TOKEN=nbt_XXXXXXXXXXXX.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`
+
 ### Arguments
 
 This script currently accepts a list of vendors as an argument, so that you can selectively


### PR DESCRIPTION
Add a small explainer about entering v1 vs v2 tokens in the config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Environment Variables section in README with clarification on formatting `NETBOX_TOKEN` for different NetBox API token versions (v1 vs v2).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->