### PR TITLE
Document --slugs argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ and device, creating anything that is missing from NetBox while skipping entries
 
 This script provides ways to selectively import devices via `--vendors` and `--slugs` arguments.
 
-To import only devices from one vendors, or multiple:
+To import only devices from one vendor, or multiple vendors:
 
 ```shell
 uv run nb-dt-import.py --vendors apc
 uv run nb-dt-import.py --vendors apc,juniper
 ```
 
-`--slugs` does partial matching on each device type's slug, and also multiple:
+`--slugs` does partial matching on each device type's slug and supports multiple values:
 
 ```shell
 uv run nb-dt-import.py --slugs x440-g2            # Imports 11 network switch device type variations

--- a/README.md
+++ b/README.md
@@ -83,19 +83,26 @@ and device, creating anything that is missing from NetBox while skipping entries
 
 ### Arguments
 
-This script currently accepts a list of vendors as an argument, so that you can selectively
-import devices.
+This script provides ways to selectively import devices via `--vendors` and `--slugs` arguments.
 
-To import only device by APC, for example:
+To import only devices from one vendors, or multiple:
 
 ```shell
 uv run nb-dt-import.py --vendors apc
+uv run nb-dt-import.py --vendors apc,juniper
 ```
 
-`--vendors` can also accept a comma-separated list of vendors if you want to import multiple.
+`--slugs` does partial matching on each device type's slug, and also multiple:
 
 ```shell
-uv run nb-dt-import.py --vendors apc,juniper
+uv run nb-dt-import.py --slugs x440-g2            # Imports 11 network switch device type variations
+uv run nb-dt-import.py --slugs ap4433a,ap7526     # Imports two specific PDUs
+```
+
+`--vendors` and `--slugs` can be combined:
+
+```shell
+uv run nb-dt-import.py --vendors "Palo Alto" --slugs 440
 ```
 
 #### Update Mode


### PR DESCRIPTION
I went to add this option and found that it already existed.

I condensed the examples to try and keep the section short.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Arguments section to document two CLI selectors for selective importing: vendor and slug filters, both supporting comma-separated lists.
  * Added examples demonstrating single and multiple vendors, single and multiple slug patterns (with matched variation notes), and combined vendor+slug usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->