### PR TITLE
fix: warn-and-skip on duplicate repo keys instead of crashing

### DIFF
--- a/core/export.py
+++ b/core/export.py
@@ -513,7 +513,11 @@ class Exporter:
                 if isinstance(data, dict) and "slug" in data:
                     key = (mfr_slug, data["slug"])
                     if key in result:
-                        raise ValueError(f"Duplicate repo device-type key {key!r}: {seen_files[key]} and {yaml_file}")
+                        self.handle.verbose_log(
+                            f"[yellow]Duplicate repo device-type key {key!r}: "
+                            f"{seen_files[key]} and {yaml_file} — keeping first[/yellow]"
+                        )
+                        continue
                     result[key] = data
                     seen_files[key] = yaml_file
         return result
@@ -535,9 +539,11 @@ class Exporter:
                     if mfr_slug:
                         key = (mfr_slug, data["model"])
                         if key in result:
-                            raise ValueError(
-                                f"Duplicate repo module-type key {key!r}: {seen_files[key]} and {yaml_file}"
+                            self.handle.verbose_log(
+                                f"[yellow]Duplicate repo module-type key {key!r}: "
+                                f"{seen_files[key]} and {yaml_file} — keeping first[/yellow]"
                             )
+                            continue
                         result[key] = data
                         seen_files[key] = yaml_file
         return result
@@ -559,7 +565,11 @@ class Exporter:
                     if mfr_slug:
                         key = (mfr_slug, data["model"])
                         if key in result:
-                            raise ValueError(f"Duplicate repo rack-type key {key!r}: {seen_files[key]} and {yaml_file}")
+                            self.handle.verbose_log(
+                                f"[yellow]Duplicate repo rack-type key {key!r}: "
+                                f"{seen_files[key]} and {yaml_file} — keeping first[/yellow]"
+                            )
+                            continue
                         result[key] = data
                         seen_files[key] = yaml_file
         return result

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "device-type-library-import"
-version = "1.5.0"
+version = "1.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
The upstream DTL repo legitimately contains files with the same model name but different part numbers (e.g. HPE 38L7559.yaml and 834167-001.yaml both have model 'HPE Drive LTO-7 Ultrium 7-SCSI'). Previously the loaders raised ValueError which crashed export-diff.

Change all three loaders (_load_repo_device_types, _load_repo_module_types, _load_repo_rack_types) to log a verbose warning and keep the first-seen entry, matching the import path's behaviour when encountering same-name records.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files with duplicate entries are now handled gracefully with detailed logging instead of causing the application to fail. The first entry is preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marcinpsk/Device-Type-Library-Import/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->