### PR TITLE
fix: integration idempotency suppressed banner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,3 +50,6 @@ jobs:
 
       - name: Check formatting
         run: uv run ruff format --check .
+
+      - name: Check docstring coverage
+        run: uv run interrogate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,13 @@ repos:
         language: system
         types: [python]
         require_serial: true
+      - id: interrogate
+        name: interrogate
+        entry: uv run --native-tls interrogate
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true
       - id: pytest
         name: pytest
         entry: uv run --native-tls pytest --cov --cov-report=term-missing

--- a/core/export.py
+++ b/core/export.py
@@ -642,6 +642,12 @@ class Exporter:
     def _determine_export_set_for_device_types(
         self, nb_records: list, repo_dt_by_slug: dict, components_by_dt_id: dict
     ) -> List[ExportItem]:
+        """Build the list of device types that need exporting to the repo.
+
+        Includes records absent from the repo, those whose serialized form
+        differs from the repo YAML, and those whose elevation images are
+        missing locally; records the repo already supersedes are skipped.
+        """
         items = []
         for rec in nb_records:
             serialized = serialize_device_type(rec, components_by_dt_id)
@@ -677,6 +683,12 @@ class Exporter:
     def _determine_export_set_for_module_types(
         self, nb_records: list, repo_mt_by_key: dict, components_by_mt_id: dict
     ) -> List[ExportItem]:
+        """Build the list of module types that need exporting to the repo.
+
+        Includes records absent from the repo and those whose serialized form
+        differs from the repo YAML; records the repo already supersedes are
+        skipped.
+        """
         items = []
         for rec in nb_records:
             serialized = serialize_module_type(rec, components_by_mt_id)
@@ -708,6 +720,12 @@ class Exporter:
         return items
 
     def _determine_export_set_for_rack_types(self, nb_records: list, repo_rt_by_key: dict) -> List[ExportItem]:
+        """Build the list of rack types that need exporting to the repo.
+
+        Includes records absent from the repo and those whose serialized form
+        differs from the repo YAML; records the repo already supersedes are
+        skipped.
+        """
         items = []
         for rec in nb_records:
             serialized = serialize_rack_type(rec)
@@ -784,6 +802,12 @@ class Exporter:
         return True  # rack types have no images
 
     def _download_device_type_images(self, item: ExportItem) -> bool:
+        """Download the front/rear elevation images for a device type.
+
+        Saves each available image under ``elevation-images/<Vendor>/`` and
+        returns True only if every image present on the record downloaded
+        successfully.
+        """
         img_dir = self.export_dir / "elevation-images" / item.mfr_name
         ok = True
         for suffix, url_path in (

--- a/core/repo.py
+++ b/core/repo.py
@@ -21,6 +21,7 @@ class _RestrictedUnpickler(pickle.Unpickler):
     """
 
     def find_class(self, module, name):
+        """Reject any class lookup — DTL pickles must hold only string tuples."""
         raise pickle.UnpicklingError(
             f"DTL pickle safety: loading class '{module}.{name}' is not permitted. "
             "The known-*.pickle files must contain only sets of string tuples."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ max-complexity = 15
 # Measure docstring coverage on first-party source only. The vendored
 # Device-Type-Library lives under repo/, and test functions are exempt from
 # docstrings (mirrors the ruff D102/D103 per-file-ignore for tests/**).
-fail-under = 80
+fail-under = 95
 exclude = ["repo", "tests", "setup.py", "conftest.py"]
 ignore-init-method = true
 ignore-magic = true
@@ -74,6 +74,7 @@ norecursedirs = ["tests/integration"]
 [tool.coverage.run]
 source = ["."]
 omit = ["tests/*", "setup.py", "conftest.py"]
+branch = true
 
 [tool.coverage.report]
 fail_under = 96

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,8 @@ fail_under = 96
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 commit_message = "chore(release): v{version}"
-build_command = ""
+build_command = "uv lock"
+assets = ["uv.lock"]
 
 [tool.semantic_release.changelog]
 template_dir = "templates"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,17 @@ max-complexity = 15
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["D102", "D103"]  # test functions don't need docstrings
 
+[tool.interrogate]
+# Measure docstring coverage on first-party source only. The vendored
+# Device-Type-Library lives under repo/, and test functions are exempt from
+# docstrings (mirrors the ruff D102/D103 per-file-ignore for tests/**).
+fail-under = 80
+exclude = ["repo", "tests", "setup.py", "conftest.py"]
+ignore-init-method = true
+ignore-magic = true
+ignore-nested-functions = true
+ignore-private = false
+
 [tool.pytest.ini_options]
 timeout = 20
 timeout_method = "thread"

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -494,9 +494,11 @@ def test_idempotency() -> None:
         ok("module-type change-detection banner suppressed (no module-type changes)")
 
     # Always-printed end-of-run summary — the authoritative idempotency check.
+    # The (?<!\d) lookbehind anchors the literal zero so "0 device types
+    # created" doesn't spuriously match "10 device types created".
     for pattern, label in [
-        (r"0 device types created", "device types created"),
-        (r"0 device types updated", "device types updated"),
+        (r"(?<!\d)0 device types created", "device types created"),
+        (r"(?<!\d)0 device types updated", "device types updated"),
     ]:
         if not re.search(pattern, out):
             fail(f"Second run: expected '{pattern}' but report says otherwise.\n{out}")
@@ -543,10 +545,10 @@ def test_update_mode() -> None:
     # suppresses the change-detection banner, so assert against the
     # always-printed end-of-run summary instead.
     result2 = run_importer()
-    if not re.search(r"0 device types created", result2.stdout):
+    if not re.search(r"(?<!\d)0 device types created", result2.stdout):
         fail(f"After update, third run shows new device types\n{result2.stdout}")
     ok("Post-update run: 0 device types created")
-    if not re.search(r"0 device types updated", result2.stdout):
+    if not re.search(r"(?<!\d)0 device types updated", result2.stdout):
         fail(f"After update, third run still shows updated device types\n{result2.stdout}")
     ok("Post-update run: 0 device types updated")
 

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -464,13 +464,23 @@ def test_idempotency() -> None:
         fail(f"Importer (2nd run) exited with code {result.returncode}")
 
     out = result.stdout
-    for pattern, label in [
-        (r"New device types:\s+0", "new device types"),
-        (r"Modified device types:\s+0", "modified device types"),
-    ]:
-        if not re.search(pattern, out):
-            fail(f"Second run: expected 0 {label} but report says otherwise.\n{out}")
-        ok(f"0 {label}")
+
+    # When there are no new/modified types, the importer intentionally
+    # suppresses the "CHANGE DETECTION REPORT" banner (avoids flooding
+    # multi-vendor runs with empty reports). A suppressed banner is therefore
+    # itself proof of idempotency; the per-type zero lines only appear when the
+    # banner is shown. Idempotency is verified against the always-printed
+    # end-of-run summary regardless.
+    if "CHANGE DETECTION REPORT" in out:
+        for pattern, label in [
+            (r"New device types:\s+0", "new device types"),
+            (r"Modified device types:\s+0", "modified device types"),
+        ]:
+            if not re.search(pattern, out):
+                fail(f"Second run: expected 0 {label} but report says otherwise.\n{out}")
+            ok(f"0 {label}")
+    else:
+        ok("change-detection banner suppressed (no device-type changes)")
 
     if "MODULE TYPE CHANGE DETECTION" in out:
         for pattern, label in [
@@ -480,6 +490,17 @@ def test_idempotency() -> None:
             if not re.search(pattern, out):
                 fail(f"Second run: expected 0 {label}.\n{out}")
             ok(f"0 {label}")
+    else:
+        ok("module-type change-detection banner suppressed (no module-type changes)")
+
+    # Always-printed end-of-run summary — the authoritative idempotency check.
+    for pattern, label in [
+        (r"0 device types created", "device types created"),
+        (r"0 device types updated", "device types updated"),
+    ]:
+        if not re.search(pattern, out):
+            fail(f"Second run: expected '{pattern}' but report says otherwise.\n{out}")
+        ok(f"0 {label}")
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -518,14 +539,16 @@ def test_update_mode() -> None:
         fail(f"eth0 recreated with wrong type: {by_name['eth0']['type']['value']!r}")
     ok("eth0 recreated with correct type '1000base-t'")
 
-    # Verify idempotent after update too
+    # Verify idempotent after update too. As in Scenario G, a no-change run
+    # suppresses the change-detection banner, so assert against the
+    # always-printed end-of-run summary instead.
     result2 = run_importer()
-    if not re.search(r"New device types:\s+0", result2.stdout):
-        fail("After update, third run shows new device types")
-    ok("Post-update run: 0 new device types")
-    if not re.search(r"Modified device types:\s+0", result2.stdout):
-        fail("After update, third run still shows modified device types")
-    ok("Post-update run: 0 modified device types")
+    if not re.search(r"0 device types created", result2.stdout):
+        fail(f"After update, third run shows new device types\n{result2.stdout}")
+    ok("Post-update run: 0 device types created")
+    if not re.search(r"0 device types updated", result2.stdout):
+        fail(f"After update, third run still shows updated device types\n{result2.stdout}")
+    ok("Post-update run: 0 device types updated")
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ wheels = [
 
 [[package]]
 name = "device-type-library-import"
-version = "1.6.0"
+version = "1.6.1"
 source = { virtual = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Include the project lockfile in release artifacts and update release build command.
  * Add docstring-coverage tooling and a pre-commit hook to run it.

* **Tests**
  * Make idempotency tests more robust to suppressed change-detection banners; rely on an always-present end-of-run summary.

* **Documentation**
  * Clarified docstrings describing export selection behavior, image download expectations, and repository pickle constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->