### PR TITLE
ci: run weekly NetBox-main test with LOGIN_REQUIRED=True

### DIFF
--- a/.github/workflows/test-netbox-main.yaml
+++ b/.github/workflows/test-netbox-main.yaml
@@ -85,7 +85,16 @@ jobs:
               SECRET_KEY = 'test-secret-key-not-for-production-1234567890123456'  # checkov:skip=CKV_SECRET_6
               API_TOKEN_PEPPERS = {0: 'a' * 64}  # checkov:skip=CKV_SECRET_6
               DEBUG = True
-              LOGIN_REQUIRED = False
+              # LOGIN_REQUIRED=True mirrors NetBox's future default (anonymous access is being
+              # removed upstream). It is also required for media to be reachable: NetBox #22400
+              # (June 2026) enforces object-level 'view' permission when serving
+              # /media/devicetype-images/ and /media/image-attachments/ via MediaView, and that
+              # view's TokenConditionalLoginRequiredMixin only authenticates the API token when
+              # LOGIN_REQUIRED is True. With it True, the integration test's Bearer-token session
+              # resolves to the admin superuser, restrict() grants access, and the image is
+              # served (a genuinely missing file still 404s through django.views.static.serve).
+              # NOTE: this also gates the REST API, so the readiness curl below must send the token.
+              LOGIN_REQUIRED = True
           ''').lstrip(), encoding='utf-8')
           "
 
@@ -116,16 +125,19 @@ jobs:
           rm -f /tmp/netbox.log && touch /tmp/netbox.log
           python manage.py runserver 0.0.0.0:8000 >> /tmp/netbox.log 2>&1 &
           echo $! > /tmp/netbox.pid
+          # LOGIN_REQUIRED=True gates the REST API, so the readiness probe must authenticate
+          # with the token created above (exposed as $NETBOX_TOKEN via GITHUB_ENV); an
+          # anonymous curl would 403 and never report ready.
           # Wait up to 60 s for NetBox to respond
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:8000/api/ > /dev/null 2>&1; then
+            if curl -sf -H "Authorization: Bearer $NETBOX_TOKEN" http://localhost:8000/api/ > /dev/null 2>&1; then
               echo "NetBox is ready (attempt $i)"
               break
             fi
             echo "Waiting for NetBox... ($i/30)"
             sleep 2
           done
-          curl -sf http://localhost:8000/api/ > /dev/null || { echo "NetBox did not start"; exit 1; }
+          curl -sf -H "Authorization: Bearer $NETBOX_TOKEN" http://localhost:8000/api/ > /dev/null || { echo "NetBox did not start"; exit 1; }
 
       - name: Install importer dependencies
         working-directory: importer
@@ -161,6 +173,6 @@ jobs:
       - name: Print NetBox version on failure
         if: failure()
         run: |
-          curl -s http://localhost:8000/api/status/ | python3 -m json.tool || true
+          curl -s -H "Authorization: Bearer $NETBOX_TOKEN" http://localhost:8000/api/status/ | python3 -m json.tool || true
           echo "--- NetBox server log ---"
           cat /tmp/netbox.log 2>/dev/null | tail -50 || true


### PR DESCRIPTION
## Problem

The weekly `test-netbox-main` job started failing on `test_first_import`:

```
FAILED tests/integration/test_import.py::test_first_import - Failed:
full-device: front_image URL '.../media/devicetype-images/testvendor-full-device.front.png' returned HTTP 404
```

## Root cause (NetBox-side, not the importer)

The importer is correct — it uploads the image and links it (the device-type API returns the `front_image` URL). The 404 comes from a recent NetBox `main` change:

- **NetBox #22400** ("Enforce object permissions for relevant static media", June 2026) added an object-level `view`-permission check to `MediaView` for `/media/devicetype-images/` and `/media/image-attachments/`.
- `MediaView` uses `TokenConditionalLoginRequiredMixin`, which **only authenticates the API token when `settings.LOGIN_REQUIRED` is `True`**. Our config set `LOGIN_REQUIRED = False`, so the test's `Bearer nbt_…` token was never processed → `request.user` was `AnonymousUser`.
- `DeviceType.objects.restrict(AnonymousUser, 'view')` returns `.none()` → `.exists()` is `False` → `raise Http404`.

`EXEMPT_VIEW_PERMISSIONS=['*']` was considered and rejected: NetBox is removing anonymous access upstream, and with `LOGIN_REQUIRED=True` an anonymous caller is rejected *before* the view's permission check, so exempting view perms can't help.

## Fix

Set **`LOGIN_REQUIRED = True`** in the generated `configuration.py`. This mirrors NetBox's future default and is also what makes media reachable: with it `True`, the media view authenticates the test's token → resolves to the admin **superuser** → `restrict()` superuser-bypass → `serve()` → **HTTP 200**. This also exercises the real production media-auth path rather than relying on anonymous access. A genuinely missing file still 404s via `serve()`, so the file-presence assertion is preserved.

`LOGIN_REQUIRED=True` also gates the REST API, so the readiness probe and the failure-diagnostic `/api/status/` curl now send `Authorization: Bearer $NETBOX_TOKEN`.

## Verification

Dispatched against this branch — all 6 integration tests pass against live NetBox `main`:

```
test_first_import PASSED   test_front_port_multiposition PASSED
test_module_types PASSED   test_graphql_schema PASSED
test_idempotency PASSED    test_update_mode PASSED
6 passed in 22.44s
```

Run: https://github.com/marcinpsk/Device-Type-Library-Import/actions/runs/27636758837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow to support authentication requirements in the testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->