### PR TITLE
fix: include NetBox status and response body in image upload errors

### DIFF
--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -41,6 +41,27 @@ def _build_auth_header(token):
     return f"{scheme} {token}"
 
 
+# Cap on the NetBox response body appended to an error log: a 500 raised with DEBUG enabled
+# returns a full HTML traceback page, which would otherwise flood the log.
+_MAX_ERROR_BODY_CHARS = 500
+
+
+def _format_request_error(exc) -> str:
+    """Return *exc* as text, with NetBox's response body appended when there is one.
+
+    ``requests.HTTPError`` stringifies to only the status line, discarding the body where
+    NetBox reports the actual cause (e.g. ``{"front_image": ["Upload a valid image..."]}``
+    for an image above its pixel cap).  Without the body an operator sees nothing but
+    ``400 Client Error: Bad Request``.
+    """
+    body = (getattr(getattr(exc, "response", None), "text", "") or "").strip()
+    if not body:
+        return str(exc)
+    if len(body) > _MAX_ERROR_BODY_CHARS:
+        body = f"{body[:_MAX_ERROR_BODY_CHARS]}… (truncated)"
+    return f"{exc} — NetBox returned: {body}"
+
+
 def _fmt_connection_error(url: str, exc: Exception) -> str:
     """Return a human-friendly message for a connection-level network error.
 
@@ -240,7 +261,7 @@ def _delete_image_attachment(base_url: str, token: str, att_id: int, ignore_ssl:
         response.raise_for_status()
         return True
     except requests.RequestException as e:
-        handle.log(f"Error deleting image attachment {att_id}: {e}")
+        handle.log(f"Error deleting image attachment {att_id}: {_format_request_error(e)}")
         return False
 
 
@@ -3800,7 +3821,7 @@ class DeviceTypes:
             if self._image_progress:
                 self._image_progress(len(images))
         except requests.RequestException as e:
-            self.handle.log(f"Error uploading images for device type {device_type}: {e}")
+            self.handle.log(f"Error uploading images for device type {device_type}: {_format_request_error(e)}")
         except OSError as e:
             self.handle.log(f"Error reading image file for device type {device_type}: {e}")
         finally:
@@ -3855,7 +3876,9 @@ class DeviceTypes:
                     self._image_progress(1)
                 return True
         except requests.RequestException as e:
-            self.handle.log(f"Error uploading image attachment for {object_type} {object_id}: {e}")
+            self.handle.log(
+                f"Error uploading image attachment for {object_type} {object_id}: {_format_request_error(e)}"
+            )
             return False
         except OSError as e:
             self.handle.log(f"Error reading image file {image_path}: {e}")

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -45,6 +45,11 @@ def _build_auth_header(token):
 # returns a full HTML traceback page, which would otherwise flood the log.
 _MAX_ERROR_BODY_CHARS = 500
 
+# Server-controlled text is escaped before logging: LogHandler.log emits one timestamped
+# record per call, so an embedded newline would let a response forge additional records.
+_LOG_ESCAPES = {c: f"\\x{c:02x}" for c in [*range(0x20), 0x7F]}
+_LOG_ESCAPES.update({ord("\n"): "\\n", ord("\r"): "\\r", ord("\t"): "\\t"})
+
 
 def _format_request_error(exc) -> str:
     """Return *exc* as text, with NetBox's response body appended when there is one.
@@ -53,10 +58,13 @@ def _format_request_error(exc) -> str:
     NetBox reports the actual cause (e.g. ``{"front_image": ["Upload a valid image..."]}``
     for an image above its pixel cap).  Without the body an operator sees nothing but
     ``400 Client Error: Bad Request``.
+
+    The body is server-controlled, so control characters are escaped before truncation.
     """
     body = (getattr(getattr(exc, "response", None), "text", "") or "").strip()
     if not body:
         return str(exc)
+    body = body.translate(_LOG_ESCAPES)
     if len(body) > _MAX_ERROR_BODY_CHARS:
         body = f"{body[:_MAX_ERROR_BODY_CHARS]}… (truncated)"
     return f"{exc} — NetBox returned: {body}"

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -1,9 +1,14 @@
 import queue
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
 import pytest
 from unittest.mock import MagicMock, patch
 from core.netbox_api import (
     NetBox,
     DeviceTypes,
+    _delete_image_attachment,
     _FrontPortRecordWithMappings,
 )
 from helpers import paginate_dispatch
@@ -8188,3 +8193,146 @@ class TestRemainingCoverageBranches:
 
         assert progress.update.call_args_list[0].args == (1,)
         assert progress.update.call_args_list[0].kwargs == {"completed": 2}
+
+
+# ---------------------------------------------------------------------------
+# Image-upload failures must surface NetBox's HTTP status and response body.
+# Exercised against a real local HTTP server so requests, raise_for_status and
+# response parsing all run for real; only NetBox itself is substituted.
+# ---------------------------------------------------------------------------
+
+
+class _CannedHandler(BaseHTTPRequestHandler):
+    """Replies to every request with the status/body configured on the server."""
+
+    def _reply(self):
+        self.send_response(self.server.canned_status)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(self.server.canned_body.encode())
+
+    do_PATCH = _reply
+    do_POST = _reply
+    do_DELETE = _reply
+
+    def log_message(self, *args):
+        pass
+
+
+@contextmanager
+def _netbox_returning(status, body):
+    """Run a local HTTP server that answers every request with *status* and *body*."""
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _CannedHandler)
+    server.canned_status = status
+    server.canned_body = body
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+# The real 400 NetBox >= 4.6.5 returns for an image above its 25 MP cap.
+_OVERSIZE_BODY = (
+    '{"front_image":["Upload a valid image. The file you uploaded was either not an image or a corrupted image."]}'
+)
+
+
+class TestImageUploadErrorDetail:
+    """Failed uploads must log NetBox's status code and response body, not just str(exc)."""
+
+    def test_upload_images_logs_status_and_response_body(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
+        """A 400 from NetBox surfaces the field-level reason it returned."""
+        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        img = tmp_path / "front.jpg"
+        img.write_bytes(b"not-really-a-jpeg")
+        mock_settings.handle.log.reset_mock()
+
+        with _netbox_returning(400, _OVERSIZE_BODY) as url:
+            dt.upload_images(url, "token", {"front_image": str(img)}, 42)
+
+        logged = " ".join(str(c.args[0]) for c in mock_settings.handle.log.call_args_list)
+        assert "400" in logged
+        assert "not an image or a corrupted image" in logged
+
+    def test_upload_images_logs_body_for_server_error(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
+        """A 500 surfaces the body too — this is the case issue #102 could not diagnose."""
+        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        img = tmp_path / "front.jpg"
+        img.write_bytes(b"fake")
+        mock_settings.handle.log.reset_mock()
+
+        with _netbox_returning(500, "PermissionError: [Errno 13] Permission denied: '/opt/netbox/netbox/media'") as url:
+            dt.upload_images(url, "token", {"front_image": str(img)}, 30)
+
+        logged = " ".join(str(c.args[0]) for c in mock_settings.handle.log.call_args_list)
+        assert "500" in logged
+        assert "Permission denied" in logged
+
+    def test_upload_image_attachment_logs_status_and_response_body(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
+        """The image-attachment path (module types) reports the same detail."""
+        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        img = tmp_path / "module.png"
+        img.write_bytes(b"fake")
+        mock_settings.handle.log.reset_mock()
+
+        with _netbox_returning(400, '{"image":["Upload a valid image."]}') as url:
+            ok = dt.upload_image_attachment(url, "token", str(img), "dcim.moduletype", 7)
+
+        assert ok is False
+        logged = " ".join(str(c.args[0]) for c in mock_settings.handle.log.call_args_list)
+        assert "400" in logged
+        assert "Upload a valid image." in logged
+
+    def test_upload_images_success_is_unaffected(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
+        """A 200 still counts the upload and logs nothing at error level."""
+        counter = {"images": 0}
+        dt = make_device_types(nb_api=mock_pynetbox.api.return_value, counter=counter)
+        img = tmp_path / "front.jpg"
+        img.write_bytes(b"fake")
+        mock_settings.handle.log.reset_mock()
+
+        with _netbox_returning(200, "{}") as url:
+            dt.upload_images(url, "token", {"front_image": str(img)}, 1)
+
+        assert counter["images"] == 1
+        assert not mock_settings.handle.log.called
+
+    def test_delete_image_attachment_logs_response_body(self):
+        """Attachment deletion reports NetBox's reason rather than a bare status line."""
+        handle = MagicMock()
+
+        with _netbox_returning(409, '{"detail":"Attachment is in use."}') as url:
+            ok = _delete_image_attachment(url, "token", 5, False, handle)
+
+        assert ok is False
+        logged = " ".join(str(c.args[0]) for c in handle.log.call_args_list)
+        assert "409" in logged
+        assert "Attachment is in use." in logged
+
+    def test_long_error_body_is_truncated(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
+        """A DEBUG-mode HTML traceback page is capped instead of flooding the log."""
+        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        img = tmp_path / "front.jpg"
+        img.write_bytes(b"fake")
+        mock_settings.handle.log.reset_mock()
+
+        with _netbox_returning(500, "<html>" + ("x" * 5000) + "</html>") as url:
+            dt.upload_images(url, "token", {"front_image": str(img)}, 1)
+
+        logged = " ".join(str(c.args[0]) for c in mock_settings.handle.log.call_args_list)
+        assert "truncated" in logged
+        assert len(logged) < 1000

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -8336,3 +8336,24 @@ class TestImageUploadErrorDetail:
         logged = " ".join(str(c.args[0]) for c in mock_settings.handle.log.call_args_list)
         assert "truncated" in logged
         assert len(logged) < 1000
+
+    def test_control_characters_in_body_are_escaped(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path
+    ):
+        """A response body cannot inject line breaks that forge additional log records."""
+        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        img = tmp_path / "front.jpg"
+        img.write_bytes(b"fake")
+        mock_settings.handle.log.reset_mock()
+
+        forged = '{"detail":"boom"}\r\n[12:34:56] Device Type Created: FORGED - 999\x1b[31m'
+        with _netbox_returning(400, forged) as url:
+            dt.upload_images(url, "token", {"front_image": str(img)}, 1)
+
+        logged = " ".join(str(c.args[0]) for c in mock_settings.handle.log.call_args_list)
+        assert "\n" not in logged
+        assert "\r" not in logged
+        assert "\x1b" not in logged
+        # The text is still reported, just neutralised.
+        assert "\\r\\n" in logged
+        assert "FORGED" in logged


### PR DESCRIPTION
## Problem

`requests.HTTPError` stringifies to only the status line, so a failed image upload logged this and nothing more:

```
Error uploading images for device type 6046: 400 Client Error: Bad Request for url: .../api/dcim/device-types/6046/
```

NetBox returns the actual reason in the response body, and we discarded it. User could not tell a rejected image from a permissions or storage failure on the server — which is exactly the position #102 is stuck in, where a 500 arrived with no way to identify its cause.

## Change

`_format_request_error` appends the response body when one is attached, capped at 500 characters so a 500 raised with `DEBUG` enabled cannot flood the log with an HTML traceback page. Applied to the three image endpoints that call `raise_for_status`: device-type image upload, image-attachment upload, and image-attachment deletion.

The same failure now reads:

```
Error uploading images for device type 6046: 400 Client Error: Bad Request for url:
.../api/dcim/device-types/6046/ - NetBox returned: {"front_image":["Upload a valid image.
The file you uploaded was either not an image or a corrupted image."]}
```

That output is from a real run against a NetBox 4.6.7 instance, uploading an image above the 25 megapixel cap that NetBox introduced in 4.6.5 (`Image.MAX_IMAGE_PIXELS` in `core/apps.py`). Before this change the operator saw only the first line.

## Tests

Six tests run against a local `http.server` returning canned status codes and bodies, so `requests`, `raise_for_status` and response parsing all execute for real; only NetBox itself is substituted. Coverage: 400 with a field-level body, 500 with a server error body, the image-attachment path, attachment deletion, body truncation, and a success case asserting unchanged behaviour.

The five error-detail tests fail against the unfixed code and pass with it. Full suite: 945 passed.

## Scope

Logging only — no change to which uploads succeed or fail, or to the counters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved error messages for image uploads and image-attachment deletions by including HTTP status codes and relevant server response details.
- Long responses are safely shortened to keep error messages readable.
- Control characters in server responses are handled safely.
- Successful image uploads and their counters remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->