### PR TITLE
fix: document Docker usage and make a mounted repo volume work

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
       interval: "weekly"
       day: "monday"
     commit-message:
-      prefix: "chore(ci)"
+      prefix: "chore"
+      include: "scope"
     groups:
       github-actions:
         patterns:
@@ -19,7 +20,8 @@ updates:
       interval: "weekly"
       day: "tuesday"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore"
+      include: "scope"
     groups:
       python-deps:
         patterns:
@@ -31,7 +33,8 @@ updates:
       interval: "weekly"
       day: "wednesday"
     commit-message:
-      prefix: "chore(docker)"
+      prefix: "chore"
+      include: "scope"
     groups:
       docker-deps:
         patterns:

--- a/.github/scripts/docker-smoke-test.sh
+++ b/.github/scripts/docker-smoke-test.sh
@@ -10,47 +10,70 @@ fail() {
     exit 1
 }
 
+# Sets $out and $status. Piping straight into grep would test only grep, so the exit
+# status of the container has to be captured separately.
+run_image() {
+    out=$(docker run --rm "$@" 2>&1) && status=0 || status=$?
+}
+
+# Assert $out holds $1, quoting the whole output when it does not.
+expect_output() {
+    case "$out" in
+    *"$1"*) ;;
+    *) shift && fail "$*: $out" ;;
+    esac
+}
+
 # Flags reach the importer's argument parser.
-docker run --rm "$IMAGE" --help | grep -q "usage: nb-dt-import.py" || fail "--help did not reach the importer"
+run_image "$IMAGE" --help
+[ "$status" -eq 0 ] || fail "--help exited $status: $out"
+expect_output "usage: nb-dt-import.py" "--help did not reach the importer"
 
 # Unknown flags are rejected by argparse rather than swallowed by the entrypoint.
-docker run --rm "$IMAGE" --not-a-real-flag 2>&1 | grep -q "unrecognized arguments" ||
-    fail "unknown flags did not reach the importer"
+run_image "$IMAGE" --not-a-real-flag
+[ "$status" -eq 2 ] || fail "an unknown flag exited $status, expected argparse's 2: $out"
+expect_output "unrecognized arguments" "unknown flags did not reach the importer"
 
-# No arguments still starts the importer. These are the ways a broken ENTRYPOINT shows up:
-# a missing file, a lost executable bit, or a wrong interpreter.
-no_args_output=$(docker run --rm "$IMAGE" 2>&1 || true)
-case "$no_args_output" in
-*"executable file not found"* | *"exec format error"* | *"permission denied"* | *"no such file or directory"*)
-    fail "no-argument run did not start the importer: $no_args_output"
-    ;;
-esac
+# No arguments still starts the importer. Assert its own missing-variable error, because
+# an entrypoint that silently does nothing also produces no Docker error.
+run_image "$IMAGE"
+[ "$status" -eq 1 ] || fail "the no-argument run exited $status, expected the importer's 1: $out"
+expect_output 'Environment variable "REPO_URL" is not set.' "the no-argument run did not start the importer"
 
 # The pre-entrypoint invocation stays supported for anyone who worked it out from the
 # Dockerfile before the image was documented.
 for legacy in "python -u nb-dt-import.py" "python nb-dt-import.py" "python3 -u nb-dt-import.py"; do
     # shellcheck disable=SC2086  # deliberate word splitting: $legacy is a command prefix
-    docker run --rm "$IMAGE" $legacy --help | grep -q "usage: nb-dt-import.py" ||
-        fail "legacy invocation '$legacy' no longer works"
+    run_image "$IMAGE" $legacy --help
+    [ "$status" -eq 0 ] || fail "legacy invocation '$legacy' exited $status: $out"
+    expect_output "usage: nb-dt-import.py" "legacy invocation '$legacy' no longer works"
 done
 
 # Arguments that are not flags run as commands, which keeps the image debuggable.
-[ "$(docker run --rm "$IMAGE" sh -c 'echo passthrough-ok')" = "passthrough-ok" ] ||
-    fail "command passthrough is broken"
-[ "$(docker run --rm "$IMAGE" python -c 'print("python-ok")')" = "python-ok" ] ||
-    fail "python command passthrough is broken"
+run_image "$IMAGE" sh -c 'echo passthrough-ok'
+[ "$status" -eq 0 ] && [ "$out" = "passthrough-ok" ] || fail "command passthrough is broken: $out"
+run_image "$IMAGE" python -c 'print("python-ok")'
+[ "$status" -eq 0 ] && [ "$out" = "python-ok" ] || fail "python command passthrough is broken: $out"
 
 # A fresh named volume inherits the image directory's ownership. Root there is what stopped
 # the importer cloning, so assert against a real mount rather than the image filesystem.
-volume="nb-dt-import-smoke-$$"
-docker volume create "$volume" >/dev/null
-trap 'docker volume rm -f "$volume" >/dev/null 2>&1 || true' EXIT
+# The daemon generates the name, so a stale volume is never adopted and then deleted.
+volume=$(docker volume create)
+cleanup() { docker volume rm -f "$volume" >/dev/null 2>&1 || true; }
+# EXIT alone leaks the volume when CI cancels the job, which sends TERM rather than exiting.
+trap cleanup EXIT
+trap 'trap - EXIT; cleanup; exit 130' INT
+trap 'trap - EXIT; cleanup; exit 129' HUP
+trap 'trap - EXIT; cleanup; exit 143' TERM
 mount="type=volume,source=$volume,target=/app/repo"
 
-[ "$(docker run --rm --mount "$mount" "$IMAGE" stat -c '%U' /app/repo)" = "appuser" ] ||
-    fail "a volume mounted at /app/repo is not owned by appuser"
-[ "$(docker run --rm --mount "$mount" "$IMAGE" sh -c 'touch /app/repo/.smoke && echo writable')" = "writable" ] ||
-    fail "appuser cannot write into a volume mounted at /app/repo"
-[ "$(docker run --rm "$IMAGE" id -un)" = "appuser" ] || fail "the container does not run as appuser"
+run_image --mount "$mount" "$IMAGE" stat -c '%U' /app/repo
+[ "$status" -eq 0 ] && [ "$out" = "appuser" ] ||
+    fail "a volume mounted at /app/repo is not owned by appuser: $out"
+run_image --mount "$mount" "$IMAGE" sh -c 'touch /app/repo/.smoke && echo writable'
+[ "$status" -eq 0 ] && [ "$out" = "writable" ] ||
+    fail "appuser cannot write into a volume mounted at /app/repo: $out"
+run_image "$IMAGE" id -un
+[ "$status" -eq 0 ] && [ "$out" = "appuser" ] || fail "the container does not run as appuser: $out"
 
 echo "smoke test passed"

--- a/.github/scripts/docker-smoke-test.sh
+++ b/.github/scripts/docker-smoke-test.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Check that a built image actually runs. CI builds the image on every push; without
+# this, a broken entrypoint or a root-owned /app/repo only shows up for users.
+set -eu
+
+IMAGE="${1:?usage: docker-smoke-test.sh <image>}"
+
+fail() {
+    echo "smoke test failed: $*" >&2
+    exit 1
+}
+
+# Flags reach the importer's argument parser.
+docker run --rm "$IMAGE" --help | grep -q "usage: nb-dt-import.py" || fail "--help did not reach the importer"
+
+# Unknown flags are rejected by argparse rather than swallowed by the entrypoint.
+docker run --rm "$IMAGE" --not-a-real-flag 2>&1 | grep -q "unrecognized arguments" ||
+    fail "unknown flags did not reach the importer"
+
+# No arguments still starts the importer. These are the ways a broken ENTRYPOINT shows up:
+# a missing file, a lost executable bit, or a wrong interpreter.
+no_args_output=$(docker run --rm "$IMAGE" 2>&1 || true)
+case "$no_args_output" in
+*"executable file not found"* | *"exec format error"* | *"permission denied"* | *"no such file or directory"*)
+    fail "no-argument run did not start the importer: $no_args_output"
+    ;;
+esac
+
+# The pre-entrypoint invocation stays supported for anyone who worked it out from the
+# Dockerfile before the image was documented.
+for legacy in "python -u nb-dt-import.py" "python nb-dt-import.py" "python3 -u nb-dt-import.py"; do
+    # shellcheck disable=SC2086  # deliberate word splitting: $legacy is a command prefix
+    docker run --rm "$IMAGE" $legacy --help | grep -q "usage: nb-dt-import.py" ||
+        fail "legacy invocation '$legacy' no longer works"
+done
+
+# Arguments that are not flags run as commands, which keeps the image debuggable.
+[ "$(docker run --rm "$IMAGE" sh -c 'echo passthrough-ok')" = "passthrough-ok" ] ||
+    fail "command passthrough is broken"
+[ "$(docker run --rm "$IMAGE" python -c 'print("python-ok")')" = "python-ok" ] ||
+    fail "python command passthrough is broken"
+
+# A volume mounted at /app/repo inherits this ownership; root here means the importer
+# cannot clone into it.
+[ "$(docker run --rm "$IMAGE" stat -c '%U' /app/repo)" = "appuser" ] || fail "/app/repo is not owned by appuser"
+[ "$(docker run --rm "$IMAGE" id -un)" = "appuser" ] || fail "the container does not run as appuser"
+
+echo "smoke test passed"

--- a/.github/scripts/docker-smoke-test.sh
+++ b/.github/scripts/docker-smoke-test.sh
@@ -40,9 +40,17 @@ done
 [ "$(docker run --rm "$IMAGE" python -c 'print("python-ok")')" = "python-ok" ] ||
     fail "python command passthrough is broken"
 
-# A volume mounted at /app/repo inherits this ownership; root here means the importer
-# cannot clone into it.
-[ "$(docker run --rm "$IMAGE" stat -c '%U' /app/repo)" = "appuser" ] || fail "/app/repo is not owned by appuser"
+# A fresh named volume inherits the image directory's ownership. Root there is what stopped
+# the importer cloning, so assert against a real mount rather than the image filesystem.
+volume="nb-dt-import-smoke-$$"
+docker volume create "$volume" >/dev/null
+trap 'docker volume rm -f "$volume" >/dev/null 2>&1 || true' EXIT
+mount="type=volume,source=$volume,target=/app/repo"
+
+[ "$(docker run --rm --mount "$mount" "$IMAGE" stat -c '%U' /app/repo)" = "appuser" ] ||
+    fail "a volume mounted at /app/repo is not owned by appuser"
+[ "$(docker run --rm --mount "$mount" "$IMAGE" sh -c 'touch /app/repo/.smoke && echo writable')" = "writable" ] ||
+    fail "appuser cannot write into a volume mounted at /app/repo"
 [ "$(docker run --rm "$IMAGE" id -un)" = "appuser" ] || fail "the container does not run as appuser"
 
 echo "smoke test passed"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      -
+        name: Build amd64 image for testing
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          load: true
+          tags: nb-dt-import:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      -
+        name: Check the image runs
+        run: ./.github/scripts/docker-smoke-test.sh nb-dt-import:smoke
+
   build-and-push-images:
+    needs: smoke-test
     runs-on: ubuntu-latest
     steps:
       -

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,40 @@
+---
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-commits:
+    name: Conventional Commits PR title
+    runs-on: ubuntu-latest
+    steps:
+      # A squash merge takes the PR title as the commit subject when the branch holds more
+      # than one commit, and semantic-release skips the release when that subject does not
+      # parse as a Conventional Commit.
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Keep in sync with allowed_tags in pyproject.toml ([tool.semantic_release.commit_parser_options]).
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ COPY *.py ./
 
 COPY core/ core/
 
+# Pre-create the library clone target so a volume mounted there inherits appuser ownership
+RUN mkdir -p /app/repo
+
 RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,13 @@ COPY *.py ./
 
 COPY core/ core/
 
+COPY docker-entrypoint.sh /usr/local/bin/
+
 # repo/ is pre-created so a volume mounted there inherits appuser ownership instead of root
 RUN mkdir -p /app/repo && useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
-# Set the command
-# venv is already on PATH, no need for `uv run` overhead
-# -u for unbuffered stdout/stderr (important for Docker logging)
-CMD ["python", "-u", "nb-dt-import.py"]
+# The entrypoint sends flags to the importer and runs anything else as a command.
+# venv is already on PATH, no need for `uv run` overhead.
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,8 @@ COPY *.py ./
 
 COPY core/ core/
 
-# Pre-create the library clone target so a volume mounted there inherits appuser ownership
-RUN mkdir -p /app/repo
-
-RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+# repo/ is pre-created so a volume mounted there inherits appuser ownership instead of root
+RUN mkdir -p /app/repo && useradd -m -u 1000 appuser && chown -R appuser:appuser /app
 USER appuser
 
 # Set the command

--- a/README.md
+++ b/README.md
@@ -442,6 +442,10 @@ repo into NetBox, it writes out the device, module, and rack types that NetBox h
 local repo does not, or that differ from it, as DTL-compatible YAML plus images. It does not
 run the import pipeline at all, so nothing in NetBox is modified.
 
+The comparison needs the local library, and export mode neither clones nor updates it: only an
+import does that. Point `REPO_PATH` at a checkout, or run an import first. An export over a
+missing library stops with an error instead of reporting every type in NetBox as absent from it.
+
 ```shell
 uv run nb-dt-import.py --export-diff
 uv run nb-dt-import.py --export-diff --vendors nokia --export-diff-dir extra/
@@ -458,7 +462,9 @@ directory to keep the output, creating it first and matching the ownership to wh
 ```shell
 mkdir -p extra
 sudo chown 1000:1000 extra   # not needed if your host account is already UID 1000
-docker run --rm --env-file .env -v "$PWD/extra:/app/extra" \
+docker run --rm --env-file .env \
+  -v dtl-library:/app/repo \
+  -v "$PWD/extra:/app/extra" \
   ghcr.io/marcinpsk/device-type-library-import:latest --export-diff
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,8 +143,15 @@ The container needs network access to `NETBOX_URL`:
 - **NetBox on another host**: nothing to do, the default bridge network can reach it.
 - **NetBox in Docker on the same host**: attach the container to the same Docker network
   (`--network netbox_default`) and use the NetBox service name in `NETBOX_URL`.
-- **NetBox on the host itself**: use `--network host`, or point `NETBOX_URL` at
-  `http://host.docker.internal:8000` and add `--add-host host.docker.internal:host-gateway`.
+- **NetBox on the host itself**: `--network host` is the simplest option on Linux. It also
+  works when NetBox listens only on `127.0.0.1`.
+
+  `host.docker.internal` works too, but needs care on Linux. Docker Desktop on macOS and
+  Windows provides the name automatically; on Linux it does not exist unless you add
+  `--add-host host.docker.internal:host-gateway`, and it then resolves to the bridge gateway
+  address, not to loopback. NetBox must therefore listen on an address the bridge can reach.
+  A server bound only to `127.0.0.1`, including a Compose port published as
+  `127.0.0.1:8000:8000`, refuses the connection.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,167 @@
 [![NetBox main](https://github.com/marcinpsk/Device-Type-Library-Import/actions/workflows/test-netbox-main.yaml/badge.svg)](https://github.com/marcinpsk/Device-Type-Library-Import/actions/workflows/test-netbox-main.yaml)
 [![NetBox](https://img.shields.io/badge/NetBox-3.2%2B_through_4.5%2B-blue)](https://netbox.dev)
 [![Python](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org)
+[![Container image](https://img.shields.io/badge/ghcr.io-device--type--library--import-2496ED?logo=docker&logoColor=white)](https://github.com/marcinpsk/Device-Type-Library-Import/pkgs/container/device-type-library-import)
 
 This library is intended to be your friend and help you import all the device-types defined within
 the [NetBox Device Type Library Repository](https://github.com/netbox-community/devicetype-library).
 
 > **Tested working with NetBox 3.2+ through 4.5+** (weekly CI run against NetBox `main`)
 
----
+## Description
+
+This script will clone a copy of the `netbox-community/devicetype-library` repository to your
+machine to allow it to import the device types you would like without copy and pasting them
+into the NetBox UI.
+
+## How to run it
+
+There are two ways to run this tool. Both use the same code and accept the same
+[environment variables](#environment-variables) and [arguments](#arguments).
+
+| Option | Use it when | Start here |
+| --- | --- | --- |
+| 🐳 **Docker image** — `ghcr.io/marcinpsk/device-type-library-import` | You want a one-off or scheduled import with no local Python setup | [Run with Docker](#run-with-docker) |
+| 📦 **Git clone** — `uv sync` | You are developing, contributing, or want to run from source | [Run from a clone](#run-from-a-clone) |
+
+> ℹ️ **There is no PyPI package.** This tool is not published to PyPI, so `pip install nb-dt-import`
+> (or any similar name) will not get you this project. Use the container image or clone the
+> repository.
+
+### Contents
+
+- [Run with Docker](#run-with-docker)
+- [Run from a clone](#run-from-a-clone)
+- [Environment variables](#environment-variables)
+- [Arguments](#arguments)
+- [Update mode](#update-mode)
+- [Component removal](#component-removal-use-with-caution)
+- [Conflict resolution](#conflict-resolution-use-with-caution)
+- [Image verification](#image-verification---verify-images)
+
+## Run with Docker
+
+Images are published to the GitHub Container Registry for `linux/amd64` and `linux/arm64`:
+
+```shell
+docker pull ghcr.io/marcinpsk/device-type-library-import:latest
+```
+
+The image is public; no `docker login` is needed to pull it.
+
+### Tags
+
+| Tag | Points at |
+| --- | --- |
+| `latest` | Newest build of the `main` branch |
+| `main` | Same as `latest` |
+| `1.7.1` | An exact release |
+| `1.7` | Newest patch release in the `1.7` series |
+| `1` | Newest release in the `1.x` series |
+
+Pin a version tag for scheduled or automated runs so an upstream change cannot alter the
+behavior of a job that already works.
+
+### Quick start
+
+Write your NetBox URL and API token (the token needs **write rights**) into a `.env` file:
+
+```shell
+NETBOX_URL=https://netbox.example.org
+NETBOX_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+See [Environment variables](#environment-variables) for everything else you can set, or copy
+[`.env.example`](.env.example) from this repository as a starting point.
+
+Then run the import:
+
+```shell
+docker run --rm --env-file .env ghcr.io/marcinpsk/device-type-library-import:latest
+```
+
+Without a volume the device-type library is cloned into the container and thrown away when the
+container exits. Mount a volume at `/app/repo` to keep the clone between runs, so later runs
+only fetch new commits:
+
+```shell
+docker run --rm --env-file .env \
+  -v dtl-library:/app/repo \
+  ghcr.io/marcinpsk/device-type-library-import:latest
+```
+
+A host directory works too, but it must be readable and writable by UID 1000 (the `appuser`
+account the container runs as):
+
+```shell
+docker run --rm --env-file .env \
+  -v "$PWD/repo:/app/repo" \
+  ghcr.io/marcinpsk/device-type-library-import:latest
+```
+
+### Passing arguments
+
+The default command is `python -u nb-dt-import.py`. The image sets no entrypoint, so repeat the
+full command to add [arguments](#arguments):
+
+```shell
+docker run --rm --env-file .env ghcr.io/marcinpsk/device-type-library-import:latest \
+  python -u nb-dt-import.py --vendors apc,juniper --update
+```
+
+Alternatively, set `VENDORS` (comma-separated) and `SLUGS` (space-separated) in your environment
+file and keep the default command.
+
+### Docker Compose
+
+```yaml
+services:
+  nb-dt-import:
+    image: ghcr.io/marcinpsk/device-type-library-import:latest
+    env_file: .env
+    volumes:
+      - dtl-library:/app/repo
+    command: ["python", "-u", "nb-dt-import.py", "--update"]
+
+volumes:
+  dtl-library:
+```
+
+Run it as a one-off job:
+
+```shell
+docker compose run --rm nb-dt-import
+```
+
+### Reaching your NetBox instance
+
+The container needs network access to `NETBOX_URL`:
+
+- **NetBox on another host**: nothing to do, the default bridge network can reach it.
+- **NetBox in Docker on the same host**: attach the container to the same Docker network
+  (`--network netbox_default`) and use the NetBox service name in `NETBOX_URL`.
+- **NetBox on the host itself**: use `--network host`, or point `NETBOX_URL` at
+  `http://host.docker.internal:8000` and add `--add-host host.docker.internal:host-gateway`.
+
+### Notes
+
+- `--env-file` is parsed by Docker, not by `python-dotenv`. Quotes are **not** stripped, so write
+  `NETBOX_TOKEN=abc123` and not `NETBOX_TOKEN="abc123"`.
+- Private or self-signed NetBox certificates: mount your CA bundle into the container and set
+  `REQUESTS_CA_BUNDLE` to its path, for example
+  `-v /etc/ssl/certs/my-ca.pem:/ca.pem:ro -e REQUESTS_CA_BUNDLE=/ca.pem`.
+- [`--verify-images`](#image-verification---verify-images) keeps a hash cache in
+  `/home/appuser/.cache/nb-dt-import`. Mount a volume there if you want the cache to survive
+  between runs.
+
+### Building the image yourself
+
+```shell
+docker build -t nb-dt-import .
+docker run --rm --env-file .env nb-dt-import
+```
+
+## Run from a clone
 
 > ⚠️ **direnv users** — This repo ships a `.envrc.example` file.  If you use
 > [direnv](https://direnv.net/), **review the file before enabling it**:
@@ -23,14 +177,6 @@ the [NetBox Device Type Library Repository](https://github.com/netbox-community/
 >
 > The file exclusively loads variables from `.env` into your shell and runs
 > `uv sync` to keep dependencies up to date.  Your `.envrc` is git-ignored.
-
-## Description
-
-This script will clone a copy of the `netbox-community/devicetype-library` repository to your
-machine to allow it to import the device types you would like without copy and pasting them
-into the NetBox UI.
-
-## Getting Started
 
 1. Install dependencies with `uv`:
 
@@ -67,6 +213,8 @@ and device, creating anything that is missing from NetBox while skipping entries
 | `REPO_URL` | | community library | Git URL of the device-type library to clone |
 | `REPO_BRANCH` | | `master` | Branch to check out |
 | `REPO_PATH` | | `./repo` | Local path where the library is cloned. Accepts absolute or relative paths. |
+| `VENDORS` | | all | Comma-separated vendors to import (same effect as `--vendors`) |
+| `SLUGS` | | all | Space-separated device-type slug substrings (same effect as `--slugs`) |
 | `IGNORE_SSL_ERRORS` | | `False` | Set `True` to skip TLS verification (dev only) |
 | `GRAPHQL_PAGE_SIZE` | | `5000` | Items per GraphQL page |
 | `PRELOAD_THREADS` | | `8` | Threads for concurrent component preloading |

--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ behavior of a job that already works.
 None of these tags is immutable: the image workflow also runs when a release is edited, which
 rebuilds and re-pushes the same version tag. Pin the digest when a run must never change:
 
+Read the digest from the tag you want, then run that digest. Substitute the `Digest:` value from
+the first command into the second:
+
 ```shell
 docker buildx imagetools inspect ghcr.io/marcinpsk/device-type-library-import:1.7.1
 docker run --rm --env-file .env \
-  ghcr.io/marcinpsk/device-type-library-import@sha256:b27ee7c0…
+  ghcr.io/marcinpsk/device-type-library-import@sha256:<digest>
 ```
 
 ### Quick start
@@ -103,20 +106,30 @@ docker run --rm --env-file .env \
   ghcr.io/marcinpsk/device-type-library-import:latest
 ```
 
-A host directory works too, but create it yourself first and give UID 1000 (`appuser`, the user
-the container runs as) write access. Docker creates a missing bind-mount source as `root`, and
-`mkdir` on a host account that is not UID 1000 has the same effect:
+A host directory works too, but create it yourself first: Docker creates a missing bind-mount
+source as `root`, which the container cannot write to. The directory owner and the user the
+container runs as must then agree. Pick one of the two modes below, and do not combine them:
+each one breaks the other.
+
+Container-user mode, where the clone ends up owned by UID 1000 (`appuser`, the image default):
 
 ```shell
 mkdir -p repo
-sudo chown 1000:1000 repo   # skip if your host account is already UID 1000
+sudo chown 1000:1000 repo   # not needed if your host account is already UID 1000
 docker run --rm --env-file .env \
   -v "$PWD/repo:/app/repo" \
   ghcr.io/marcinpsk/device-type-library-import:latest
 ```
 
-To keep the files owned by your host account instead, run the container as your own user with
-`--user "$(id -u):$(id -g)"`.
+Host-user mode, where the clone stays owned by your own account. Leave the directory as `mkdir`
+created it and run the container as yourself:
+
+```shell
+mkdir -p repo
+docker run --rm --env-file .env --user "$(id -u):$(id -g)" \
+  -v "$PWD/repo:/app/repo" \
+  ghcr.io/marcinpsk/device-type-library-import:latest
+```
 
 ### Passing arguments
 
@@ -439,11 +452,12 @@ Files that already exist and differ are skipped with a warning. Add
 
 The export directory is relative to the working directory, which is `/app` in the container.
 A `docker run --rm` therefore writes to `/app/extra` and discards it on exit. Mount a host
-directory to keep the output, creating it first for the same reason as the library volume:
+directory to keep the output, creating it first and matching the ownership to whichever
+[mode](#run-with-docker) you use for the library volume. Container-user mode:
 
 ```shell
 mkdir -p extra
-sudo chown 1000:1000 extra   # skip if your host account is already UID 1000
+sudo chown 1000:1000 extra   # not needed if your host account is already UID 1000
 docker run --rm --env-file .env -v "$PWD/extra:/app/extra" \
   ghcr.io/marcinpsk/device-type-library-import:latest --export-diff
 ```

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ There are two ways to run this tool. Both use the same code and accept the same
 - [Component removal](#component-removal-use-with-caution)
 - [Conflict resolution](#conflict-resolution-use-with-caution)
 - [Image verification](#image-verification---verify-images)
+- [Export mode](#export-mode)
 
 ## Run with Docker
 
@@ -277,6 +278,9 @@ uv run nb-dt-import.py --vendors "Palo Alto" --slugs 440
 | `--remove-unmanaged-types` | off | Also delete components whose entire YAML section is missing (e.g. NetBox has interfaces but YAML defines none). Requires `--remove-components`. **Aggressive.** |
 | `--force-resolve-conflicts` | off | Automatically resolve NetBox constraint failures during `--update`. **Destructive.** See below. |
 | `--verify-images` | off | Verify images recorded in NetBox are physically present on the server. Uses an HTTP presence check per image and a local SHA-256 cache to detect local file changes (does not hash the remote file). Re-uploads any image that is missing on the server or whose local file has changed. Useful after recreating a devcontainer or updating local image files. **Makes one HTTP request per image.** |
+| `--export-diff` | off | Export device, module, and rack types that NetBox holds but the local repo does not, or that differ, as DTL-compatible YAML plus images. Does **not** run the import pipeline. See [Export mode](#export-mode). |
+| `--export-diff-dir` | `extra/` | Directory the export writes to. Only meaningful with `--export-diff`. |
+| `--force-export-overwrite` | off | Overwrite files in the export directory that differ from what would be generated from NetBox. Without it, changed files are skipped with a warning. Only meaningful with `--export-diff`. |
 
 #### Update Mode
 
@@ -387,6 +391,26 @@ uv run nb-dt-import.py --vendors nokia --verify-images
   still knows about images, but the files are gone
 - After replacing a local image file with a higher-quality version and wanting NetBox to pick
   it up
+
+#### Export Mode
+
+`--export-diff` runs in the opposite direction to every other mode: instead of importing the
+repo into NetBox, it writes out the device, module, and rack types that NetBox holds but the
+local repo does not, or that differ from it, as DTL-compatible YAML plus images. It does not
+run the import pipeline at all, so nothing in NetBox is modified.
+
+```shell
+uv run nb-dt-import.py --export-diff
+uv run nb-dt-import.py --export-diff --vendors nokia --export-diff-dir extra/
+```
+
+Files that already exist and differ are skipped with a warning. Add
+`--force-export-overwrite` to replace them.
+
+Because it is an export, the import-only flags are rejected rather than ignored:
+`--update`, `--only-new`, `--remove-components`, `--remove-unmanaged-types`, `--slugs`,
+`--verify-images`, and `--force-resolve-conflicts` all exit with an error. `--vendors` still
+works, and narrows the export to those manufacturers.
 
 We're happy about any pull requests!
 

--- a/README.md
+++ b/README.md
@@ -94,15 +94,20 @@ docker run --rm --env-file .env \
   ghcr.io/marcinpsk/device-type-library-import:latest
 ```
 
-A host directory works too, but create it yourself first. Docker creates a missing bind-mount
-source as `root`, and the container runs as UID 1000 (`appuser`), which then cannot write to it:
+A host directory works too, but create it yourself first and give UID 1000 (`appuser`, the user
+the container runs as) write access. Docker creates a missing bind-mount source as `root`, and
+`mkdir` on a host account that is not UID 1000 has the same effect:
 
 ```shell
 mkdir -p repo
+sudo chown 1000:1000 repo   # skip if your host account is already UID 1000
 docker run --rm --env-file .env \
   -v "$PWD/repo:/app/repo" \
   ghcr.io/marcinpsk/device-type-library-import:latest
 ```
+
+To keep the files owned by your host account instead, run the container as your own user with
+`--user "$(id -u):$(id -g)"`.
 
 ### Passing arguments
 
@@ -114,7 +119,8 @@ docker run --rm --env-file .env ghcr.io/marcinpsk/device-type-library-import:lat
 ```
 
 Alternatively, set `VENDORS` (comma-separated) and `SLUGS` (space-separated) in your environment
-file and pass no arguments at all.
+file and pass no arguments at all. `SLUGS` applies to imports only; [export runs](#export-mode)
+report that they ignore it.
 
 An argument that does not start with `-` runs as a command instead, so the image stays
 usable for debugging:
@@ -428,6 +434,7 @@ directory to keep the output, creating it first for the same reason as the libra
 
 ```shell
 mkdir -p extra
+sudo chown 1000:1000 extra   # skip if your host account is already UID 1000
 docker run --rm --env-file .env -v "$PWD/extra:/app/extra" \
   ghcr.io/marcinpsk/device-type-library-import:latest --export-diff
 ```
@@ -436,6 +443,10 @@ Because it is an export, the import-only flags are rejected rather than ignored:
 `--update`, `--only-new`, `--remove-components`, `--remove-unmanaged-types`, `--slugs`,
 `--verify-images`, and `--force-resolve-conflicts` all exit with an error. `--vendors` still
 works, and narrows the export to those manufacturers.
+
+`SLUGS` in the environment is a default for imports, not an explicit flag, so an export reports
+that it is ignoring the value and continues. The same environment file therefore works for both
+modes.
 
 We're happy about any pull requests!
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ The image is public; no `docker login` is needed to pull it.
 Pin a version tag for scheduled or automated runs so an upstream change cannot alter the
 behavior of a job that already works.
 
+None of these tags is immutable: the image workflow also runs when a release is edited, which
+rebuilds and re-pushes the same version tag. Pin the digest when a run must never change:
+
+```shell
+docker buildx imagetools inspect ghcr.io/marcinpsk/device-type-library-import:1.7.1
+docker run --rm --env-file .env \
+  ghcr.io/marcinpsk/device-type-library-import@sha256:b27ee7c0…
+```
+
 ### Quick start
 
 Write your NetBox URL and API token (the token needs **write rights**) into a `.env` file:

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ docker run --rm --env-file .env \
   ghcr.io/marcinpsk/device-type-library-import:latest
 ```
 
-A host directory works too, but it must be readable and writable by UID 1000 (the `appuser`
-account the container runs as):
+A host directory works too, but create it yourself first. Docker creates a missing bind-mount
+source as `root`, and the container runs as UID 1000 (`appuser`), which then cannot write to it:
 
 ```shell
+mkdir -p repo
 docker run --rm --env-file .env \
   -v "$PWD/repo:/app/repo" \
   ghcr.io/marcinpsk/device-type-library-import:latest
@@ -105,16 +106,30 @@ docker run --rm --env-file .env \
 
 ### Passing arguments
 
-The default command is `python -u nb-dt-import.py`. The image sets no entrypoint, so repeat the
-full command to add [arguments](#arguments):
+Append [arguments](#arguments) to the image name:
 
 ```shell
 docker run --rm --env-file .env ghcr.io/marcinpsk/device-type-library-import:latest \
-  python -u nb-dt-import.py --vendors apc,juniper --update
+  --vendors apc,juniper --update
 ```
 
 Alternatively, set `VENDORS` (comma-separated) and `SLUGS` (space-separated) in your environment
-file and keep the default command.
+file and pass no arguments at all.
+
+An argument that does not start with `-` runs as a command instead, so the image stays
+usable for debugging:
+
+```shell
+docker run --rm -it ghcr.io/marcinpsk/device-type-library-import:latest bash
+```
+
+Older images had no entrypoint, so the only way to pass a flag was to repeat the whole
+command. That form still works:
+
+```shell
+docker run --rm --env-file .env ghcr.io/marcinpsk/device-type-library-import:latest \
+  python -u nb-dt-import.py --vendors apc
+```
 
 ### Docker Compose
 
@@ -125,7 +140,7 @@ services:
     env_file: .env
     volumes:
       - dtl-library:/app/repo
-    command: ["python", "-u", "nb-dt-import.py", "--update"]
+    command: ["--update"]
 
 volumes:
   dtl-library:
@@ -406,6 +421,16 @@ uv run nb-dt-import.py --export-diff --vendors nokia --export-diff-dir extra/
 
 Files that already exist and differ are skipped with a warning. Add
 `--force-export-overwrite` to replace them.
+
+The export directory is relative to the working directory, which is `/app` in the container.
+A `docker run --rm` therefore writes to `/app/extra` and discards it on exit. Mount a host
+directory to keep the output, creating it first for the same reason as the library volume:
+
+```shell
+mkdir -p extra
+docker run --rm --env-file .env -v "$PWD/extra:/app/extra" \
+  ghcr.io/marcinpsk/device-type-library-import:latest --export-diff
+```
 
 Because it is an export, the import-only flags are rejected rather than ignored:
 `--update`, `--only-new`, `--remove-components`, `--remove-unmanaged-types`, `--slugs`,

--- a/core/export.py
+++ b/core/export.py
@@ -476,8 +476,8 @@ class Exporter:
             return
         raise FileNotFoundError(
             f"No device-type library found at {self.repo_path}: expected at least one of "
-            f"{', '.join(_LIBRARY_TYPE_DIRS)}. Clone or mount the library before exporting, "
-            "otherwise every type in NetBox counts as missing from it."
+            f"{', '.join(_LIBRARY_TYPE_DIRS)}. Export mode does not clone the library. "
+            "Clone it to that path, or run an import first, which clones it for you."
         )
 
     def _verify_export_dir_writable(self) -> None:

--- a/core/export.py
+++ b/core/export.py
@@ -31,6 +31,9 @@ from core.netbox_api import IMAGE_EXTENSIONS, _build_auth_header
 
 _SKIP = object()  # sentinel: image already exists, no download needed
 
+# Top-level directories that make a checkout a device-type library.
+_LIBRARY_TYPE_DIRS = ("device-types", "module-types", "rack-types")
+
 # Maps Content-Type to a canonical extension for extension-less attachments.
 _CONTENT_TYPE_EXT = {
     "image/png": ".png",
@@ -217,6 +220,7 @@ class Exporter:
     def run(self, progress=None) -> None:
         """Run the export-diff workflow."""
         self._module_image_details = None
+        self._verify_repo_available()
         self._verify_export_dir_writable()
         manifest_path = self.export_dir / ".export-manifest.json"
         manifest = load_manifest(manifest_path)
@@ -465,6 +469,16 @@ class Exporter:
         )
 
     # ── Directory helpers ────────────────────────────────────────────────────
+
+    def _verify_repo_available(self) -> None:
+        """Raise FileNotFoundError when the library is absent, which would otherwise read as an empty one."""
+        if any((self.repo_path / name).is_dir() for name in _LIBRARY_TYPE_DIRS):
+            return
+        raise FileNotFoundError(
+            f"No device-type library found at {self.repo_path}: expected at least one of "
+            f"{', '.join(_LIBRARY_TYPE_DIRS)}. Clone or mount the library before exporting, "
+            "otherwise every type in NetBox counts as missing from it."
+        )
 
     def _verify_export_dir_writable(self) -> None:
         """Raise PermissionError if export dir cannot be created or written to."""

--- a/core/repo.py
+++ b/core/repo.py
@@ -408,7 +408,8 @@ class DTLRepo:
             self.handle.exception("InvalidRepoPath", self.repo_path, path_error)
 
         # Test for .git, not the directory itself: a mounted-but-empty volume must still clone.
-        if os.path.isdir(os.path.join(self.repo_path, ".git")):
+        # exists(), not isdir(): worktrees and submodules hold .git as a file.
+        if os.path.exists(os.path.join(self.repo_path, ".git")):
             # Repo exists; pull from existing remote (pull_repo validates origin URL)
             self.pull_repo()
         else:

--- a/core/repo.py
+++ b/core/repo.py
@@ -377,7 +377,7 @@ class DTLRepo:
     def __init__(self, args, repo_path, exception_handler):
         """Initialize repository management, updating an existing clone or creating a new one.
 
-        If the target path already exists as a directory, the repository will be updated from
+        If the target path already holds a Git clone, the repository will be updated from
         its configured remote; otherwise the provided URL is validated and a new clone is
         created. The initializer sets instance attributes used by other methods (handler,
         supported YAML extensions, URL, repo path, branch, repo reference, and current
@@ -407,7 +407,8 @@ class DTLRepo:
         if not is_path_valid:
             self.handle.exception("InvalidRepoPath", self.repo_path, path_error)
 
-        if os.path.isdir(self.repo_path):
+        # Test for .git, not the directory itself: a mounted-but-empty volume must still clone.
+        if os.path.isdir(os.path.join(self.repo_path, ".git")):
             # Repo exists; pull from existing remote (pull_repo validates origin URL)
             self.pull_repo()
         else:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+# Images before this entrypoint had no ENTRYPOINT, so the only way to pass a flag was to
+# repeat the whole command. Accept that form and drop the interpreter prefix.
+case "$1 $2 $3" in
+"python -u nb-dt-import.py" | "python3 -u nb-dt-import.py") shift 3 ;;
+esac
+case "$1 $2" in
+"python nb-dt-import.py" | "python3 nb-dt-import.py") shift 2 ;;
+esac
+
+# Flags, or no arguments at all, run the importer. Anything else runs as given, so
+# `docker run … bash` and `docker run … python -c …` still work for debugging.
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+    set -- python -u /app/nb-dt-import.py "$@"
+fi
+
+exec "$@"

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -921,7 +921,8 @@ def _build_argument_parser() -> ArgumentParser:
     parser.add_argument(
         "--slugs",
         nargs="+",
-        default=settings.SLUGS,
+        # None distinguishes "not passed" from an env-provided default, which export mode ignores.
+        default=None,
         help="List of device-type slugs to import eg. ap4431 ws-c3850-24t-l",
     )
     parser.add_argument("--branch", default=settings.REPO_BRANCH, help="Git branch to use from repo")
@@ -1161,9 +1162,16 @@ def main():
     args.vendors = [
         re.sub(r"\W+", "-", v.strip().casefold()) for vendor in args.vendors for v in vendor.split(",") if v.strip()
     ]
-    args.slugs = [s.strip() for slug in args.slugs for s in slug.split(",") if s.strip()]
+    # None means --slugs was not passed, so the environment default applies.
+    slug_values = settings.SLUGS if args.slugs is None else args.slugs
+    args.slugs = [s.strip() for slug in slug_values for s in slug.split(",") if s.strip()]
 
     handle = LogHandler(args)
+
+    # An explicit --slugs is already rejected, so anything left here came from the environment.
+    if args.export_diff and args.slugs:
+        handle.log("Ignoring SLUGS from the environment: --export-diff does not filter by slug.")
+        args.slugs = []
 
     _check_env_vars(handle)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,13 @@ commit_message = "chore(release): v{version}"
 build_command = "uv lock"
 assets = ["uv.lock"]
 
+# Stated rather than left to the parser defaults, which the release job picks up unpinned.
+# Keep in sync with types in .github/workflows/pr-title.yml.
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]
+
 [tool.semantic_release.changelog]
 template_dir = "templates"
 

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -347,6 +347,44 @@ class TestCanonMfrSlug:
         assert _canon_mfr_slug({}) == ""
 
 
+class TestExporterRequiresTheLibrary:
+    """The export compares NetBox against the library, so an absent library is not an empty one."""
+
+    def test_run_fails_before_querying_netbox_when_the_repo_holds_no_library(self, tmp_path):
+        """A fresh container has an empty /app/repo, which used to read as 'NetBox has everything'."""
+        settings = _make_settings(tmp_path)
+        (tmp_path / "repo").mkdir()
+        exporter = Exporter(settings, _make_handle(), str(tmp_path / "extra"), False, None)
+        exporter.graphql = MagicMock()
+
+        with pytest.raises(FileNotFoundError, match="device-types"):
+            exporter.run()
+
+        exporter.graphql.get_device_types.assert_not_called()
+
+    def test_run_fails_when_the_repo_path_does_not_exist_at_all(self, tmp_path):
+        settings = _make_settings(tmp_path)
+        exporter = Exporter(settings, _make_handle(), str(tmp_path / "extra"), False, None)
+        exporter.graphql = MagicMock()
+
+        with pytest.raises(FileNotFoundError):
+            exporter.run()
+
+    def test_run_accepts_a_library_holding_only_one_of_the_three_type_dirs(self, tmp_path):
+        """A vendor-filtered or partial checkout is still a real library, so it must not be rejected."""
+        settings = _make_settings(tmp_path)
+        (tmp_path / "repo" / "module-types").mkdir(parents=True)
+        exporter = Exporter(settings, _make_handle(), str(tmp_path / "extra"), False, None)
+        exporter.graphql = MagicMock()
+        exporter.graphql.get_device_types = MagicMock(return_value=({}, {}))
+        exporter.graphql.get_module_types = MagicMock(return_value={})
+        exporter.graphql.get_rack_types = MagicMock(return_value={})
+
+        exporter.run()
+
+        exporter.graphql.get_device_types.assert_called_once()
+
+
 class TestExporterDirWritable:
     """Tests for export directory writability checks."""
 
@@ -531,7 +569,7 @@ class TestManifestConsistency:
         from core.export_manifest import load_manifest
 
         settings = _make_settings(tmp_path)
-        (tmp_path / "repo").mkdir(parents=True)
+        (tmp_path / "repo" / "device-types").mkdir(parents=True)
         export_dir = tmp_path / "extra"
         exporter = Exporter(settings, _make_handle(), str(export_dir), False, None)
         # Patch _download_image to simulate failure (returns None)
@@ -552,7 +590,7 @@ class TestManifestConsistency:
         from core.export_manifest import load_manifest
 
         settings = _make_settings(tmp_path)
-        (tmp_path / "repo").mkdir(parents=True)
+        (tmp_path / "repo" / "device-types").mkdir(parents=True)
         export_dir = tmp_path / "extra"
         exporter = Exporter(settings, _make_handle(), str(export_dir), False, None)
         # First call: _SKIP (already exists); second call: hash string (success)
@@ -574,7 +612,7 @@ class TestManifestConsistency:
         from core.export_manifest import load_manifest
 
         settings = _make_settings(tmp_path)
-        (tmp_path / "repo").mkdir(parents=True)
+        (tmp_path / "repo" / "device-types").mkdir(parents=True)
         export_dir = tmp_path / "extra"
         exporter = Exporter(settings, _make_handle(), str(export_dir), False, None)
         # First call: hash (success); second call: None (failure)
@@ -695,7 +733,7 @@ class TestExporterAdditionalCoverage:
 
     def _make_exporter(self, tmp_path, force_overwrite=False):
         settings = _make_settings(tmp_path)
-        (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "repo" / "device-types").mkdir(parents=True, exist_ok=True)
         return Exporter(settings, _make_handle(), str(tmp_path / "extra"), force_overwrite, None)
 
     def test_get_module_image_details_is_cached(self, tmp_path):

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -357,8 +357,14 @@ class TestExporterRequiresTheLibrary:
         exporter = Exporter(settings, _make_handle(), str(tmp_path / "extra"), False, None)
         exporter.graphql = MagicMock()
 
-        with pytest.raises(FileNotFoundError, match="device-types"):
+        with pytest.raises(FileNotFoundError) as err:
             exporter.run()
+
+        message = str(err.value)
+        assert str(tmp_path / "repo") in message
+        assert "device-types" in message
+        # The message has to name a way out, not only the missing path.
+        assert "run an import first" in message
 
         exporter.graphql.get_device_types.assert_not_called()
 

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -3,6 +3,7 @@ import os
 import re
 import runpy
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -1649,9 +1650,32 @@ class TestDirectHelpers:
         ):
             nb_dt_import._run_export_diff(nb_dt_import.settings, handle, args)
 
-        MockExporter.assert_called_once()
+        assert MockExporter.call_args.kwargs == {
+            "settings": nb_dt_import.settings,
+            "handle": handle,
+            "export_dir": "extra",
+            "force_overwrite": True,
+            "vendor_slugs": ["nokia"],
+        }
         handle.set_console.assert_called_once_with(progress.console)
         MockExporter.return_value.run.assert_called_once_with(progress=progress)
+
+    def test_run_export_diff_sends_no_vendor_filter_when_vendors_is_empty(self, nb_dt_import):
+        """An empty --vendors must reach the exporter as None, not as an empty list."""
+        args = SimpleNamespace(
+            export_diff_dir="extra",
+            force_export_overwrite=False,
+            vendors=[],
+            show_remaining_time=False,
+        )
+
+        with (
+            patch("nb_dt_import.get_progress_panel", return_value=nullcontext(None)),
+            patch("core.export.Exporter") as MockExporter,
+        ):
+            nb_dt_import._run_export_diff(nb_dt_import.settings, MagicMock(), args)
+
+        assert MockExporter.call_args.kwargs["vendor_slugs"] is None
 
 
 class TestMainAdditionalCoverage:

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -1145,6 +1145,19 @@ class TestPerVendorLoop:
 
         mock_nb.load_vendor.assert_not_called()
 
+    def test_slugs_from_the_environment_still_filter_an_import(self, nb_dt_import, monkeypatch):
+        """The --slugs sentinel default must not drop the SLUGS environment default for imports."""
+        monkeypatch.setattr(nb_dt_import.settings, "SLUGS", ["env-slug"])
+        mock_nb = _make_mock_netbox()
+        mock_repo = _make_mock_repo()
+        mock_repo.discover_vendors.return_value = [{"name": "APC", "slug": "apc"}]
+        mock_repo.get_devices.return_value = (["file.yaml"], [])
+        mock_repo.parse_files.return_value = []
+
+        self._run_main(["nb-dt-import.py"], mock_repo, mock_nb, nb_dt_import)
+
+        assert mock_repo.parse_files.call_args.kwargs["slugs"] == ["env-slug"]
+
     def test_vendor_with_matching_slug_is_processed(self, nb_dt_import):
         """Vendor whose slug matches parsed files does call load_vendor."""
         mock_nb = _make_mock_netbox()
@@ -1436,6 +1449,44 @@ class TestExportDiffFlags:
         )
         assert result.returncode == 2
         assert "--export-diff" in result.stderr
+
+    def test_export_diff_runs_with_slugs_set_in_the_environment(self):
+        """SLUGS in the environment is an import default, not an explicit --slugs, so export runs."""
+        import os
+        import subprocess
+
+        # Blank the NetBox variables so the run stops at the env check and reaches no server.
+        env = {
+            **os.environ,
+            "SLUGS": "ap4431",
+            "REPO_URL": "https://example.com/devicetype-library.git",
+            "NETBOX_URL": "",
+            "NETBOX_TOKEN": "",
+        }
+        result = subprocess.run(
+            ["uv", "run", "--native-tls", "nb-dt-import.py", "--export-diff"],
+            capture_output=True,
+            text=True,
+            cwd=_PROJECT_ROOT,
+            env=env,
+        )
+        assert "--slugs is an import-only flag" not in result.stderr
+        # Reaching the env-var check proves argument validation let the run through.
+        assert 'Environment variable "NETBOX_URL" is not set' in result.stderr
+        assert "Ignoring SLUGS from the environment" in result.stdout
+
+    def test_export_diff_still_rejects_an_explicit_slugs_flag(self):
+        """Passing --slugs on the command line stays an error, environment default or not."""
+        import subprocess
+
+        result = subprocess.run(
+            ["uv", "run", "--native-tls", "nb-dt-import.py", "--export-diff", "--slugs", "ap4431"],
+            capture_output=True,
+            text=True,
+            cwd=_PROJECT_ROOT,
+        )
+        assert result.returncode == 2
+        assert "--slugs is an import-only flag" in result.stderr
 
 
 class TestDirectHelpers:

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -1670,7 +1670,7 @@ class TestMainAdditionalCoverage:
         MockRepo.assert_not_called()
         MockNetBox.assert_not_called()
 
-    def test_main_clears_environment_slugs_before_running_the_export(self, nb_dt_import, monkeypatch):
+    def test_main_clears_environment_slugs_before_running_the_export(self, nb_dt_import, monkeypatch, capsys):
         """The export must receive no slug filter, and must say it dropped the environment value."""
         monkeypatch.setattr(nb_dt_import.settings, "SLUGS", ["env-slug"])
         with (
@@ -1681,6 +1681,7 @@ class TestMainAdditionalCoverage:
 
         args = mock_run_export.call_args.args[2]
         assert args.slugs == []
+        assert "Ignoring SLUGS from the environment" in capsys.readouterr().out
 
     def test_main_uses_slug_fast_path_device_files(self, nb_dt_import):
         mock_repo = _make_mock_repo()

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -1670,6 +1670,18 @@ class TestMainAdditionalCoverage:
         MockRepo.assert_not_called()
         MockNetBox.assert_not_called()
 
+    def test_main_clears_environment_slugs_before_running_the_export(self, nb_dt_import, monkeypatch):
+        """The export must receive no slug filter, and must say it dropped the environment value."""
+        monkeypatch.setattr(nb_dt_import.settings, "SLUGS", ["env-slug"])
+        with (
+            patch.object(sys, "argv", ["nb-dt-import.py", "--export-diff"]),
+            patch("nb_dt_import._run_export_diff") as mock_run_export,
+        ):
+            nb_dt_import.main()
+
+        args = mock_run_export.call_args.args[2]
+        assert args.slugs == []
+
     def test_main_uses_slug_fast_path_device_files(self, nb_dt_import):
         mock_repo = _make_mock_repo()
         mock_repo.discover_vendors.return_value = [{"name": "Cisco", "slug": "cisco"}]

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -1,5 +1,6 @@
 import importlib.util
 import os
+import re
 import runpy
 import sys
 from pathlib import Path
@@ -1877,3 +1878,42 @@ class TestMainAdditionalCoverage:
 
         netbox.device_types.stop_component_preload.assert_called_once_with("job-2", progress=progress)
         mock_finalize.assert_called_once_with(progress, {})
+
+
+class TestReadmeArgumentCoverage:
+    """The README arguments table and the argparse parser must not drift apart."""
+
+    README_HEADING = "#### All Arguments"
+
+    @classmethod
+    def _documented_flags(cls):
+        """Return the ``--flags`` in the Argument column of the README's All Arguments table."""
+        readme = Path(__file__).resolve().parents[1] / "README.md"
+        lines = readme.read_text(encoding="utf-8").splitlines()
+        starts = [i for i, line in enumerate(lines) if line.strip() == cls.README_HEADING]
+        assert starts, f"README.md has no '{cls.README_HEADING}' heading; update README_HEADING"
+        start = starts[0]
+        end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("#")), len(lines))
+        rows = [line for line in lines[start:end] if line.lstrip().startswith("|")]
+        # First cell only: descriptions cross-reference other flags and would mask a missing row.
+        first_cells = [row.strip().strip("|").split("|")[0] for row in rows]
+        return set(re.findall(r"`(--[\w-]+)`", "\n".join(first_cells)))
+
+    @staticmethod
+    def _parser_flags(nb_dt_import):
+        """Return the long options the real parser defines; argparse exposes no public accessor."""
+        parser = nb_dt_import._build_argument_parser()
+        return {
+            option
+            for action in parser._actions
+            for option in action.option_strings
+            if option.startswith("--") and option != "--help"
+        }
+
+    def test_every_parser_flag_is_documented(self, nb_dt_import):
+        missing = self._parser_flags(nb_dt_import) - self._documented_flags()
+        assert not missing, f"CLI flags missing from the README arguments table: {sorted(missing)}"
+
+    def test_table_documents_no_removed_flags(self, nb_dt_import):
+        stale = self._documented_flags() - self._parser_flags(nb_dt_import)
+        assert not stale, f"README arguments table documents flags the parser no longer defines: {sorted(stale)}"

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -1624,6 +1624,7 @@ class TestDirectHelpers:
             "--force-resolve-conflicts is an import-only flag and cannot be used with --export-diff"
         )
 
+    def test_run_export_diff_wires_up_exporter(self, nb_dt_import):
         """_run_export_diff wires up Exporter with progress panel and console."""
         handle = MagicMock()
         progress = MagicMock()

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -1,0 +1,32 @@
+"""Checks that the release configuration agrees with the CI that enforces it."""
+
+import pathlib
+import tomllib
+
+import yaml
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_PYPROJECT = _ROOT / "pyproject.toml"
+_PR_TITLE_WORKFLOW = _ROOT / ".github" / "workflows" / "pr-title.yml"
+
+
+def _allowed_tags():
+    """Return the commit types semantic-release parses, from pyproject.toml."""
+    config = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return config["tool"]["semantic_release"]["commit_parser_options"]["allowed_tags"]
+
+
+def _pr_title_types():
+    """Return the commit types the PR-title check accepts, from the workflow."""
+    workflow = yaml.safe_load(_PR_TITLE_WORKFLOW.read_text(encoding="utf-8"))
+    step = workflow["jobs"]["conventional-commits"]["steps"][0]
+    return step["with"]["types"].split()
+
+
+def test_pr_title_types_match_the_release_parser():
+    """A type accepted by one and not the other silently skips or blocks a release.
+
+    A squash merge takes the PR title as the commit subject, so a type the workflow
+    allows but the parser rejects lands on main as an unparseable subject.
+    """
+    assert sorted(_pr_title_types()) == sorted(_allowed_tags())

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -19,7 +19,9 @@ def _allowed_tags():
 def _pr_title_types():
     """Return the commit types the PR-title check accepts, from the workflow."""
     workflow = yaml.safe_load(_PR_TITLE_WORKFLOW.read_text(encoding="utf-8"))
-    step = workflow["jobs"]["conventional-commits"]["steps"][0]
+    steps = workflow["jobs"]["conventional-commits"]["steps"]
+    # Found by action rather than by position, so an added step does not silently pass this.
+    step = next(s for s in steps if s.get("uses", "").startswith("amannn/action-semantic-pull-request@"))
     return step["with"]["types"].split()
 
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, call, mock_open, patch
-from git import exc as git_exc
+from git import Repo as GitRepo, exc as git_exc
 from core.repo import (
     DTLRepo,
     _resolve_index_path,
@@ -125,6 +125,69 @@ class TestDTLRepoInit:
             "ftp://bad.url",
             "URL must use HTTPS, SSH, or file protocol",
         )
+
+
+class TestDTLRepoRealGit:
+    """Clone/pull branching driven against a real local Git repository (no git mocks)."""
+
+    @pytest.fixture(autouse=True)
+    def mock_git_repo(self):
+        """Override the global autouse git mock so these tests exercise real git."""
+        yield None
+
+    @staticmethod
+    def _make_source_repo(path):
+        """Create a real git repository at *path* holding one device-type file."""
+        source = GitRepo.init(path, initial_branch="master")
+        devices = path / "device-types" / "TestVendor"
+        devices.mkdir(parents=True)
+        (devices / "device.yaml").write_text("manufacturer: TestVendor\nmodel: Test\n")
+        source.index.add(["device-types/TestVendor/device.yaml"])
+        source.index.commit("initial")
+        return source
+
+    def _init_dtl(self, source, target):
+        """Build a DTLRepo pointing at the *source* repository and the *target* path."""
+        mock_args = MagicMock()
+        mock_args.url = f"file://{source}"
+        mock_args.branch = "master"
+        mock_handle = MagicMock()
+        dtl = DTLRepo(mock_args, str(target), mock_handle)
+        return dtl, mock_handle
+
+    def test_clones_into_existing_empty_directory(self, tmp_path):
+        """A mounted-but-empty target (Docker volume on first run) must be cloned into, not pulled."""
+        source = tmp_path / "source"
+        source.mkdir()
+        self._make_source_repo(source)
+
+        target = tmp_path / "repo"
+        target.mkdir()
+
+        _, mock_handle = self._init_dtl(source, target)
+
+        mock_handle.exception.assert_not_called()
+        assert (target / ".git").is_dir()
+        assert (target / "device-types" / "TestVendor" / "device.yaml").is_file()
+
+    def test_pulls_when_target_is_an_existing_clone(self, tmp_path):
+        source = tmp_path / "source"
+        source.mkdir()
+        source_repo = self._make_source_repo(source)
+
+        target = tmp_path / "repo"
+        target.mkdir()
+        self._init_dtl(source, target)
+
+        new_file = source / "device-types" / "TestVendor" / "second.yaml"
+        new_file.write_text("manufacturer: TestVendor\nmodel: Second\n")
+        source_repo.index.add(["device-types/TestVendor/second.yaml"])
+        source_repo.index.commit("second device")
+
+        _, mock_handle = self._init_dtl(source, target)
+
+        mock_handle.exception.assert_not_called()
+        assert (target / "device-types" / "TestVendor" / "second.yaml").is_file()
 
 
 class TestDTLRepoPathMethods:

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from unittest.mock import MagicMock, call, mock_open, patch
 from git import Actor, Repo as GitRepo, exc as git_exc
@@ -10,6 +12,15 @@ from core.repo import (
     validate_git_url,
     normalize_port_mappings,
 )
+
+
+def _clone_present(present=True):
+    """Steer only the .git probe in DTLRepo.__init__, leaving every other path check real."""
+    real_exists = os.path.exists
+    return patch(
+        "os.path.exists",
+        side_effect=lambda p: present if str(p).endswith(".git") else real_exists(p),
+    )
 
 
 class TestValidateGitUrl:
@@ -71,7 +82,7 @@ class TestDTLRepoInit:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=isdir),
+            _clone_present(isdir),
             patch("core.repo.Repo") as MockRepo,
         ):
             if mock_repo:
@@ -86,7 +97,7 @@ class TestDTLRepoInit:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=True),
+            _clone_present(),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_git_repo = MagicMock()
@@ -105,7 +116,7 @@ class TestDTLRepoInit:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=False),
+            _clone_present(False),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_cloned = MagicMock()
@@ -118,7 +129,7 @@ class TestDTLRepoInit:
         mock_args.url = "ftp://bad.url"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        with patch("os.path.isdir", return_value=False), patch("core.repo.Repo"):
+        with _clone_present(False), patch("core.repo.Repo"):
             DTLRepo(mock_args, "/tmp/repo", mock_handle)
         mock_handle.exception.assert_called_with(
             "InvalidGitURL",
@@ -137,6 +148,12 @@ class TestDTLRepoRealGit:
     def mock_git_repo(self):
         """Override the global autouse git mock so these tests exercise real git."""
         yield None
+
+    @pytest.fixture(autouse=True)
+    def clear_ambient_git_env(self, monkeypatch):
+        """Drop git's per-command variables: a hook runner exports GIT_DIR for the outer repo."""
+        for var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR"):
+            monkeypatch.delenv(var, raising=False)
 
     @classmethod
     def _commit(cls, repo, path, message):
@@ -197,6 +214,28 @@ class TestDTLRepoRealGit:
         mock_handle.exception.assert_not_called()
         assert (target / "device-types" / "TestVendor" / "second.yaml").is_file()
 
+    def test_pulls_when_target_is_a_git_worktree(self, tmp_path):
+        """A worktree holds .git as a file, so testing for a .git directory would clone over it."""
+        source = tmp_path / "source"
+        source.mkdir()
+        self._make_source_repo(source)
+
+        clone = tmp_path / "clone"
+        clone.mkdir()
+        self._init_dtl(source, clone)
+        # Park the clone on another branch so the worktree below can hold master.
+        clone_repo = GitRepo(clone)
+        clone_repo.git.checkout("-b", "parked")
+
+        worktree = tmp_path / "worktree"
+        clone_repo.git.worktree("add", str(worktree), "master")
+        assert (worktree / ".git").is_file(), "a worktree must have .git as a file for this test to mean anything"
+
+        mock_handle = self._init_dtl(source, worktree)
+
+        mock_handle.exception.assert_not_called()
+        assert (worktree / "device-types" / "TestVendor" / "device.yaml").is_file()
+
 
 class TestDTLRepoPathMethods:
     """Tests for DTLRepo path helper methods (get_relative_path, get_absolute_path, etc.)."""
@@ -207,7 +246,7 @@ class TestDTLRepoPathMethods:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=True),
+            _clone_present(),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_git_repo = MagicMock()
@@ -242,7 +281,7 @@ class TestPullRepo:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=True),
+            _clone_present(),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_git_repo = MagicMock()
@@ -259,7 +298,7 @@ class TestPullRepo:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=True),
+            _clone_present(),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_git_repo = MagicMock()
@@ -279,7 +318,7 @@ class TestPullRepo:
         mock_args.branch = "main"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=True),
+            _clone_present(),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_git_repo = MagicMock()
@@ -301,7 +340,7 @@ class TestPullRepo:
         mock_args.branch = "missing-branch"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=True),
+            _clone_present(),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_git_repo = MagicMock()
@@ -319,7 +358,7 @@ class TestPullRepo:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=True),
+            _clone_present(),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_git_repo = MagicMock()
@@ -335,7 +374,7 @@ class TestPullRepo:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=True),
+            _clone_present(),
             patch("core.repo.Repo") as MockRepo,
         ):
             mock_git_repo = MagicMock()
@@ -355,7 +394,7 @@ class TestCloneRepo:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=False),
+            _clone_present(False),
             patch("core.repo.Repo") as MockRepo,
         ):
             MockRepo.clone_from.side_effect = git_exc.GitCommandError("clone", 128)
@@ -368,7 +407,7 @@ class TestCloneRepo:
         mock_args.branch = "master"
         mock_handle = MagicMock()
         with (
-            patch("os.path.isdir", return_value=False),
+            _clone_present(False),
             patch("core.repo.Repo") as MockRepo,
         ):
             MockRepo.clone_from.side_effect = RuntimeError("failed")

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, call, mock_open, patch
-from git import Repo as GitRepo, exc as git_exc
+from git import Actor, Repo as GitRepo, exc as git_exc
 from core.repo import (
     DTLRepo,
     _resolve_index_path,
@@ -135,15 +135,23 @@ class TestDTLRepoRealGit:
         """Override the global autouse git mock so these tests exercise real git."""
         yield None
 
-    @staticmethod
-    def _make_source_repo(path):
+    # Pinned so the fixture never depends on ambient git config or on getpass.getuser().
+    ACTOR = Actor("DTL test", "dtl-test@example.invalid")
+
+    @classmethod
+    def _commit(cls, repo, path, message):
+        """Stage *path* in *repo* and commit it under the fixed test identity."""
+        repo.index.add([path])
+        repo.index.commit(message, author=cls.ACTOR, committer=cls.ACTOR)
+
+    @classmethod
+    def _make_source_repo(cls, path):
         """Create a real git repository at *path* holding one device-type file."""
         source = GitRepo.init(path, initial_branch="master")
         devices = path / "device-types" / "TestVendor"
         devices.mkdir(parents=True)
         (devices / "device.yaml").write_text("manufacturer: TestVendor\nmodel: Test\n")
-        source.index.add(["device-types/TestVendor/device.yaml"])
-        source.index.commit("initial")
+        cls._commit(source, "device-types/TestVendor/device.yaml", "initial")
         return source
 
     def _init_dtl(self, source, target):
@@ -181,8 +189,7 @@ class TestDTLRepoRealGit:
 
         new_file = source / "device-types" / "TestVendor" / "second.yaml"
         new_file.write_text("manufacturer: TestVendor\nmodel: Second\n")
-        source_repo.index.add(["device-types/TestVendor/second.yaml"])
-        source_repo.index.commit("second device")
+        self._commit(source_repo, "device-types/TestVendor/second.yaml", "second device")
 
         _, mock_handle = self._init_dtl(source, target)
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -130,13 +130,13 @@ class TestDTLRepoInit:
 class TestDTLRepoRealGit:
     """Clone/pull branching driven against a real local Git repository (no git mocks)."""
 
+    # Pinned so the fixture never depends on ambient git config or on getpass.getuser().
+    ACTOR = Actor("DTL test", "dtl-test@example.invalid")
+
     @pytest.fixture(autouse=True)
     def mock_git_repo(self):
         """Override the global autouse git mock so these tests exercise real git."""
         yield None
-
-    # Pinned so the fixture never depends on ambient git config or on getpass.getuser().
-    ACTOR = Actor("DTL test", "dtl-test@example.invalid")
 
     @classmethod
     def _commit(cls, repo, path, message):
@@ -155,13 +155,13 @@ class TestDTLRepoRealGit:
         return source
 
     def _init_dtl(self, source, target):
-        """Build a DTLRepo pointing at the *source* repository and the *target* path."""
+        """Run DTLRepo against *source* and *target*; return its exception handler for assertions."""
         mock_args = MagicMock()
         mock_args.url = f"file://{source}"
         mock_args.branch = "master"
         mock_handle = MagicMock()
-        dtl = DTLRepo(mock_args, str(target), mock_handle)
-        return dtl, mock_handle
+        DTLRepo(mock_args, str(target), mock_handle)
+        return mock_handle
 
     def test_clones_into_existing_empty_directory(self, tmp_path):
         """A mounted-but-empty target (Docker volume on first run) must be cloned into, not pulled."""
@@ -172,13 +172,14 @@ class TestDTLRepoRealGit:
         target = tmp_path / "repo"
         target.mkdir()
 
-        _, mock_handle = self._init_dtl(source, target)
+        mock_handle = self._init_dtl(source, target)
 
         mock_handle.exception.assert_not_called()
         assert (target / ".git").is_dir()
         assert (target / "device-types" / "TestVendor" / "device.yaml").is_file()
 
     def test_pulls_when_target_is_an_existing_clone(self, tmp_path):
+        """A second run over an existing clone must fetch new upstream commits."""
         source = tmp_path / "source"
         source.mkdir()
         source_repo = self._make_source_repo(source)
@@ -191,7 +192,7 @@ class TestDTLRepoRealGit:
         new_file.write_text("manufacturer: TestVendor\nmodel: Second\n")
         self._commit(source_repo, "device-types/TestVendor/second.yaml", "second device")
 
-        _, mock_handle = self._init_dtl(source, target)
+        mock_handle = self._init_dtl(source, target)
 
         mock_handle.exception.assert_not_called()
         assert (target / "device-types" / "TestVendor" / "second.yaml").is_file()

--- a/tests/test_suite_hygiene.py
+++ b/tests/test_suite_hygiene.py
@@ -2,8 +2,29 @@
 
 import ast
 import pathlib
+import tomllib
 
 _TESTS_DIR = pathlib.Path(__file__).resolve().parent
+_ROOT = _TESTS_DIR.parent
+
+# pytest's own default when python_files is not configured.
+_DEFAULT_PYTHON_FILES = ["test_*.py", "*_test.py"]
+
+
+def _discover(root, patterns, pruned):
+    """Return files under *root* matching *patterns*, minus anything inside *pruned*."""
+    found = {path for pattern in patterns for path in root.rglob(pattern)}
+    return sorted(p for p in found if not any(p.is_relative_to(d) for d in pruned))
+
+
+def _collected_test_files():
+    """Return the test files pytest collects, following python_files and norecursedirs."""
+    options = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["tool"]["pytest"]["ini_options"]
+    patterns = options.get("python_files", _DEFAULT_PYTHON_FILES)
+    if isinstance(patterns, str):
+        patterns = patterns.split()
+    pruned = [(_ROOT / entry).resolve() for entry in options.get("norecursedirs", [])]
+    return _discover(_TESTS_DIR, patterns, pruned)
 
 
 def _orphaned_docstrings(tree):
@@ -17,6 +38,19 @@ def _orphaned_docstrings(tree):
                     yield node.name, statement.lineno
 
 
+def test_the_scan_follows_pytest_discovery(tmp_path):
+    """Scanning a different set than pytest runs makes the guard below miss files, or invent them."""
+    (tmp_path / "test_first.py").touch()
+    (tmp_path / "second_test.py").touch()
+    (tmp_path / "helpers.py").touch()
+    (tmp_path / "skipped").mkdir()
+    (tmp_path / "skipped" / "test_third.py").touch()
+
+    found = _discover(tmp_path, _DEFAULT_PYTHON_FILES, [tmp_path / "skipped"])
+
+    assert [p.name for p in found] == ["second_test.py", "test_first.py"]
+
+
 def test_no_test_function_contains_an_orphaned_docstring():
     """A dropped ``def`` header silently merges two tests into one.
 
@@ -25,7 +59,7 @@ def test_no_test_function_contains_an_orphaned_docstring():
     once an earlier assertion fails. Ruff has no rule for this; B018 exempts strings.
     """
     offenders = []
-    for path in sorted(_TESTS_DIR.rglob("test_*.py")):
+    for path in _collected_test_files():
         tree = ast.parse(path.read_text(encoding="utf-8"))
         for name, lineno in _orphaned_docstrings(tree):
             offenders.append(f"{path.relative_to(_TESTS_DIR)}:{lineno} in {name}")

--- a/tests/test_suite_hygiene.py
+++ b/tests/test_suite_hygiene.py
@@ -19,10 +19,12 @@ def _discover(root, patterns, pruned):
 
 def _collected_test_files():
     """Return the test files pytest collects, following python_files and norecursedirs."""
-    options = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["tool"]["pytest"]["ini_options"]
+    config = tomllib.loads((_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    options = config["tool"]["pytest"]["ini_options"]
     patterns = options.get("python_files", _DEFAULT_PYTHON_FILES)
     if isinstance(patterns, str):
         patterns = patterns.split()
+    # norecursedirs entries are read as paths; pytest also accepts globs, which this ignores.
     pruned = [(_ROOT / entry).resolve() for entry in options.get("norecursedirs", [])]
     return _discover(_TESTS_DIR, patterns, pruned)
 

--- a/tests/test_suite_hygiene.py
+++ b/tests/test_suite_hygiene.py
@@ -1,0 +1,35 @@
+"""Structural checks on the test suite itself."""
+
+import ast
+import pathlib
+
+_TESTS_DIR = pathlib.Path(__file__).resolve().parent
+
+
+def _orphaned_docstrings(tree):
+    """Yield (function, lineno) for every bare string statement that is not a docstring."""
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for statement in node.body[1:]:
+            if isinstance(statement, ast.Expr) and isinstance(statement.value, ast.Constant):
+                if isinstance(statement.value.value, str):
+                    yield node.name, statement.lineno
+
+
+def test_no_test_function_contains_an_orphaned_docstring():
+    """A dropped ``def`` header silently merges two tests into one.
+
+    The second test's docstring is left as a bare string statement, so the body keeps
+    running as the tail of the first test: unnamed, unreported, and skipped entirely
+    once an earlier assertion fails. Ruff has no rule for this; B018 exempts strings.
+    """
+    offenders = []
+    for path in sorted(_TESTS_DIR.rglob("test_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for name, lineno in _orphaned_docstrings(tree):
+            offenders.append(f"{path.relative_to(_TESTS_DIR)}:{lineno} in {name}")
+
+    assert not offenders, "Bare string statement inside a test function, likely a lost `def` header:\n" + "\n".join(
+        offenders
+    )


### PR DESCRIPTION
Closes #106

## What

The README documented only the `uv sync` + clone workflow, so the container image published at `ghcr.io/marcinpsk/device-type-library-import` was effectively invisible to anyone reading the project page.

- Add a chooser table at the top of the README naming the two supported ways to run the tool (container image, Git clone), each linking to its own section.
- Add a **Run with Docker** section: pull command, tag table, quick start, volume for the library clone, argument passing, a Compose file, how to reach a NetBox instance from the container, and notes on `--env-file` parsing, custom CA bundles, and the `--verify-images` hash cache.
- State explicitly that the project is not published to PyPI, so `pip install` will not get it.
- Move the direnv warning out of the top of the file into the clone section, where it applies.
- Document `VENDORS` and `SLUGS` in the environment-variable table; they were already supported but undocumented, and they are the natural way to filter an import when running the image with its default command.

## Why the code changes

Verifying the Docker instructions against the published image turned up two defects in exactly the flow the new docs describe.

**1. A mounted volume at `/app/repo` failed on the first run.**

`DTLRepo.__init__` treated any existing directory at `REPO_PATH` as an existing clone and called `pull_repo()`. Docker always creates the mount point before the container starts, so the directory exists and is empty on the first run. GitPython then raised `InvalidGitRepositoryError`, surfaced as:

```
Package devicetype-library is already installed, updating /app/repo
An unknown error occurred: "Git Repository Error"
```

Fixed by testing for a `.git` directory rather than the directory itself. This also affects non-Docker users who pre-create `REPO_PATH`.

**2. A named volume was created root-owned.**

`/app/repo` did not exist in the image, so Docker initialised a named volume mounted there with root ownership. The container runs as `appuser` (UID 1000), and `validate_repo_path` correctly rejected it:

```
Invalid repository path "/app/repo".
```

Fixed by creating the directory in the image before the `chown`, so a fresh named volume inherits `appuser` ownership.

## Testing

Two tests added to `tests/test_repo.py` in a class that overrides the global autouse git mock, so they drive real `git` against a real local repository and real temporary directories:

- `test_clones_into_existing_empty_directory` — the mounted-but-empty case.
- `test_pulls_when_target_is_an_existing_clone` — the second-run case, asserting a new upstream commit arrives.

Both fail against the unfixed code with the same `Git Repository Error` seen in the container, and pass after the fix. Full suite: 948 passed.

Every command in the new Docker section was run against a container built from this branch, using a `file://` source repository and a live NetBox 4.6 instance:

- default command with no volume, with a bind mount, and with a named volume
- first run clones, second run pulls
- appended arguments (`… image python -u nb-dt-import.py --vendors … `)
- `VENDORS` environment variable with the default command
- `docker compose run --rm`

## Follow-ups (not in this PR)

- The image sets no `ENTRYPOINT`, so passing a flag means repeating `python -u nb-dt-import.py`. An `ENTRYPOINT ["python", "-u", "nb-dt-import.py"]` with an empty `CMD` would let users append flags directly. It is a breaking change for anyone already using the current form, so it is left out here.
- `latest` and `main` both track the `main` branch, so merging republishes `latest` with the two volume fixes immediately, while `1.7.1` and the other semver tags keep the old behaviour until a release is cut. The README tells users to pin a version tag for automated runs, so a patch release after merge would close that gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Empty or mounted directories can now be used as clone destinations.
  - Docker supports flexible importer flags, legacy invocations, and custom commands.
  - Added environment-based slug configuration for imports.

- **Bug Fixes**
  - Existing Git repositories continue updating through the pull workflow.
  - Environment-provided slug filters no longer affect export-diff operations.
  - Docker containers now support non-root execution with writable repository volumes.
  - Exports now report a clear error when the repository library is missing.

- **Documentation**
  - Reorganized Docker and source-clone setup guidance.
  - Added publishing, Compose, networking, environment-variable, image-building, and export-mode documentation.
  - Documented all available command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Also in this PR

`--export-diff`, `--export-diff-dir`, and `--force-export-overwrite` were in the CLI but absent from the README. Added as table rows plus an **Export Mode** section covering the direction of the flow, the default `extra/` target, overwrite behaviour, and the import-only flags that are rejected rather than ignored. Each exclusion was checked against the CLI: `--update`, `--only-new`, `--remove-components`, `--remove-unmanaged-types`, `--slugs`, `--verify-images`, and `--force-resolve-conflicts` all exit with an error, while `--vendors` is accepted and narrows the export.

The `host.docker.internal` guidance was also corrected after testing on a Linux host: without `--add-host` the name does not resolve at all, and with it the name resolves to the bridge gateway, so a NetBox bound only to `127.0.0.1` refuses the connection. `--network host` is now the recommendation, with both constraints stated.
