### PR TITLE
fix: report the NetBox response body on GraphQL HTTP errors and retry 500

### DIFF
--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -143,6 +143,29 @@ COMPONENT_TEMPLATE_FIELDS = {
 # in the query to correctly cache module bays owned by module types.
 _NO_MODULE_TYPE = {"device_bay_templates"}
 
+# NetBox returns the real cause (a database error, a plugin traceback) in the response body,
+# so it is worth reporting. Django error pages can be large, hence the cap.
+_MAX_ERROR_BODY_CHARS = 1000
+
+# 500 is included because NetBox returns it while its database is restarting or out of
+# connections, which is transient during a long paginated run.
+_RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
+
+
+def _response_body_detail(response):
+    """Return the response body as a suffix for an error message, truncated and stripped."""
+    if response is None:
+        return ""
+    try:
+        body = response.text.strip()
+    except Exception:  # pragma: no cover - a body that cannot be decoded is not worth failing on
+        return ""
+    if not body:
+        return ""
+    if len(body) > _MAX_ERROR_BODY_CHARS:
+        body = f"{body[:_MAX_ERROR_BODY_CHARS]}… (truncated)"
+    return f"\nResponse body: {body}"
+
 
 class NetBoxGraphQLClient:
     """Client for querying NetBox via its GraphQL API.
@@ -237,18 +260,20 @@ class NetBoxGraphQLClient:
                 body = response.json()
             except requests.exceptions.HTTPError as exc:
                 status = exc.response.status_code if exc.response is not None else None
+                detail = _response_body_detail(exc.response)
                 if status == 403:
                     raise GraphQLError(
                         f"403 Forbidden from {self.graphql_url}\n"
                         "Hint: Verify that your API token has the required permissions "
                         "and that GraphQL is enabled in the NetBox configuration."
+                        f"{detail}"
                     ) from exc
-                if status in {429, 502, 503, 504} and attempt < _retries:
+                if status in _RETRYABLE_STATUSES and attempt < _retries:
                     backoff = 2**attempt
                     time.sleep(backoff)
                     continue
-                # Non-transient HTTP errors are not retried.
-                raise GraphQLError(str(exc)) from exc
+                # Non-transient HTTP errors, and retryable ones that ran out of attempts.
+                raise GraphQLError(f"{exc}{detail}") from exc
             except requests.RequestException as exc:
                 if attempt < _retries:
                     backoff = 2**attempt

--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -294,7 +294,13 @@ class NetBoxGraphQLClient:
                 raise GraphQLError(f"Invalid JSON response from NetBox GraphQL endpoint: {exc}") from exc
 
             if "errors" in body:
-                messages = "; ".join(e.get("message", str(e)) for e in body["errors"])
+                errors = body["errors"]
+                messages = "; ".join(e.get("message", str(e)) for e in errors)
+                # An execution error carries the response path of the field whose resolver
+                # failed, and arrives with partial data. The schema was fine, so it must not
+                # look like an unsupported field to callers that downgrade their query.
+                if any(isinstance(e, dict) and "path" in e for e in errors):
+                    raise GraphQLError(messages)
                 raise GraphQLSchemaError(messages)
 
             return body.get("data", {})
@@ -623,10 +629,10 @@ class NetBoxGraphQLClient:
         """
         try:
             items = self.query_all(query, list_key="image_attachment_list")
-        except GraphQLError as e:
-            if isinstance(e, GraphQLCountMismatchError):
-                raise
-            # Fallback: fetch all attachments and filter in Python
+        except GraphQLSchemaError:
+            # Older NetBox rejects the ContentTypeFilter syntax: fetch all attachments and
+            # filter in Python. Only a schema rejection may trigger this, since the fallback
+            # scans every attachment in the install.
             fallback_query = """
             query($pagination: OffsetPaginationInput) {
               image_attachment_list(pagination: $pagination) {
@@ -684,9 +690,8 @@ class NetBoxGraphQLClient:
         """
         try:
             items = self.query_all(query, list_key="image_attachment_list")
-        except GraphQLError as e:
-            if isinstance(e, GraphQLCountMismatchError):
-                raise
+        except GraphQLSchemaError:
+            # Same fallback as get_module_type_images, restricted to schema rejections.
             fallback_query = """
             query($pagination: OffsetPaginationInput) {
               image_attachment_list(pagination: $pagination) {

--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -29,6 +29,16 @@ class GraphQLCountMismatchError(GraphQLError):
     """
 
 
+class GraphQLSchemaError(GraphQLError):
+    """Raised when NetBox answers 200 but rejects the query itself.
+
+    Only the server's schema can produce this, so it is the one failure that tells
+    a caller a field is unsupported.  Transport failures must stay a plain
+    :class:`GraphQLError`: they say nothing about the schema and retrying is the
+    right response.
+    """
+
+
 class DotDict(dict):
     """Dict subclass that supports attribute access, matching pynetbox Record patterns.
 
@@ -285,7 +295,7 @@ class NetBoxGraphQLClient:
 
             if "errors" in body:
                 messages = "; ".join(e.get("message", str(e)) for e in body["errors"])
-                raise GraphQLError(messages)
+                raise GraphQLSchemaError(messages)
 
             return body.get("data", {})
 
@@ -776,15 +786,16 @@ class NetBoxGraphQLClient:
         #   Tier 1: mappings { ... }       (NetBox 4.5+)
         #   Tier 2: rear_port_position     (<4.5 direct scalar field)
         #   Tier 3: neither                (future: field removed entirely)
+        # Only a schema rejection means the tier is unsupported. Transport failures
+        # propagate: falling back on those queries an older tier against a server that
+        # supports the newer one, silently dropping the mappings data.
         original_exc = last_exc = None
         for variant in field_variants:
             try:
                 return self.query_all(
                     _build_query(variant), list_key=list_key, on_page=on_page, variables=extra_variables
                 )
-            except GraphQLError as exc:
-                if isinstance(exc, GraphQLCountMismatchError):
-                    raise
+            except GraphQLSchemaError as exc:
                 last_exc = exc
                 if original_exc is None:
                     original_exc = exc

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -25,7 +25,12 @@ from core.compat import (
     module_type_filter_kwargs,
 )
 from core.formatting import log_property_diffs
-from core.graphql_client import GraphQLCountMismatchError, GraphQLError, NetBoxGraphQLClient
+from core.graphql_client import (
+    GraphQLCountMismatchError,
+    GraphQLError,
+    GraphQLSchemaError,
+    NetBoxGraphQLClient,
+)
 from core.normalization import values_equal
 from core.outcomes import EntityKind, Outcome, OutcomeRegistry
 from core.schema_reader import load_properties_for_type
@@ -2413,13 +2418,12 @@ class DeviceTypes:
                 vendor_dt_ids = {record.id for record in self.existing_device_types.values()}
                 vendor_mt_data = self.graphql.get_module_types(manufacturer_slugs=[manufacturer_slug])
                 vendor_mt_ids = {record.id for models in vendor_mt_data.values() for record in models.values()}
-            except Exception as exc:
+            except GraphQLSchemaError as exc:
+                # Only a rejected query shape may skip the guard; a failed request must not.
                 self.handle.log(f"WARNING: Component cache integrity check skipped: {exc}")
             else:
                 self._verify_component_cache_integrity(vendor_dt_ids, vendor_mt_ids)
-                # Count check is intentionally outside the warning try/except above:
-                # a mismatch means GraphQL silently truncated results and the import
-                # must not proceed with incomplete data.
+                # A mismatch means GraphQL truncated results, so let it propagate.
                 self._check_component_counts_against_rest(vendor_dt_ids, vendor_mt_ids)
 
         self._global_preload_done = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ testpaths = [
 norecursedirs = ["tests/integration"]
 markers = [
   "integration: end-to-end tests that require a live NetBox instance (set NETBOX_URL + NETBOX_TOKEN)",
+  "real_http: drives a local HTTP server, so the GraphQL session mock is not applied",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,8 +64,10 @@ def mock_graphql_requests(request):
     Patches ``requests.Session`` in ``core.graphql_client`` so any client created
     during a test uses a mock session.  Returns empty lists for all GraphQL
     list queries by default.
+
+    Tests marked ``real_http`` drive a local server instead and get no patching.
     """
-    if request.node.get_closest_marker("integration"):
+    if request.node.get_closest_marker("integration") or request.node.get_closest_marker("real_http"):
         yield None
         return
     with patch("core.graphql_client.requests.Session") as MockSession:
@@ -83,6 +85,13 @@ def mock_graphql_requests(request):
         }
         mock_session.post.return_value = response
         yield mock_session.post
+
+
+@pytest.fixture
+def no_retry_backoff():
+    """Drop the client's 1+2+4s retry back-off, leaving the retry count and error type intact."""
+    with patch("core.graphql_client.time.sleep"):
+        yield
 
 
 @pytest.fixture

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -2540,6 +2540,53 @@ class TestErrorHandlingStandards:
             if isinstance(node, ast.ExceptHandler) and node.type is not None:
                 yield node, names
 
+    @staticmethod
+    def _terminates(handler):
+        """Report whether the handler cannot fall through to the code after it."""
+        last = handler.body[-1]
+        if isinstance(last, (ast.Raise, ast.Return)):
+            return True
+        call = last.value if isinstance(last, ast.Expr) else None
+        if not isinstance(call, ast.Call):
+            return False
+        # Bare `system_exit(...)`/`exit(...)`, or a qualified `sys.exit(...)`/`os._exit(...)`.
+        if isinstance(call.func, ast.Name):
+            return call.func.id in {"system_exit", "exit", "quit"}
+        return isinstance(call.func, ast.Attribute) and call.func.attr in {"exit", "_exit"}
+
+    def test_the_guard_sees_every_terminating_handler(self):
+        """A handler that raises, returns or exits does not fall through, however it is spelled."""
+        source = textwrap.dedent(
+            """
+            try:
+                a()
+            except E:
+                raise
+            try:
+                b()
+            except E:
+                return None
+            try:
+                c()
+            except E:
+                system_exit("boom")
+            try:
+                d()
+            except E:
+                sys.exit(1)
+            try:
+                e()
+            except E:
+                os._exit(1)
+            try:
+                f()
+            except E:
+                log("carrying on")
+            """
+        )
+        handlers = [n for n in ast.walk(ast.parse(source)) if isinstance(n, ast.ExceptHandler)]
+        assert [self._terminates(h) for h in handlers] == [True, True, True, True, True, False]
+
     def test_the_guard_sees_aliased_and_qualified_catches(self):
         """An import alias or a module-qualified name must not defeat the two guards below."""
         source = textwrap.dedent(
@@ -2592,22 +2639,12 @@ class TestErrorHandlingStandards:
         """
         import core.netbox_api
 
-        def _terminates(handler):
-            """Report whether the handler cannot fall through to the code after it."""
-            last = handler.body[-1]
-            if isinstance(last, ast.Raise):
-                return True
-            call = last.value if isinstance(last, ast.Expr) else None
-            return (
-                isinstance(call, ast.Call)
-                and isinstance(call.func, ast.Name)
-                and call.func.id in {"system_exit", "exit"}
-            )
-
         source = pathlib.Path(core.netbox_api.__file__).read_text(encoding="utf-8")
         tree = ast.parse(source)
         offenders = [
-            h.lineno for h, names in self._handlers(tree) if self._catches_base_error(h, names) and not _terminates(h)
+            h.lineno
+            for h, names in self._handlers(tree)
+            if self._catches_base_error(h, names) and not self._terminates(h)
         ]
 
         assert not offenders, (

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -2313,3 +2313,82 @@ class TestHTTPErrorReporting:
 
         assert "ProgrammingError: relation does not exist" in str(excinfo.value)
         assert len(calls) == 2
+
+
+class TestComponentFallbackClassification:
+    """The front_port_templates tier fallback must react to schema errors, not to transport failures."""
+
+    EMPTY_PAGE = '{"data": {"front_port_template_list": []}}'
+    SCHEMA_ERROR = '{"errors": [{"message": "Cannot query field \'mappings\' on type \'FrontPortTemplateType\'."}]}'
+
+    @pytest.fixture(autouse=True)
+    def mock_graphql_requests(self):
+        """Override the global session mock so these tests drive a real HTTP server."""
+        yield None
+
+    @staticmethod
+    def _serve(reply_for_tier):
+        """Serve front-port queries, dispatching on which field tier the query uses.
+
+        *reply_for_tier* maps "T1"/"T2"/"T3" to a body string, or to None meaning
+        "close the connection without responding" (a transport failure).  Returns
+        (url, server, attempts) where *attempts* records the tier of each request.
+        """
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        attempts = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                raw = self.rfile.read(int(self.headers.get("Content-Length", 0))).decode()
+                if "mappings {" in raw:
+                    tier = "T1"
+                elif "rear_port_position" in raw:
+                    tier = "T2"
+                else:
+                    tier = "T3"
+                attempts.append(tier)
+
+                body = reply_for_tier.get(tier)
+                if body is None:
+                    self.close_connection = True
+                    return
+                payload = body.encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *args):
+                """Silence the default stderr access log."""
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return f"http://127.0.0.1:{server.server_port}", server, attempts
+
+    def test_transport_failure_does_not_fall_back_to_older_field_tiers(self):
+        """A dropped connection means "try again", not "this NetBox lacks mappings"."""
+        from core.graphql_client import GraphQLError
+
+        url, server, attempts = self._serve({"T1": None, "T2": self.EMPTY_PAGE, "T3": self.EMPTY_PAGE})
+        try:
+            client = NetBoxGraphQLClient(url, "token", page_size=10)
+            with pytest.raises(GraphQLError):
+                client.get_component_templates("front_port_templates")
+        finally:
+            server.shutdown()
+
+        assert set(attempts) == {"T1"}, f"transport failure triggered a schema fallback: {attempts}"
+
+    def test_schema_error_still_falls_back_to_the_older_field_tier(self):
+        url, server, attempts = self._serve({"T1": self.SCHEMA_ERROR, "T2": self.EMPTY_PAGE})
+        try:
+            client = NetBoxGraphQLClient(url, "token", page_size=10)
+            result = client.get_component_templates("front_port_templates")
+        finally:
+            server.shutdown()
+
+        assert result == []
+        assert "T1" in attempts and "T2" in attempts

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -2198,3 +2198,102 @@ class TestErrorHierarchy:
 
         with pytest.raises(GraphQLError):
             raise GraphQLCountMismatchError("page cap exceeded")
+
+
+class TestHTTPErrorReporting:
+    """HTTP failures are reported against a real server, so the response body is real too."""
+
+    @pytest.fixture(autouse=True)
+    def mock_graphql_requests(self):
+        """Override the global session mock so these tests drive a real HTTP server."""
+        yield None
+
+    @staticmethod
+    def _serve(responses):
+        """Run a local HTTP server that replies with each (status, body) in *responses*.
+
+        The final entry repeats once the list is exhausted.  Returns (url, server, calls)
+        where *calls* is a mutable list recording how many requests arrived.
+        """
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        calls = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                index = min(len(calls), len(responses) - 1)
+                calls.append(index)
+                status, body = responses[index]
+                payload = body.encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *args):
+                """Silence the default stderr access log."""
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return f"http://127.0.0.1:{server.server_port}", server, calls
+
+    def _client(self, url):
+        return NetBoxGraphQLClient(url, "token", page_size=10)
+
+    def test_server_error_reports_the_response_body(self):
+        from core.graphql_client import GraphQLError
+
+        url, server, _ = self._serve([(500, "IntegrityError at /graphql/: connection lost")])
+        try:
+            client = self._client(url)
+            with pytest.raises(GraphQLError) as excinfo:
+                client.query("{ manufacturer_list { id } }", _retries=0)
+        finally:
+            server.shutdown()
+
+        assert "IntegrityError at /graphql/: connection lost" in str(excinfo.value)
+
+    def test_server_error_body_is_truncated(self):
+        from core.graphql_client import GraphQLError
+
+        url, server, _ = self._serve([(500, "E" * 5000)])
+        try:
+            client = self._client(url)
+            with pytest.raises(GraphQLError) as excinfo:
+                client.query("{ manufacturer_list { id } }", _retries=0)
+        finally:
+            server.shutdown()
+
+        message = str(excinfo.value)
+        assert "truncated" in message
+        assert len(message) < 2000
+
+    def test_transient_server_error_is_retried(self):
+        """A NetBox 500 during a database restart must not abort a long run."""
+        url, server, calls = self._serve(
+            [(500, "database is starting up"), (200, '{"data": {"manufacturer_list": []}}')]
+        )
+        try:
+            client = self._client(url)
+            result = client.query("{ manufacturer_list { id } }")
+        finally:
+            server.shutdown()
+
+        assert result == {"manufacturer_list": []}
+        assert len(calls) == 2
+
+    def test_persistent_server_error_still_reports_the_body(self):
+        from core.graphql_client import GraphQLError
+
+        url, server, calls = self._serve([(500, "ProgrammingError: relation does not exist")])
+        try:
+            client = self._client(url)
+            with pytest.raises(GraphQLError) as excinfo:
+                client.query("{ manufacturer_list { id } }", _retries=1)
+        finally:
+            server.shutdown()
+
+        assert "ProgrammingError: relation does not exist" in str(excinfo.value)
+        assert len(calls) == 2

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -2268,7 +2268,23 @@ class TestHTTPErrorReporting:
 
         message = str(excinfo.value)
         assert "truncated" in message
-        assert len(message) < 2000
+        assert "E" * 1000 in message
+        assert "E" * 1001 not in message
+
+    def test_forbidden_error_reports_both_the_hint_and_the_body(self):
+        from core.graphql_client import GraphQLError
+
+        url, server, _ = self._serve([(403, "GraphQL access is disabled")])
+        try:
+            client = self._client(url)
+            with pytest.raises(GraphQLError) as excinfo:
+                client.query("{ manufacturer_list { id } }", _retries=0)
+        finally:
+            server.shutdown()
+
+        message = str(excinfo.value)
+        assert "Verify that your API token has the required permissions" in message
+        assert "GraphQL access is disabled" in message
 
     def test_transient_server_error_is_retried(self):
         """A NetBox 500 during a database restart must not abort a long run."""

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -2519,3 +2519,42 @@ class TestErrorHandlingStandards:
             "execution failures, which silently downgrades the query and returns "
             "incomplete data."
         )
+
+    def test_consumers_never_continue_after_catching_the_base_graphql_error(self):
+        """A consumer may catch GraphQLError to fail loudly, never to carry on.
+
+        netbox_api skipped the cache truncation guard whenever the vendor id fetch failed,
+        so a dropped connection turned into an unguarded import.
+        """
+        import ast
+        import pathlib
+
+        import core.netbox_api
+
+        def _terminates(handler):
+            """Report whether the handler cannot fall through to the code after it."""
+            last = handler.body[-1]
+            if isinstance(last, ast.Raise):
+                return True
+            call = last.value if isinstance(last, ast.Expr) else None
+            return (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id in {"system_exit", "exit"}
+            )
+
+        source = pathlib.Path(core.netbox_api.__file__).read_text(encoding="utf-8")
+        offenders = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.ExceptHandler) or node.type is None:
+                continue
+            caught = node.type.elts if isinstance(node.type, ast.Tuple) else [node.type]
+            if any(isinstance(c, ast.Name) and c.id == "GraphQLError" for c in caught) and not _terminates(node):
+                offenders.append(node.lineno)
+
+        assert not offenders, (
+            f"core/netbox_api.py catches GraphQLError and continues at line(s) {offenders}. "
+            "A failed request is not evidence about the data: catch GraphQLSchemaError to "
+            "react to a rejected query shape, or let the error propagate. Continuing turns a "
+            "transport failure into a disabled correctness guard."
+        )

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -1,5 +1,9 @@
 """Tests for the NetBox GraphQL client module (TDD - tests written first)."""
 
+import ast
+import pathlib
+import textwrap
+
 import pytest
 from unittest.mock import MagicMock
 import requests
@@ -2328,6 +2332,14 @@ class TestComponentFallbackClassification:
         """Override the global session mock so these tests drive a real HTTP server."""
         yield None
 
+    @pytest.fixture(autouse=True)
+    def no_retry_backoff(self):
+        """Drop the 1+2+4s production back-off; the retry count and error type are unchanged."""
+        from unittest.mock import patch
+
+        with patch("core.graphql_client.time.sleep"):
+            yield
+
     @staticmethod
     def _serve(reply_for_tier):
         """Serve front-port queries, dispatching on which field tier the query uses.
@@ -2428,6 +2440,14 @@ class TestImageAttachmentFallbackClassification:
         """Override the global session mock so these tests drive a real HTTP server."""
         yield None
 
+    @pytest.fixture(autouse=True)
+    def no_retry_backoff(self):
+        """Drop the 1+2+4s production back-off; the retry count and error type are unchanged."""
+        from unittest.mock import patch
+
+        with patch("core.graphql_client.time.sleep"):
+            yield
+
     @classmethod
     def _serve(cls, filtered_body, unfiltered_body):
         """Serve the filtered and unfiltered attachment queries, recording which arrived.
@@ -2492,25 +2512,69 @@ class TestImageAttachmentFallbackClassification:
 class TestErrorHandlingStandards:
     """Guard the defect class where a broad catch turns a failure into a silent downgrade."""
 
+    BASE_ERROR = "GraphQLError"
+
+    @classmethod
+    def _local_names_for_base_error(cls, tree):
+        """Return every local name bound to the base error, following import aliases."""
+        names = {cls.BASE_ERROR}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                names.update(a.asname for a in node.names if a.name == cls.BASE_ERROR and a.asname)
+        return names
+
+    @classmethod
+    def _catches_base_error(cls, handler, names):
+        """Report whether *handler* catches the base error, aliased or module-qualified."""
+        caught = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+        return any(
+            (isinstance(c, ast.Name) and c.id in names) or (isinstance(c, ast.Attribute) and c.attr == cls.BASE_ERROR)
+            for c in caught
+        )
+
+    @classmethod
+    def _handlers(cls, tree):
+        """Yield (handler, names) for every except clause that names an exception type."""
+        names = cls._local_names_for_base_error(tree)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler) and node.type is not None:
+                yield node, names
+
+    def test_the_guard_sees_aliased_and_qualified_catches(self):
+        """An import alias or a module-qualified name must not defeat the two guards below."""
+        source = textwrap.dedent(
+            """
+            from core.graphql_client import GraphQLError as GQLError
+            from core import graphql_client
+
+            try:
+                a()
+            except GQLError:
+                pass
+            try:
+                b()
+            except graphql_client.GraphQLError:
+                pass
+            try:
+                c()
+            except graphql_client.GraphQLSchemaError:
+                pass
+            """
+        )
+        tree = ast.parse(source)
+        assert [self._catches_base_error(h, n) for h, n in self._handlers(tree)] == [True, True, False]
+
     def test_client_never_catches_the_base_graphql_error(self):
         """Three separate fallbacks caught GraphQLError and downgraded the query on any failure.
 
         Only GraphQLSchemaError says the server rejected the query. The base class also
         covers transport and execution failures, where downgrading returns incomplete data.
         """
-        import ast
-        import pathlib
-
         import core.graphql_client
 
         source = pathlib.Path(core.graphql_client.__file__).read_text(encoding="utf-8")
-        offenders = []
-        for node in ast.walk(ast.parse(source)):
-            if not isinstance(node, ast.ExceptHandler) or node.type is None:
-                continue
-            caught = node.type.elts if isinstance(node.type, ast.Tuple) else [node.type]
-            if any(isinstance(c, ast.Name) and c.id == "GraphQLError" for c in caught):
-                offenders.append(node.lineno)
+        tree = ast.parse(source)
+        offenders = [h.lineno for h, names in self._handlers(tree) if self._catches_base_error(h, names)]
 
         assert not offenders, (
             f"core/graphql_client.py catches GraphQLError at line(s) {offenders}. "
@@ -2526,9 +2590,6 @@ class TestErrorHandlingStandards:
         netbox_api skipped the cache truncation guard whenever the vendor id fetch failed,
         so a dropped connection turned into an unguarded import.
         """
-        import ast
-        import pathlib
-
         import core.netbox_api
 
         def _terminates(handler):
@@ -2544,13 +2605,10 @@ class TestErrorHandlingStandards:
             )
 
         source = pathlib.Path(core.netbox_api.__file__).read_text(encoding="utf-8")
-        offenders = []
-        for node in ast.walk(ast.parse(source)):
-            if not isinstance(node, ast.ExceptHandler) or node.type is None:
-                continue
-            caught = node.type.elts if isinstance(node.type, ast.Tuple) else [node.type]
-            if any(isinstance(c, ast.Name) and c.id == "GraphQLError" for c in caught) and not _terminates(node):
-                offenders.append(node.lineno)
+        tree = ast.parse(source)
+        offenders = [
+            h.lineno for h, names in self._handlers(tree) if self._catches_base_error(h, names) and not _terminates(h)
+        ]
 
         assert not offenders, (
             f"core/netbox_api.py catches GraphQLError and continues at line(s) {offenders}. "

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -891,11 +891,13 @@ class TestGetModuleTypeImageDetails:
         assert result[43]["detail"] == {"att_id": 3, "url": "http://example.com/detail.jpg"}
 
     def test_fallback_on_graphql_error(self, mocker):
-        """When filtered query fails, falls back to fetch-all + Python filter by object_type."""
-        from core.graphql_client import GraphQLError
+        """When NetBox rejects the filter syntax, falls back to fetch-all + Python filter by object_type."""
+        from core.graphql_client import GraphQLSchemaError
 
         client = self._make_client()
-        error = GraphQLError("Field 'filters' not found")
+        # A rejected filter argument reaches this path as GraphQLSchemaError; a transport
+        # failure stays a plain GraphQLError and must not reach the fallback.
+        error = GraphQLSchemaError("Field 'filters' not found")
 
         fallback_items = [
             {
@@ -2382,6 +2384,26 @@ class TestComponentFallbackClassification:
 
         assert set(attempts) == {"T1"}, f"transport failure triggered a schema fallback: {attempts}"
 
+    def test_resolver_failure_does_not_fall_back_to_older_field_tiers(self):
+        """An execution error carries a path and partial data; the schema is fine, so do not downgrade."""
+        from core.graphql_client import GraphQLError, GraphQLSchemaError
+
+        resolver_failure = (
+            '{"data": {"front_port_template_list": [{"name": "FP1", "mappings": null}]}, '
+            '"errors": [{"message": "Resolver failed", '
+            '"path": ["front_port_template_list", 0, "mappings"]}]}'
+        )
+        url, server, attempts = self._serve({"T1": resolver_failure, "T2": self.EMPTY_PAGE})
+        try:
+            client = NetBoxGraphQLClient(url, "token", page_size=10)
+            with pytest.raises(GraphQLError) as excinfo:
+                client.get_component_templates("front_port_templates")
+        finally:
+            server.shutdown()
+
+        assert set(attempts) == {"T1"}, f"resolver failure triggered a schema fallback: {attempts}"
+        assert not isinstance(excinfo.value, GraphQLSchemaError)
+
     def test_schema_error_still_falls_back_to_the_older_field_tier(self):
         url, server, attempts = self._serve({"T1": self.SCHEMA_ERROR, "T2": self.EMPTY_PAGE})
         try:
@@ -2392,3 +2414,76 @@ class TestComponentFallbackClassification:
 
         assert result == []
         assert "T1" in attempts and "T2" in attempts
+
+
+class TestImageAttachmentFallbackClassification:
+    """The image-attachment filter fallback must react to schema errors, not to transport failures."""
+
+    FILTERED_MARKER = "filters:"
+    EMPTY_PAGE = '{"data": {"image_attachment_list": []}}'
+    SCHEMA_ERROR = '{"errors": [{"message": "Unknown argument \'filters\' on field \'image_attachment_list\'."}]}'
+
+    @pytest.fixture(autouse=True)
+    def mock_graphql_requests(self):
+        """Override the global session mock so these tests drive a real HTTP server."""
+        yield None
+
+    @classmethod
+    def _serve(cls, filtered_body, unfiltered_body):
+        """Serve the filtered and unfiltered attachment queries, recording which arrived.
+
+        A body of None means "close the connection without responding".
+        """
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        attempts = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                raw = self.rfile.read(int(self.headers.get("Content-Length", 0))).decode()
+                kind = "filtered" if cls.FILTERED_MARKER in raw else "unfiltered"
+                attempts.append(kind)
+                body = filtered_body if kind == "filtered" else unfiltered_body
+                if body is None:
+                    self.close_connection = True
+                    return
+                payload = body.encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def log_message(self, *args):
+                """Silence the default stderr access log."""
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return f"http://127.0.0.1:{server.server_port}", server, attempts
+
+    @pytest.mark.parametrize("method", ["get_module_type_images", "get_module_type_image_details"])
+    def test_transport_failure_does_not_trigger_the_unfiltered_fallback(self, method):
+        """Falling back on a dropped connection replaces one filtered query with a whole-table scan."""
+        from core.graphql_client import GraphQLError
+
+        url, server, attempts = self._serve(None, self.EMPTY_PAGE)
+        try:
+            client = NetBoxGraphQLClient(url, "token", page_size=10)
+            with pytest.raises(GraphQLError):
+                getattr(client, method)()
+        finally:
+            server.shutdown()
+
+        assert set(attempts) == {"filtered"}, f"transport failure triggered the unfiltered fallback: {attempts}"
+
+    @pytest.mark.parametrize("method", ["get_module_type_images", "get_module_type_image_details"])
+    def test_schema_error_still_triggers_the_unfiltered_fallback(self, method):
+        url, server, attempts = self._serve(self.SCHEMA_ERROR, self.EMPTY_PAGE)
+        try:
+            client = NetBoxGraphQLClient(url, "token", page_size=10)
+            getattr(client, method)()
+        finally:
+            server.shutdown()
+
+        assert "filtered" in attempts and "unfiltered" in attempts

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -2206,13 +2206,9 @@ class TestErrorHierarchy:
             raise GraphQLCountMismatchError("page cap exceeded")
 
 
+@pytest.mark.real_http
 class TestHTTPErrorReporting:
     """HTTP failures are reported against a real server, so the response body is real too."""
-
-    @pytest.fixture(autouse=True)
-    def mock_graphql_requests(self):
-        """Override the global session mock so these tests drive a real HTTP server."""
-        yield None
 
     @staticmethod
     def _serve(responses):
@@ -2321,24 +2317,13 @@ class TestHTTPErrorReporting:
         assert len(calls) == 2
 
 
+@pytest.mark.real_http
+@pytest.mark.usefixtures("no_retry_backoff")
 class TestComponentFallbackClassification:
     """The front_port_templates tier fallback must react to schema errors, not to transport failures."""
 
     EMPTY_PAGE = '{"data": {"front_port_template_list": []}}'
     SCHEMA_ERROR = '{"errors": [{"message": "Cannot query field \'mappings\' on type \'FrontPortTemplateType\'."}]}'
-
-    @pytest.fixture(autouse=True)
-    def mock_graphql_requests(self):
-        """Override the global session mock so these tests drive a real HTTP server."""
-        yield None
-
-    @pytest.fixture(autouse=True)
-    def no_retry_backoff(self):
-        """Drop the 1+2+4s production back-off; the retry count and error type are unchanged."""
-        from unittest.mock import patch
-
-        with patch("core.graphql_client.time.sleep"):
-            yield
 
     @staticmethod
     def _serve(reply_for_tier):
@@ -2428,25 +2413,14 @@ class TestComponentFallbackClassification:
         assert "T1" in attempts and "T2" in attempts
 
 
+@pytest.mark.real_http
+@pytest.mark.usefixtures("no_retry_backoff")
 class TestImageAttachmentFallbackClassification:
     """The image-attachment filter fallback must react to schema errors, not to transport failures."""
 
     FILTERED_MARKER = "filters:"
     EMPTY_PAGE = '{"data": {"image_attachment_list": []}}'
     SCHEMA_ERROR = '{"errors": [{"message": "Unknown argument \'filters\' on field \'image_attachment_list\'."}]}'
-
-    @pytest.fixture(autouse=True)
-    def mock_graphql_requests(self):
-        """Override the global session mock so these tests drive a real HTTP server."""
-        yield None
-
-    @pytest.fixture(autouse=True)
-    def no_retry_backoff(self):
-        """Drop the 1+2+4s production back-off; the retry count and error type are unchanged."""
-        from unittest.mock import patch
-
-        with patch("core.graphql_client.time.sleep"):
-            yield
 
     @classmethod
     def _serve(cls, filtered_body, unfiltered_body):

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -2487,3 +2487,35 @@ class TestImageAttachmentFallbackClassification:
             server.shutdown()
 
         assert "filtered" in attempts and "unfiltered" in attempts
+
+
+class TestErrorHandlingStandards:
+    """Guard the defect class where a broad catch turns a failure into a silent downgrade."""
+
+    def test_client_never_catches_the_base_graphql_error(self):
+        """Three separate fallbacks caught GraphQLError and downgraded the query on any failure.
+
+        Only GraphQLSchemaError says the server rejected the query. The base class also
+        covers transport and execution failures, where downgrading returns incomplete data.
+        """
+        import ast
+        import pathlib
+
+        import core.graphql_client
+
+        source = pathlib.Path(core.graphql_client.__file__).read_text(encoding="utf-8")
+        offenders = []
+        for node in ast.walk(ast.parse(source)):
+            if not isinstance(node, ast.ExceptHandler) or node.type is None:
+                continue
+            caught = node.type.elts if isinstance(node.type, ast.Tuple) else [node.type]
+            if any(isinstance(c, ast.Name) and c.id == "GraphQLError" for c in caught):
+                offenders.append(node.lineno)
+
+        assert not offenders, (
+            f"core/graphql_client.py catches GraphQLError at line(s) {offenders}. "
+            "Catch GraphQLSchemaError to react to a rejected query, or let the error "
+            "propagate to the retry. Catching the base class also swallows transport and "
+            "execution failures, which silently downgrades the query and returns "
+            "incomplete data."
+        )

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -8355,17 +8355,13 @@ class TestImageUploadErrorDetail:
         assert "FORGED" in logged
 
 
+@pytest.mark.real_http
 class TestPreloadIntegrityGuard:
     """The cache truncation guard must survive a transport failure.
 
     Driven against a real HTTP server so the failure, the retry policy and the raised
     exception type are the production ones.
     """
-
-    @pytest.fixture(autouse=True)
-    def mock_graphql_requests(self):
-        """Override the global session mock so these tests drive a real HTTP server."""
-        yield None
 
     @staticmethod
     def _serve(module_type_response):

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -6603,12 +6603,12 @@ class TestVerifyComponentCacheIntegrity:
 
 
 class TestPreloadAllComponentsIntegrityCheckError:
-    """preload_all_components skips integrity check gracefully when get_module_types raises."""
+    """preload_all_components skips the integrity check only for a rejected query shape."""
 
-    def test_get_module_types_raises_does_not_propagate(
+    def test_get_module_types_transport_error_propagates(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types
     ):
-        """When get_module_types raises, no exception propagates and _global_preload_done is True."""
+        """Any failure other than a schema rejection must reach the caller, guard unfinished."""
         from unittest.mock import patch as _patch
 
         mock_nb_api = mock_pynetbox.api.return_value
@@ -6616,14 +6616,10 @@ class TestPreloadAllComponentsIntegrityCheckError:
 
         with _patch.object(dt, "_preload_global"):
             with _patch.object(dt.graphql, "get_module_types", side_effect=RuntimeError("network error")):
-                # Should not raise
-                dt.preload_all_components(manufacturer_slug="cisco")
+                with pytest.raises(RuntimeError, match="network error"):
+                    dt.preload_all_components(manufacturer_slug="cisco")
 
-        assert dt._global_preload_done is True
-        # Warning was logged
-        dt.handle.log.assert_called()
-        warning_call = dt.handle.log.call_args_list[-1][0][0]
-        assert "WARNING" in warning_call
+        assert dt._global_preload_done is False
 
 
 # ---------------------------------------------------------------------------
@@ -8357,3 +8353,86 @@ class TestImageUploadErrorDetail:
         # The text is still reported, just neutralised.
         assert "\\r\\n" in logged
         assert "FORGED" in logged
+
+
+class TestPreloadIntegrityGuard:
+    """The cache truncation guard must survive a transport failure.
+
+    Driven against a real HTTP server so the failure, the retry policy and the raised
+    exception type are the production ones.
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_graphql_requests(self):
+        """Override the global session mock so these tests drive a real HTTP server."""
+        yield None
+
+    @staticmethod
+    def _serve(module_type_response):
+        """Answer component queries with empty lists and the module-type query with *module_type_response*."""
+        import json as _json
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                body = self.rfile.read(int(self.headers.get("Content-Length", 0))).decode()
+                if "module_type_list" in body:
+                    status, payload = module_type_response
+                else:
+                    key = next((k for k in _ALL_COMPONENT_KEYS if k in body), "unknown_list")
+                    status, payload = 200, _json.dumps({"data": {key: []}})
+                encoded = payload.encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+
+            def log_message(self, *args):
+                """Silence the default stderr access log."""
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        return f"http://127.0.0.1:{server.server_port}", server
+
+    @staticmethod
+    def _device_types(url, handle):
+        from core.graphql_client import NetBoxGraphQLClient
+
+        return DeviceTypes(
+            MagicMock(),
+            handle,
+            MagicMock(),
+            False,
+            False,
+            graphql=NetBoxGraphQLClient(url, "token", page_size=10),
+            max_threads=2,
+        )
+
+    def test_transport_failure_does_not_skip_the_truncation_guard(self):
+        """A failed request must not silently disable the check that catches truncated results."""
+        from core.graphql_client import GraphQLError
+
+        url, server = self._serve((403, '{"detail": "forbidden"}'))
+        handle = MagicMock()
+        try:
+            device_types = self._device_types(url, handle)
+            with pytest.raises(GraphQLError):
+                device_types.preload_all_components(manufacturer_slug="acme")
+        finally:
+            server.shutdown()
+
+    def test_schema_rejection_skips_the_guard_with_a_warning(self):
+        """A server that cannot answer the query shape may skip the check, and says so."""
+        import json as _json
+
+        rejection = _json.dumps({"errors": [{"message": "Cannot query field 'weight' on type 'ModuleTypeType'."}]})
+        url, server = self._serve((200, rejection))
+        handle = MagicMock()
+        try:
+            device_types = self._device_types(url, handle)
+            device_types.preload_all_components(manufacturer_slug="acme")
+        finally:
+            server.shutdown()
+
+        logged = " ".join(str(call) for call in handle.log.call_args_list)
+        assert "integrity check skipped" in logged

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -8421,6 +8421,10 @@ class TestPreloadIntegrityGuard:
         finally:
             server.shutdown()
 
+        logged = " ".join(str(call) for call in handle.log.call_args_list)
+        assert "integrity check skipped" not in logged
+        assert device_types._global_preload_done is False
+
     def test_schema_rejection_skips_the_guard_with_a_warning(self):
         """A server that cannot answer the query shape may skip the check, and says so."""
         import json as _json


### PR DESCRIPTION
## What

A 500 from the NetBox GraphQL endpoint reported only this:

```
Error: NetBox GraphQL request failed — 500 Server Error: Internal Server Error for url: http://…/graphql/
This may be a temporary connectivity issue. Check that NetBox is reachable and try again.
```

`raise_for_status()` raises an `HTTPError` whose `str()` is just the status line, and `core/graphql_client.py` passed that straight to `GraphQLError`. The response body, which carries the actual cause, was dropped. This is the same gap `3aa7bc3` closed for image uploads.

Two changes:

- **Include the response body**, truncated to 1000 characters because Django error pages are large. Applied to the generic path and to the existing 403 hint.
- **Treat `500` as retryable** alongside `429/502/503/504`. NetBox returns 500 while its database is restarting or has run out of connections. That is transient, but it aborted a long paginated run that would otherwise have recovered.

## How it came up

A full `--export-diff` (330 vendors, ~2970 GraphQL requests) failed against a NetBox whose Postgres was restarting. The failure was intermittent in a way the error message could not explain: one run got four minutes in past the metadata phase, the next died on the first query. Narrowing it down needed a scratch script that monkeypatched `_session.post` purely to see the body NetBox was returning. That work belongs in the client.

With the retry change, that run survives the restart instead of aborting.

## Testing

Four tests in a new `TestHTTPErrorReporting` class, all confirmed red before the fix and green after:

| Test | Asserts |
| --- | --- |
| `test_server_error_reports_the_response_body` | the body text reaches the raised `GraphQLError` |
| `test_server_error_body_is_truncated` | a 5000-character body is capped and marked truncated |
| `test_transient_server_error_is_retried` | 500 then 200 succeeds, and exactly 2 requests are made |
| `test_persistent_server_error_still_reports_the_body` | retries are exhausted and the body is still reported |

They run a real `http.server` on localhost and drive the actual `requests` stack, rather than asserting against a mock.

That was necessary, not stylistic. The existing `test_query_raises_on_http_error` asserts against a `MagicMock` whose `.text` is never set, so it passes whether or not the body is reported: it cannot detect this bug. The test module also installs an autouse fixture that patches `core.graphql_client.requests.Session` for every test in the file, so no test there was reaching real HTTP at all. The new class overrides that fixture. My first attempt at these tests silently ran against the mock session and produced nonsense assertions until I found it.

The old mock-based test is left in place; it still covers the plain raise path.

Full suite: 950 passed.

## Note

Retrying a genuinely permanent 500 now costs about 7 seconds (three attempts, exponential back-off) before the same error surfaces, and the error is now more informative than before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP error messages with bounded response details.
  * Added retries for temporary server errors.
  * Preserved access-denied guidance alongside relevant response context.
  * Limited lengthy error details for clearer messages.
  * Restricted compatibility fallbacks to schema mismatch errors.
  * Ensured connection, transport, and resolver failures are reported directly.
  * Improved component-cache integrity handling when schema validation is unavailable.
  * Prevented non-schema failures from being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Second fix: the front-port tier fallback misread transport failures

Found while diagnosing the export failures that motivated the change above.

`_query_component_endpoint` tries three field shapes for `front_port_templates`, newest first, and treated **any** `GraphQLError` as "this tier is unsupported":

```python
except GraphQLError as exc:      # connection reset, timeout, HTTP 500 — all land here
    last_exc = exc               # …so try the older field shape
```

Every failure in this client raises `GraphQLError`, so a dropped connection on tier 1 downgraded the query to the pre-4.5 shape. Against a NetBox that *does* support `mappings`, the fallback then **succeeded** and returned front-port records with the mappings data missing. A transport blip became silently incomplete data rather than an error.

Two further effects, both observed:

- It tripled the request count for that endpoint at exactly the moment the server was already failing.
- It left `Cannot query field 'rear_port_position' on type 'FrontPortTemplateType'` in the NetBox log, pointing at a schema problem that does not exist. That log line is what put me onto this.

Only NetBox rejecting the query says anything about the schema. `GraphQLSchemaError` is now raised on the 200-with-errors path, and the tier loop catches that alone; transport failures propagate to the existing retry. The `GraphQLCountMismatchError` re-raise inside the loop is removed as redundant, since it is not a `GraphQLSchemaError`.

`GraphQLSchemaError` subclasses `GraphQLError`, so the two callers that catch `GraphQLError` (`nb-dt-import.py:1248`, `core/netbox_api.py:469`) are unaffected.

### Testing

Two tests against a local `http.server` that dispatches on which field tier the query uses and can drop the connection mid-request:

| Test | Asserts |
| --- | --- |
| `test_transport_failure_does_not_fall_back_to_older_field_tiers` | a dropped connection attempts tier 1 only, and raises |
| `test_schema_error_still_falls_back_to_the_older_field_tier` | a genuine `Cannot query field` still falls back and succeeds |

The first fails against the unfixed code by **not raising at all** — the old code fell back and returned tier 2's data, which is the silent-degradation bug itself.

Verified on a real NetBox 4.6.7 that tier 1 succeeds on an idle server (7/7 requests, HTTP 200, no fallback). That is what establishes the tier-2 error in its log could only have followed a tier-1 transport failure.

Full suite: 953 passed.
