### PR TITLE
ci: gate pull requests into develop

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,10 +10,12 @@ on:
     branches:
       - 'master'
       - 'main'
+  # develop is absent from push above on purpose: a push build publishes a :develop tag.
   pull_request:
     branches:
       - 'master'
       - 'main'
+      - 'develop'
   workflow_dispatch:
   release:
     types: [published, edited]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,10 +8,12 @@ on:
     branches:
       - 'master'
       - 'main'
+      - 'develop'
   pull_request:
     branches:
       - 'master'
       - 'main'
+      - 'develop'
 
 jobs:
   test:


### PR DESCRIPTION
Work now lands on `develop` first and reaches `main` as a single merge. Both gating workflows filtered `pull_request` on `master` and `main`, so a pull request into `develop` ran only the title check and the bot review, and nothing that executes the code.

| Workflow | Before, on a PR into develop | After |
| --- | --- | --- |
| `tests.yml` (3.12, 3.14) | not run | runs |
| `docker.yml` (smoke-test, build) | not run | runs |
| `pr-title.yml` | runs (no branch filter) | unchanged |

## Why the two differ

`tests.yml` takes `develop` on `push` as well, so a merge into `develop` is covered, not only the pull request that precedes it.

`docker.yml` takes it on `pull_request` only. The build step already skips publishing for pull requests (`push: ${{ github.event_name != 'pull_request' }}`), so a PR gets the smoke test and a build with no registry write. Adding `develop` to the `push` trigger instead would publish a `:develop` image on every merge through `type=ref,event=branch`, which the develop-to-main flow does not call for. The comment in the file records that the omission is deliberate.

Unchanged: `latest` stays bound to the default branch through the existing `endsWith(github.ref, ...default_branch)` guard, and `release.yml` still triggers on a push to `main` alone, so releases continue to come from `main`.

## Verification

This pull request is its own test. `pull_request` workflows are read from the head ref, so the checks below either run against `base: develop` or they do not, which is exactly the behaviour being changed.