### PR TITLE
refactor: give the component cache one owner and a small interface

### DIFF
--- a/core/change_detector.py
+++ b/core/change_detector.py
@@ -311,14 +311,12 @@ class ChangeDetector:
             List of ComponentChange objects for all differences
         """
         changes = []
-        cache_key = (parent_type, device_type_id)
 
         for yaml_key, (cache_name, properties) in COMPONENT_TYPES.items():
             yaml_components = list(yaml_data.get(yaml_key) or [])
 
-            # Get cached components for this device type
-            cached = self.device_types.cached_components.get(cache_name, {})
-            existing_components = cached.get(cache_key, {})
+            # entries(), not get(): detection must read the cache, never trigger a fetch.
+            existing_components = self.device_types.components.entries(cache_name, parent_type, device_type_id)
 
             # Build set of YAML component names for this type
             yaml_component_names = {comp.get("name") for comp in yaml_components if comp.get("name")}

--- a/core/component_cache.py
+++ b/core/component_cache.py
@@ -18,7 +18,11 @@ from core.compat import (
     module_type_filter_key,
     module_type_filter_kwargs,
 )
-from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError
+from core.graphql_client import (
+    GraphQLCountMismatchError,
+    GraphQLSchemaError,
+    _NO_MODULE_TYPE as NO_MODULE_TYPE_ENDPOINTS,
+)
 
 # Component endpoints fetched up front, with the label shown in the progress display.
 PRELOAD_TARGETS = (
@@ -53,9 +57,6 @@ ENDPOINT_CACHE_MAP = {
 # detection, and where REST provides them.  Add an endpoint here if a NetBox
 # version drops a field from GraphQL but keeps it in REST.
 REST_ONLY_ENDPOINTS: frozenset = frozenset()
-
-# Endpoints that only apply to device types.  Matches _NO_MODULE_TYPE in graphql_client.
-NO_MODULE_TYPE_ENDPOINTS: frozenset = frozenset({"device_bay_templates"})
 
 
 def _chunked(items, size):
@@ -140,7 +141,7 @@ class RichTaskDisplay:
         try:
             self.progress.stop_task(task_id)
             self.progress.remove_task(task_id)
-        except Exception:
+        except KeyError:
             pass
 
 
@@ -229,6 +230,7 @@ class ComponentCache:
             "updates": updates,
             "display": display,
             "done": set(),
+            "manufacturer_slug": manufacturer_slug,
         }
 
     def pump(self):
@@ -264,15 +266,24 @@ class ComponentCache:
             return
         if self._job is None:
             self.begin_prefetch(manufacturer_slug=manufacturer_slug)
+        elif (
+            manufacturer_slug is not None
+            and self._job["manufacturer_slug"] is not None
+            and manufacturer_slug != self._job["manufacturer_slug"]
+        ):
+            raise ValueError(
+                f"Prefetch for manufacturer {self._job['manufacturer_slug']!r} "
+                f"cannot be collected for {manufacturer_slug!r}."
+            )
 
         records = self._collect()
         for endpoint_name, label in PRELOAD_TARGETS:
             count = self.populate(endpoint_name, records.get(endpoint_name, []))
             self.handle.verbose_log(f"Cached {count} {label}.")
 
-        self._ready = True
         if manufacturer_slug is not None:
             self._verify_vendor_scope(manufacturer_slug, device_type_ids or set())
+        self._ready = True
 
     def close(self):
         """Cancel a prefetch in flight and release its executor."""
@@ -306,7 +317,7 @@ class ComponentCache:
         """
         return self._entries.get(endpoint_name, {}).get((parent_type, parent_id), {})
 
-    def get(self, endpoint_name, parent_id, parent_type, endpoint):
+    def get(self, endpoint_name, parent_type, parent_id, endpoint):
         """Return cached components for one parent, falling back to a targeted REST filter.
 
         A miss means the parent was created during this run or its entry was invalidated
@@ -444,9 +455,9 @@ class ComponentCache:
             return
         module_type_ids = {record.id for models in module_types.values() for record in models.values()}
 
-        self._drop_foreign_entries(device_type_ids, module_type_ids)
-        # A count mismatch means GraphQL truncated the fetch, so let it propagate.
-        self._check_counts_against_rest(device_type_ids, module_type_ids)
+        vendor_scope_valid = self._drop_foreign_entries(device_type_ids, module_type_ids)
+        # A count mismatch means the prefetch failed an integrity check, so let it propagate.
+        self._check_counts_against_rest(device_type_ids, module_type_ids, vendor_scope_valid)
 
     def _belongs_to_vendor(self, key, device_type_ids, module_type_ids):
         """Whether the cache *key* names a device or module type of the current vendor."""
@@ -482,7 +493,7 @@ class ComponentCache:
             total += rest_endpoint.count(**{filter_key: chunk})
         return total
 
-    def _check_counts_against_rest(self, device_type_ids, module_type_ids):
+    def _check_counts_against_rest(self, device_type_ids, module_type_ids, vendor_scope_valid):
         """Compare each endpoint's cached count with REST, which GraphQL cannot truncate.
 
         Raises:
@@ -512,8 +523,10 @@ class ComponentCache:
                 rest_count += self._rest_count(rest_endpoint, mt_filter_key, mt_ids)
 
             if cached_count != rest_count:
+                if vendor_scope_valid:
+                    reason = "GraphQL may have silently truncated the result set."
+                else:
+                    reason = "The cache failed vendor validation after cross-vendor contamination was cleared."
                 raise GraphQLCountMismatchError(
-                    f"{endpoint_name}: GraphQL returned {cached_count} records "
-                    f"but REST reports {rest_count} — "
-                    "GraphQL may have silently truncated the result set."
+                    f"{endpoint_name}: GraphQL returned {cached_count} records but REST reports {rest_count}. {reason}"
                 )

--- a/core/component_cache.py
+++ b/core/component_cache.py
@@ -1,0 +1,519 @@
+"""The component-template cache: one owner for prefetch, lookup and readiness.
+
+NetBox stores component templates (interfaces, power ports, ...) per device type and
+per module type.  Comparing a whole vendor one template at a time is an N+1 query, so
+this module fetches every endpoint once, concurrently, and answers lookups from memory.
+
+The interface is deliberately small: ``begin_prefetch``, ``pump``, ``ensure_ready``,
+``get``, ``entries``, ``invalidate``.  Futures, the progress queue, per-endpoint task
+state and the readiness flag stay inside.  Callers used to sequence those by hand.
+"""
+
+import concurrent.futures
+import queue
+
+from core.compat import (
+    device_type_filter_key,
+    device_type_filter_kwargs,
+    module_type_filter_key,
+    module_type_filter_kwargs,
+)
+from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError
+
+# Component endpoints fetched up front, with the label shown in the progress display.
+PRELOAD_TARGETS = (
+    ("interface_templates", "Interfaces"),
+    ("power_port_templates", "Power Ports"),
+    ("console_port_templates", "Console Ports"),
+    ("console_server_port_templates", "Console Server Ports"),
+    ("power_outlet_templates", "Power Outlets"),
+    ("rear_port_templates", "Rear Ports"),
+    ("front_port_templates", "Front Ports"),
+    ("device_bay_templates", "Device Bays"),
+    ("module_bay_templates", "Module Bays"),
+)
+
+# YAML component key -> (pynetbox endpoint attribute, cache name).
+ENDPOINT_CACHE_MAP = {
+    "interfaces": ("interface_templates", "interface_templates"),
+    "power-ports": ("power_port_templates", "power_port_templates"),
+    "console-ports": ("console_port_templates", "console_port_templates"),
+    "power-outlets": ("power_outlet_templates", "power_outlet_templates"),
+    "console-server-ports": (
+        "console_server_port_templates",
+        "console_server_port_templates",
+    ),
+    "rear-ports": ("rear_port_templates", "rear_port_templates"),
+    "front-ports": ("front_port_templates", "front_port_templates"),
+    "device-bays": ("device_bay_templates", "device_bay_templates"),
+    "module-bays": ("module_bay_templates", "module_bay_templates"),
+}
+
+# Endpoints whose GraphQL schema is missing fields required for accurate change
+# detection, and where REST provides them.  Add an endpoint here if a NetBox
+# version drops a field from GraphQL but keeps it in REST.
+REST_ONLY_ENDPOINTS: frozenset = frozenset()
+
+# Endpoints that only apply to device types.  Matches _NO_MODULE_TYPE in graphql_client.
+NO_MODULE_TYPE_ENDPOINTS: frozenset = frozenset({"device_bay_templates"})
+
+
+def _chunked(items, size):
+    """Yield successive *size*-length chunks of *items*."""
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+class NullTaskDisplay:
+    """Progress sink that reports nothing, so the cache never branches on a missing display."""
+
+    def add(self, key, label):
+        """Register a task for *key*."""
+
+    def advance(self, key, amount):
+        """Advance *key* by *amount*, which is negative when a retry rewinds it."""
+
+    def finish(self, key, total):
+        """Mark *key* complete at *total*."""
+
+    def discard(self, key):
+        """Drop *key* without completing it."""
+
+
+class RichTaskDisplay:
+    """Progress sink backed by a Rich Progress instance.
+
+    A *registry* makes the tasks cumulative: they are created once, shared between
+    vendors, and left on screen for the caller to finalize.  Without one, this display
+    owns its tasks and removes them as each endpoint completes.
+    """
+
+    def __init__(self, progress, registry=None):
+        """Wrap *progress*, reusing tasks from *registry* when one is given."""
+        self.progress = progress
+        self.registry = registry
+        self.task_ids = {}
+
+    @property
+    def _owns_tasks(self):
+        """Whether this display may stop and remove its tasks, rather than a shared owner."""
+        return self.registry is None
+
+    def add(self, key, label):
+        """Create, or borrow from the registry, the task that tracks *key*."""
+        description = f"Caching {label}"
+        if self.registry is None:
+            self.task_ids[key] = self.progress.add_task(description, total=None)
+            return
+        if description not in self.registry:
+            self.registry[description] = self.progress.add_task(description, total=None)
+        self.task_ids[key] = self.registry[description]
+
+    def advance(self, key, amount):
+        """Advance *key*, clamping a rewind at zero so a retry cannot show a negative bar."""
+        task_id = self.task_ids.get(key)
+        if task_id is None or not amount:
+            return
+        if amount > 0:
+            self.progress.update(task_id, advance=amount)
+            return
+        task = next((t for t in self.progress.tasks if t.id == task_id), None)
+        if task is not None:
+            self.progress.update(task_id, completed=max(0, task.completed + amount))
+
+    def finish(self, key, total):
+        """Complete *key* at *total*, and clear it when this display owns the task."""
+        task_id = self.task_ids.pop(key, None)
+        if task_id is None or not self._owns_tasks:
+            return
+        self.progress.update(task_id, total=total, completed=total)
+        self._clear(task_id)
+
+    def discard(self, key):
+        """Drop *key*, and clear it when this display owns the task."""
+        task_id = self.task_ids.pop(key, None)
+        if task_id is not None and self._owns_tasks:
+            self._clear(task_id)
+
+    def _clear(self, task_id):
+        """Stop and remove *task_id*, tolerating a display that already dropped it."""
+        try:
+            self.progress.stop_task(task_id)
+            self.progress.remove_task(task_id)
+        except Exception:
+            pass
+
+
+class ComponentCache:
+    """Component templates for one vendor, fetched once and answered from memory.
+
+    Lookups are keyed ``{endpoint: {(parent_type, parent_id): {name: record}}}`` where
+    *parent_type* is ``"device"`` or ``"module"``.  A miss falls back to a targeted REST
+    filter, which happens for types created during this run and after an invalidation.
+    """
+
+    def __init__(self, netbox, graphql, handle, new_filters, max_threads, wrap_record=None):
+        """Build a cache over the *netbox* REST client and the *graphql* client.
+
+        Args:
+            netbox: pynetbox API object, used for REST fallbacks and count checks.
+            graphql: GraphQL client used for the bulk fetch.
+            handle: Log handler.
+            new_filters (bool): Whether this NetBox takes the newer filter parameter names.
+            max_threads (int): Upper bound on concurrent endpoint fetches.
+            wrap_record (callable | None): Applied to every front-port record, so change
+                detection sees one mappings shape across NetBox versions.
+        """
+        self.netbox = netbox
+        self.graphql = graphql
+        self.handle = handle
+        self.new_filters = new_filters
+        self.max_threads = max_threads
+        self._wrap_record = wrap_record or (lambda record: record)
+
+        self._entries = {}
+        self._ready = False
+        self._job = None
+
+    # ── State ────────────────────────────────────────────────────────────────
+
+    @property
+    def ready(self):
+        """Whether the bulk prefetch has completed for the current vendor."""
+        return self._ready
+
+    def reset(self):
+        """Drop every entry and cancel any prefetch, so a new vendor starts clean."""
+        self.close()
+        self._entries = {}
+        self._ready = False
+
+    # ── Prefetch lifecycle ───────────────────────────────────────────────────
+
+    def begin_prefetch(self, manufacturer_slug=None, display=None):
+        """Start fetching every endpoint in the background.
+
+        Returns immediately.  Call :meth:`pump` while doing other work to advance the
+        display, then :meth:`ensure_ready` to collect the results.  A second call while
+        a prefetch is already in flight is a no-op.
+        """
+        if self._job is not None or self._ready:
+            return
+
+        display = display or NullTaskDisplay()
+        for endpoint_name, label in PRELOAD_TARGETS:
+            display.add(endpoint_name, label)
+
+        updates = queue.Queue()
+        max_workers = max(1, min(len(PRELOAD_TARGETS), self.max_threads))
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
+        try:
+            futures = {
+                endpoint_name: executor.submit(
+                    self._fetch_endpoint,
+                    endpoint_name,
+                    lambda name, advance: updates.put((name, advance)),
+                    manufacturer_slug,
+                )
+                for endpoint_name, _label in PRELOAD_TARGETS
+            }
+        except Exception:
+            executor.shutdown(wait=False, cancel_futures=True)
+            for endpoint_name, _label in PRELOAD_TARGETS:
+                display.discard(endpoint_name)
+            raise
+
+        self._job = {
+            "executor": executor,
+            "futures": futures,
+            "updates": updates,
+            "display": display,
+            "done": set(),
+        }
+
+    def pump(self):
+        """Advance the display for a prefetch in flight, without blocking.
+
+        Returns:
+            bool: True when something advanced, so a caller can tell idle from busy.
+        """
+        if self._job is None:
+            return False
+        advanced = self._drain_updates()
+        for endpoint_name in self._pending():
+            future = self._job["futures"][endpoint_name]
+            if not future.done():
+                continue
+            self._finish_endpoint(endpoint_name, future)
+            advanced = True
+        return advanced
+
+    def ensure_ready(self, manufacturer_slug=None, device_type_ids=None):
+        """Populate the cache, starting the prefetch first when nothing is in flight.
+
+        Idempotent: the second and later calls return at once.  Callers that need cached
+        data call this instead of tracking whether an earlier stage already ran.
+
+        Args:
+            manufacturer_slug (str | None): When given, the vendor-scoped integrity and
+                count checks run once the fetch completes.
+            device_type_ids (set | None): Device-type IDs for this vendor, used by those
+                checks.  Ignored when *manufacturer_slug* is None.
+        """
+        if self._ready:
+            return
+        if self._job is None:
+            self.begin_prefetch(manufacturer_slug=manufacturer_slug)
+
+        records = self._collect()
+        for endpoint_name, label in PRELOAD_TARGETS:
+            count = self.populate(endpoint_name, records.get(endpoint_name, []))
+            self.handle.verbose_log(f"Cached {count} {label}.")
+
+        self._ready = True
+        if manufacturer_slug is not None:
+            self._verify_vendor_scope(manufacturer_slug, device_type_ids or set())
+
+    def close(self):
+        """Cancel a prefetch in flight and release its executor."""
+        job, self._job = self._job, None
+        if job is None:
+            return
+        for future in job["futures"].values():
+            if not future.done():
+                future.cancel()
+        job["executor"].shutdown(wait=False, cancel_futures=True)
+        for endpoint_name in job["futures"]:
+            if endpoint_name not in job["done"]:
+                job["display"].discard(endpoint_name)
+
+    def __enter__(self):
+        """Return the cache, so a run can scope the prefetch to a ``with`` block."""
+        return self
+
+    def __exit__(self, *exc_info):
+        """Cancel any prefetch left in flight."""
+        self.close()
+        return False
+
+    # ── Lookup ───────────────────────────────────────────────────────────────
+
+    def entries(self, endpoint_name, parent_type, parent_id):
+        """Return the cached ``{name: record}`` for one parent, or ``{}`` on a miss.
+
+        A pure read: unlike :meth:`get` it never reaches NetBox, so change detection
+        cannot turn a cold cache into a burst of REST calls.
+        """
+        return self._entries.get(endpoint_name, {}).get((parent_type, parent_id), {})
+
+    def get(self, endpoint_name, parent_id, parent_type, endpoint):
+        """Return cached components for one parent, falling back to a targeted REST filter.
+
+        A miss means the parent was created during this run or its entry was invalidated
+        after a mutation.  Both are narrow, so one filtered call is cheap.
+        """
+        key = (parent_type, parent_id)
+        cached = self._entries.get(endpoint_name, {})
+        if key in cached:
+            return cached[key]
+
+        if parent_type == "device":
+            filter_kwargs = device_type_filter_kwargs(parent_id, new_filters=self.new_filters)
+        else:
+            filter_kwargs = module_type_filter_kwargs(parent_id, new_filters=self.new_filters)
+        result = {item.name: item for item in endpoint.filter(**filter_kwargs)}
+        self.record(endpoint_name, parent_type, parent_id, result)
+        return result
+
+    def record(self, endpoint_name, parent_type, parent_id, components):
+        """Store the known ``{name: record}`` set for one parent.
+
+        The write half of :meth:`entries`.  An empty mapping is meaningful: it says the
+        parent has no components, which is a hit rather than a reason to re-read NetBox.
+        """
+        self._entries.setdefault(endpoint_name, {})[(parent_type, parent_id)] = components
+
+    def invalidate(self, endpoint_name, parent_type, parent_id):
+        """Drop one parent's entry, so the next lookup re-reads it after a mutation."""
+        self._entries.get(endpoint_name, {}).pop((parent_type, parent_id), None)
+
+    def populate(self, endpoint_name, records):
+        """Index *records* under *endpoint_name*, merging with what is already cached.
+
+        Returns:
+            int: How many records carried a parent and were indexed.
+        """
+        indexed = self._entries.setdefault(endpoint_name, {})
+        count = 0
+        for item in records:
+            if getattr(item, "device_type", None):
+                key = ("device", item.device_type.id)
+            elif getattr(item, "module_type", None):
+                key = ("module", item.module_type.id)
+            else:
+                continue
+            indexed.setdefault(key, {})[item.name] = item
+            count += 1
+        return count
+
+    # ── Fetching ─────────────────────────────────────────────────────────────
+
+    def _fetch_endpoint(self, endpoint_name, on_advance, manufacturer_slug):
+        """Return every record for *endpoint_name*, reporting each page through *on_advance*."""
+        if endpoint_name in REST_ONLY_ENDPOINTS:
+            records = list(getattr(self.netbox.dcim, endpoint_name).all())
+            if records:
+                on_advance(endpoint_name, len(records))
+            return records
+
+        records = self.graphql.get_component_templates(
+            endpoint_name,
+            manufacturer_slug=manufacturer_slug,
+            on_page=lambda n: n and on_advance(endpoint_name, n),
+        )
+        if endpoint_name == "front_port_templates":
+            records = [self._wrap_record(record) for record in records]
+        return records
+
+    def _pending(self):
+        """Return the endpoints whose future has not been collected yet."""
+        return [name for name in self._job["futures"] if name not in self._job["done"]]
+
+    def _drain_updates(self):
+        """Apply every queued page count to the display, coalescing per endpoint."""
+        totals = {}
+        while True:
+            try:
+                endpoint_name, advance = self._job["updates"].get_nowait()
+            except queue.Empty:
+                break
+            totals[endpoint_name] = totals.get(endpoint_name, 0) + advance
+
+        for endpoint_name, advance in totals.items():
+            self._job["display"].advance(endpoint_name, advance)
+        return any(totals.values())
+
+    def _finish_endpoint(self, endpoint_name, future):
+        """Mark *endpoint_name* complete on the display, sizing the bar to the result."""
+        try:
+            total = max(len(future.result()), 1)
+        except Exception:
+            total = 1
+        self._job["display"].finish(endpoint_name, total)
+        self._job["done"].add(endpoint_name)
+
+    def _collect(self):
+        """Wait for every endpoint future and return ``{endpoint: [records]}``."""
+        job = self._job
+        try:
+            while self._pending():
+                self._drain_updates()
+                progressed = False
+                for endpoint_name in self._pending():
+                    if job["futures"][endpoint_name].done():
+                        self._finish_endpoint(endpoint_name, job["futures"][endpoint_name])
+                        progressed = True
+                if self._pending() and not progressed:
+                    concurrent.futures.wait(
+                        [job["futures"][name] for name in self._pending()],
+                        timeout=0.1,
+                        return_when=concurrent.futures.FIRST_COMPLETED,
+                    )
+
+            records = {}
+            for endpoint_name, future in job["futures"].items():
+                try:
+                    records[endpoint_name] = future.result()
+                except Exception as exc:
+                    self.handle.log(f"Preload failed for {endpoint_name}: {exc}")
+                    raise
+            return records
+        finally:
+            job["executor"].shutdown(wait=True)
+            self._job = None
+
+    # ── Vendor-scoped checks ─────────────────────────────────────────────────
+
+    def _verify_vendor_scope(self, manufacturer_slug, device_type_ids):
+        """Run the cross-vendor and truncation checks for the vendor just fetched."""
+        try:
+            module_types = self.graphql.get_module_types(manufacturer_slugs=[manufacturer_slug])
+        except GraphQLSchemaError as exc:
+            # Only a rejected query shape may skip the guard; a failed request must not.
+            self.handle.log(f"WARNING: Component cache integrity check skipped: {exc}")
+            return
+        module_type_ids = {record.id for models in module_types.values() for record in models.values()}
+
+        self._drop_foreign_entries(device_type_ids, module_type_ids)
+        # A count mismatch means GraphQL truncated the fetch, so let it propagate.
+        self._check_counts_against_rest(device_type_ids, module_type_ids)
+
+    def _belongs_to_vendor(self, key, device_type_ids, module_type_ids):
+        """Whether the cache *key* names a device or module type of the current vendor."""
+        parent_type, parent_id = key
+        if parent_type == "device":
+            return parent_id in device_type_ids
+        return parent_id in module_type_ids
+
+    def _drop_foreign_entries(self, device_type_ids, module_type_ids):
+        """Clear any endpoint holding no record for this vendor, which means stale data.
+
+        Returns:
+            bool: True when every non-empty endpoint held at least one matching record.
+        """
+        all_ok = True
+        for endpoint_name, indexed in list(self._entries.items()):
+            if not indexed:
+                continue
+            if any(self._belongs_to_vendor(key, device_type_ids, module_type_ids) for key in indexed):
+                continue
+            self.handle.log(
+                f"ERROR: Cached {endpoint_name} contains no records matching the current vendor — "
+                "clearing to prevent cross-vendor contamination."
+            )
+            self._entries[endpoint_name] = {}
+            all_ok = False
+        return all_ok
+
+    def _rest_count(self, rest_endpoint, filter_key, ids):
+        """Return the REST count for *ids*, chunked to stay inside the URL length limit."""
+        total = 0
+        for chunk in _chunked(ids, 100):
+            total += rest_endpoint.count(**{filter_key: chunk})
+        return total
+
+    def _check_counts_against_rest(self, device_type_ids, module_type_ids):
+        """Compare each endpoint's cached count with REST, which GraphQL cannot truncate.
+
+        Raises:
+            GraphQLCountMismatchError: When an endpoint holds fewer records than REST reports.
+        """
+        dt_filter_key = device_type_filter_key(self.new_filters)
+        mt_filter_key = module_type_filter_key(self.new_filters)
+        dt_ids = list(device_type_ids)
+        mt_ids = list(module_type_ids)
+
+        for endpoint_name, _label in PRELOAD_TARGETS:
+            if endpoint_name in REST_ONLY_ENDPOINTS:
+                # Already fetched over REST, so comparing REST to REST proves nothing.
+                continue
+
+            cached_count = sum(
+                len(records)
+                for key, records in self._entries.get(endpoint_name, {}).items()
+                if self._belongs_to_vendor(key, device_type_ids, module_type_ids)
+            )
+
+            rest_endpoint = getattr(self.netbox.dcim, endpoint_name)
+            rest_count = 0
+            if dt_ids:
+                rest_count += self._rest_count(rest_endpoint, dt_filter_key, dt_ids)
+            if mt_ids and endpoint_name not in NO_MODULE_TYPE_ENDPOINTS:
+                rest_count += self._rest_count(rest_endpoint, mt_filter_key, mt_ids)
+
+            if cached_count != rest_count:
+                raise GraphQLCountMismatchError(
+                    f"{endpoint_name}: GraphQL returned {cached_count} records "
+                    f"but REST reports {rest_count} — "
+                    "GraphQL may have silently truncated the result set."
+                )

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -1331,7 +1331,7 @@ class NetBox:
                 continue
             endpoint_attr, cache_name = ENDPOINT_CACHE_MAP[component_key]
             endpoint = getattr(self.netbox.dcim, endpoint_attr)
-            existing_components = self.device_types.components.get(cache_name, existing_module.id, "module", endpoint)
+            existing_components = self.device_types.components.get(cache_name, "module", existing_module.id, endpoint)
             requested_names = {c.get("name") for c in components if c.get("name")}
             if any(name not in existing_components for name in requested_names):
                 return True
@@ -1376,7 +1376,7 @@ class NetBox:
         # processing in normal mode; this call is a no-op then.  When no device types were
         # present (e.g. vendor-filtered runs or --only-new was used for device types) the
         # preload is triggered here so module-type comparisons still hit accurate cache data.
-        self.device_types.ensure_components_ready()
+        self.device_types.ensure_components_ready(manufacturer_slug=module_types[0]["manufacturer"]["slug"])
 
         existing_module_map = {}
         for module_type in module_types:
@@ -1537,7 +1537,7 @@ class NetBox:
                 When False the property drift is still present; a component-only reconciliation
                 must not be recorded as a full ``module_updated`` success.
         """
-        self.device_types.ensure_components_ready()
+        self.device_types.ensure_components_ready(manufacturer_slug=curr_mt["manufacturer"]["slug"])
         identity = f"{module_type_res.manufacturer.name}/{module_type_res.model}"
         component_changes = self.change_detector._compare_components(curr_mt, module_type_res.id, parent_type="module")
         if component_changes:
@@ -2149,7 +2149,7 @@ class DeviceTypes:
             cache_name (str | None): Cache entry invalidated after creation, or None to skip.
         """
         # Look up existing components via cache or API fallback
-        existing = self.components.get(cache_name, parent_id, parent_type, endpoint)
+        existing = self.components.get(cache_name, parent_type, parent_id, endpoint)
 
         to_create = [x for x in items if x["name"] not in existing]
         parent_key = "device_type" if parent_type == "device" else "module_type"
@@ -2206,8 +2206,8 @@ class DeviceTypes:
         """
         existing_rp = self.components.get(
             "rear_port_templates",
-            device_type_id,
             parent_type,
+            device_type_id,
             self.netbox.dcim.rear_port_templates,
         )
         rear_ports_payload = []
@@ -2275,8 +2275,8 @@ class DeviceTypes:
                 rp_name, _fp_pos, rp_pos = first
             rps = self.components.get(
                 "rear_port_templates",
-                device_type_id,
                 parent_type,
+                device_type_id,
                 self.netbox.dcim.rear_port_templates,
             )
             rp = rps.get(rp_name)
@@ -2309,7 +2309,7 @@ class DeviceTypes:
         if not endpoint:
             return
 
-        existing = self.components.get(cache_name, device_type_id, parent_type, endpoint)
+        existing = self.components.get(cache_name, parent_type, device_type_id, endpoint)
 
         updates = []
         for change in changes:
@@ -2467,7 +2467,7 @@ class DeviceTypes:
             if not endpoint:
                 continue
 
-            existing = self.components.get(cache_name, device_type_id, parent_type, endpoint)
+            existing = self.components.get(cache_name, parent_type, device_type_id, endpoint)
 
             ids_to_delete = []
             for change in changes:
@@ -2525,8 +2525,8 @@ class DeviceTypes:
         if bridged_interfaces:
             all_interfaces = self.components.get(
                 "interface_templates",
-                device_type,
                 "device",
+                device_type,
                 self.netbox.dcim.interface_templates,
             )
 
@@ -2585,8 +2585,8 @@ class DeviceTypes:
             """Resolve power-port name references in *items* and persist the outlet templates for device type *pid*."""
             existing_pp = self.components.get(
                 "power_port_templates",
-                pid,
                 "device",
+                pid,
                 self.netbox.dcim.power_port_templates,
             )
 
@@ -2681,8 +2681,8 @@ class DeviceTypes:
             """Resolve rear-port position references in *items* and persist the front port templates for *pid*."""
             existing_rp = self.components.get(
                 "rear_port_templates",
-                pid,
                 parent_type,
+                pid,
                 self.netbox.dcim.rear_port_templates,
             )
 
@@ -2844,8 +2844,8 @@ class DeviceTypes:
             """Resolve power-port name references in *items* and persist the outlet templates for module type *pid*."""
             existing_pp = self.components.get(
                 "power_port_templates",
-                pid,
                 "module",
+                pid,
                 self.netbox.dcim.power_port_templates,
             )
 

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -1,12 +1,9 @@
 """NetBox REST and GraphQL API client for importing device and module type libraries."""
 
 from collections import Counter
-import concurrent.futures
 from functools import lru_cache
 import hashlib
-import itertools
 import json
-import queue
 import re
 import tempfile
 import time
@@ -18,19 +15,9 @@ import glob
 from pathlib import Path
 
 from core.change_detector import ChangeDetector, ChangeType
-from core.compat import (
-    device_type_filter_key,
-    device_type_filter_kwargs,
-    module_type_filter_key,
-    module_type_filter_kwargs,
-)
+from core.component_cache import ENDPOINT_CACHE_MAP, ComponentCache
 from core.formatting import log_property_diffs
-from core.graphql_client import (
-    GraphQLCountMismatchError,
-    GraphQLError,
-    GraphQLSchemaError,
-    NetBoxGraphQLClient,
-)
+from core.graphql_client import GraphQLError, NetBoxGraphQLClient
 from core.normalization import values_equal
 from core.outcomes import EntityKind, Outcome, OutcomeRegistry
 from core.schema_reader import load_properties_for_type
@@ -345,22 +332,6 @@ IMAGE_EXTENSIONS = {
     ".tiff",
     ".svg",
 }
-
-# Maximum number of IDs per endpoint.filter() call to avoid excessively long URLs.
-FILTER_CHUNK_SIZE = 200
-
-
-def _chunked(iterable, size):
-    """Yield successive *size*-length chunks from *iterable*.
-
-    Accepts any iterable; does not require a Sequence.
-    """
-    it = iter(iterable)
-    while True:
-        chunk = list(itertools.islice(it, size))
-        if not chunk:
-            break
-        yield chunk
 
 
 def _image_dir_for_yaml(src_file: str, src_segment: str, dst_segment: str) -> "Path | None":
@@ -1128,7 +1099,7 @@ class NetBox:
             change_report (ChangeReport | None): Pre-computed change report; required when ``update`` is True.
             remove_components (bool): If True (with ``update``), remove components absent from YAML.
         """
-        # Note: Caching is now done externally before this method via preload_all_components()
+        # Note: the component cache is populated before this method runs.
 
         iterator = progress if progress is not None else device_types_to_add
         # Pre-index change_report for O(1) lookup instead of an O(M) scan per device type.
@@ -1360,9 +1331,7 @@ class NetBox:
                 continue
             endpoint_attr, cache_name = ENDPOINT_CACHE_MAP[component_key]
             endpoint = getattr(self.netbox.dcim, endpoint_attr)
-            existing_components = self.device_types._get_cached_or_fetch(
-                cache_name, existing_module.id, "module", endpoint
-            )
+            existing_components = self.device_types.components.get(cache_name, existing_module.id, "module", endpoint)
             requested_names = {c.get("name") for c in components if c.get("name")}
             if any(name not in existing_components for name in requested_names):
                 return True
@@ -1407,8 +1376,7 @@ class NetBox:
         # processing in normal mode; this call is a no-op then.  When no device types were
         # present (e.g. vendor-filtered runs or --only-new was used for device types) the
         # preload is triggered here so module-type comparisons still hit accurate cache data.
-        if not self.device_types._global_preload_done:
-            self.device_types.preload_all_components()
+        self.device_types.ensure_components_ready()
 
         existing_module_map = {}
         for module_type in module_types:
@@ -1569,8 +1537,7 @@ class NetBox:
                 When False the property drift is still present; a component-only reconciliation
                 must not be recorded as a full ``module_updated`` success.
         """
-        if not self.device_types._global_preload_done:
-            self.device_types.preload_all_components()
+        self.device_types.ensure_components_ready()
         identity = f"{module_type_res.manufacturer.name}/{module_type_res.model}"
         component_changes = self.change_detector._compare_components(curr_mt, module_type_res.id, parent_type="module")
         if component_changes:
@@ -1998,25 +1965,6 @@ class NetBox:
                 self._persist_hash_cache()
 
 
-# Component type -> (dcim endpoint attribute name, cache key name).
-# The two tuple elements are intentionally identical today (endpoint attribute == cache name)
-# but are kept separate to allow them to diverge independently in the future.
-ENDPOINT_CACHE_MAP = {
-    "interfaces": ("interface_templates", "interface_templates"),
-    "power-ports": ("power_port_templates", "power_port_templates"),
-    "console-ports": ("console_port_templates", "console_port_templates"),
-    "power-outlets": ("power_outlet_templates", "power_outlet_templates"),
-    "console-server-ports": (
-        "console_server_port_templates",
-        "console_server_port_templates",
-    ),
-    "rear-ports": ("rear_port_templates", "rear_port_templates"),
-    "front-ports": ("front_port_templates", "front_port_templates"),
-    "device-bays": ("device_bay_templates", "device_bay_templates"),
-    "module-bays": ("module_bay_templates", "module_bay_templates"),
-}
-
-
 class _FrontPortRecordWithMappings:
     """Wrapper around a front port template record that normalises port mappings.
 
@@ -2126,8 +2074,14 @@ class DeviceTypes:
         self.repo_path = repo_path
         self.m2m_front_ports = m2m_front_ports
         self.max_threads = max_threads
-        self.cached_components = {}
-        self._global_preload_done = False
+        self.components = ComponentCache(
+            netbox,
+            graphql,
+            exception_handler,
+            new_filters,
+            max_threads,
+            wrap_record=_FrontPortRecordWithMappings,
+        )
         self._image_progress = None
         self.existing_device_types = {}
         self.existing_device_types_by_slug = {}
@@ -2151,831 +2105,21 @@ class DeviceTypes:
         Args:
             manufacturer_slug (str): Manufacturer slug to load device types for.
         """
-        self.cached_components = {}
-        self._global_preload_done = False
+        self.components.reset()
         by_model, by_slug = self.graphql.get_device_types(manufacturer_slugs=[manufacturer_slug])
         self.existing_device_types = by_model
         self.existing_device_types_by_slug = by_slug
 
-    # Endpoints whose GraphQL schema is missing fields required for accurate
-    # change detection and where the REST API provides the missing data.
-    # Add endpoint names here if a future NetBox version drops a field from
-    # GraphQL but keeps it in REST (or vice-versa).
-    REST_ONLY_ENDPOINTS: frozenset = frozenset()
+    def ensure_components_ready(self, manufacturer_slug=None):
+        """Populate the component cache, scoping the vendor checks to the loaded device types.
 
-    # Endpoints that only apply to device types (no module-type path).
-    # Matches _NO_MODULE_TYPE in graphql_client.py.
-    _NO_MODULE_TYPE_ENDPOINTS: frozenset = frozenset({"device_bay_templates"})
-
-    @staticmethod
-    def _component_preload_targets():
-        """Return the list of ``(endpoint_attr, display_label)`` pairs used for component preloading."""
-        return [
-            ("interface_templates", "Interfaces"),
-            ("power_port_templates", "Power Ports"),
-            ("console_port_templates", "Console Ports"),
-            ("console_server_port_templates", "Console Server Ports"),
-            ("power_outlet_templates", "Power Outlets"),
-            ("rear_port_templates", "Rear Ports"),
-            ("front_port_templates", "Front Ports"),
-            ("device_bay_templates", "Device Bays"),
-            ("module_bay_templates", "Module Bays"),
-        ]
-
-    def start_component_preload(
-        self,
-        progress=None,
-        manufacturer_slug: str | None = None,
-        task_registry: dict | None = None,
-    ):
-        """Start concurrent component prefetch and return a preload job handle.
-
-        Args:
-            progress: Optional Rich Progress instance for task tracking.
-            manufacturer_slug (str | None): When provided, fetch only component templates
-                belonging to this manufacturer's device types and module types.
-            task_registry (dict | None): When provided, task_ids are looked up or created
-                in this shared registry so they persist and accumulate counts across all
-                vendors rather than appearing and disappearing per vendor.
+        Idempotent, so any stage that needs cached components may call it without
+        knowing whether an earlier stage already did.
         """
-        components = self._component_preload_targets()
-        max_workers = max(1, min(len(components), self.max_threads))
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-
-        try:
-            endpoint_totals = {endpoint_name: None for endpoint_name, _label in components}
-            progress_updates = queue.Queue()
-            task_ids = None
-
-            if progress is not None:
-                task_ids = {}
-                for endpoint_name, label in components:
-                    desc = f"Caching {label}"
-                    if task_registry is not None:
-                        if desc not in task_registry:
-                            task_registry[desc] = progress.add_task(desc, total=None)
-                        task_ids[endpoint_name] = task_registry[desc]
-                    else:
-                        task_ids[endpoint_name] = progress.add_task(desc, total=None)
-
-            def update_progress(endpoint_name, advance):
-                """Put a progress update onto the queue for the main thread to consume."""
-                progress_updates.put((endpoint_name, advance))
-
-            futures = {
-                endpoint_name: executor.submit(
-                    self._fetch_global_endpoint_records,
-                    endpoint_name,
-                    update_progress,
-                    manufacturer_slug,
-                )
-                for endpoint_name, _label in components
-            }
-            return {
-                "mode": "global",
-                "components": components,
-                "futures": futures,
-                "progress_updates": progress_updates,
-                "endpoint_totals": endpoint_totals,
-                "task_ids": task_ids,
-                "finished_endpoints": set(),
-                "executor": executor,
-                # When task_registry is provided the caller owns the tasks;
-                # this job must not stop or remove them on completion.
-                "owns_tasks": task_registry is None,
-            }
-        except Exception:
-            executor.shutdown(wait=False, cancel_futures=True)
-            raise
-
-    @staticmethod
-    def stop_component_preload(preload_job, progress=None):
-        """Cancel any pending futures in *preload_job* and shut down its executor.
-
-        Args:
-            preload_job (dict | None): Preload job returned by :meth:`start_component_preload`; no-op if None.
-            progress: Optional Rich Progress instance; if provided, any remaining progress
-                tasks in the job are removed from the display.
-        """
-        if not preload_job:
-            return
-
-        futures = preload_job.get("futures", {})
-        for future in futures.values():
-            if not future.done():
-                future.cancel()
-
-        executor = preload_job.get("executor")
-        if executor:
-            executor.shutdown(wait=False, cancel_futures=True)
-            preload_job["executor"] = None
-
-        if progress is not None:
-            task_ids = preload_job.get("task_ids") or {}
-            owns_tasks = preload_job.get("owns_tasks", True)
-            if owns_tasks:
-                for task_id in task_ids.values():
-                    try:
-                        progress.stop_task(task_id)
-                        progress.remove_task(task_id)
-                    except Exception:
-                        pass
-
-    @staticmethod
-    def _apply_progress_updates(progress_updates, progress, task_ids, allowed_endpoints=None):
-        """Drain the progress queue and advance the corresponding Rich progress tasks.
-
-        Args:
-            progress_updates (queue.Queue | None): Queue of ``(endpoint_name, advance)`` tuples.
-            progress: Rich Progress instance, or None to skip.
-            task_ids (dict | None): Mapping of endpoint name to Rich task ID.
-            allowed_endpoints (set | None): If provided, only updates for these endpoints are applied.
-
-        Returns:
-            bool: True if at least one task was advanced; False otherwise.
-        """
-        if progress_updates is None or progress is None or not task_ids:
-            return False
-
-        advanced = False
-        updates = {}
-        while True:
-            try:
-                endpoint_name, advance = progress_updates.get_nowait()
-                if allowed_endpoints is not None and endpoint_name not in allowed_endpoints:
-                    # Drop updates for already-completed endpoints; their progress tasks are
-                    # already stopped so re-enqueuing would have no visible effect.
-                    continue
-                updates[endpoint_name] = updates.get(endpoint_name, 0) + advance
-            except queue.Empty:
-                break
-
-        for endpoint_name, advance in updates.items():
-            if advance == 0:
-                continue
-            task_id = task_ids.get(endpoint_name)
-            if task_id is not None:
-                if advance < 0:
-                    # Rewind on retry: clamp completed at 0 to avoid negative bars.
-                    task = next((t for t in progress.tasks if t.id == task_id), None)
-                    if task is not None:
-                        new_completed = max(0, task.completed + advance)
-                        progress.update(task_id, completed=new_completed)
-                else:
-                    progress.update(task_id, advance=advance)
-                advanced = True
-
-        return advanced
-
-    def pump_preload_progress(self, preload_job, progress):
-        """Drain pending progress updates and mark completed endpoints for *preload_job*.
-
-        Intended to be called periodically while parsing is in progress so that the
-        progress bar advances before :meth:`preload_all_components` is called.
-
-        Args:
-            preload_job (dict | None): Preload job returned by :meth:`start_component_preload`.
-            progress: Rich Progress instance.
-
-        Returns:
-            bool: True if any progress updates were applied or endpoints were marked done.
-        """
-        if not preload_job:
-            return False
-        futures = preload_job.get("futures", {})
-        finished_endpoints = preload_job.setdefault("finished_endpoints", set())
-        pending_endpoints = {endpoint_name for endpoint_name in futures if endpoint_name not in finished_endpoints}
-
-        advanced = self._apply_progress_updates(
-            preload_job.get("progress_updates"),
-            progress,
-            preload_job.get("task_ids"),
-            allowed_endpoints=pending_endpoints if pending_endpoints else None,
+        self.components.ensure_ready(
+            manufacturer_slug=manufacturer_slug,
+            device_type_ids={record.id for record in self.existing_device_types.values()},
         )
-
-        task_ids = preload_job.get("task_ids") or {}
-        owns_tasks = preload_job.get("owns_tasks", True)
-        for endpoint_name in pending_endpoints:
-            future = futures.get(endpoint_name)
-            if future is None or not future.done():
-                continue
-            if progress is not None and endpoint_name in task_ids:
-                try:
-                    records = future.result()
-                    final_total = max(len(records), 1)
-                except Exception:
-                    final_total = 1
-                if owns_tasks:
-                    progress.update(task_ids[endpoint_name], total=final_total, completed=final_total)
-                    progress.stop_task(task_ids[endpoint_name])
-                    progress.remove_task(task_ids[endpoint_name])
-            finished_endpoints.add(endpoint_name)
-            advanced = True
-
-        return advanced
-
-    def preload_all_components(
-        self,
-        progress_wrapper=None,
-        preload_job=None,
-        progress=None,
-        manufacturer_slug: str | None = None,
-        task_registry: dict | None = None,
-    ):
-        """Pre-fetch component templates to avoid N+1 queries during updates.
-
-        Args:
-            progress_wrapper: Optional callable to wrap iterables with progress bars.
-            preload_job: Optional preload job from :meth:`start_component_preload`.
-            progress: Optional shared Rich Progress instance used to render
-                all caching tasks inside a single progress panel.
-            manufacturer_slug (str | None): When provided, only fetch component templates
-                for device/module types belonging to this manufacturer.
-            task_registry (dict | None): Shared registry for cumulative progress tasks.
-                When provided, "Caching X" tasks persist across all vendors.
-        """
-        components = self._component_preload_targets()
-
-        if preload_job:
-            self._preload_global(
-                preload_job.get("components", components),
-                progress_wrapper,
-                preload_job=preload_job,
-                progress=progress,
-                task_registry=task_registry,
-            )
-        else:
-            self._preload_global(
-                components,
-                progress_wrapper,
-                progress=progress,
-                manufacturer_slug=manufacturer_slug,
-                task_registry=task_registry,
-            )
-
-        if manufacturer_slug is not None:
-            try:
-                vendor_dt_ids = {record.id for record in self.existing_device_types.values()}
-                vendor_mt_data = self.graphql.get_module_types(manufacturer_slugs=[manufacturer_slug])
-                vendor_mt_ids = {record.id for models in vendor_mt_data.values() for record in models.values()}
-            except GraphQLSchemaError as exc:
-                # Only a rejected query shape may skip the guard; a failed request must not.
-                self.handle.log(f"WARNING: Component cache integrity check skipped: {exc}")
-            else:
-                self._verify_component_cache_integrity(vendor_dt_ids, vendor_mt_ids)
-                # A mismatch means GraphQL truncated results, so let it propagate.
-                self._check_component_counts_against_rest(vendor_dt_ids, vendor_mt_ids)
-
-        self._global_preload_done = True
-
-    def _preload_track_progress(
-        self,
-        components,
-        futures,
-        progress,
-        task_ids,
-        preload_job,
-        progress_updates,
-        endpoint_totals,
-        owns_tasks=True,
-    ):
-        """Collect preload results and advance progress tasks as each endpoint future completes.
-
-        Handles already-finished endpoints from a shared preload job, then drains
-        the remaining pending futures while advancing per-endpoint progress tasks.
-
-        Args:
-            components (list): Sequence of ``(endpoint_name, label)`` pairs.
-            futures (dict): Mapping of endpoint name to submitted Future.
-            progress: Rich Progress instance for task updates.
-            task_ids (dict): Mapping of endpoint name to progress task ID.
-            preload_job (dict | None): Shared preload-job state dict, or None.
-            progress_updates (queue.Queue | None): Queue carrying ``(endpoint_name, advance)`` tuples.
-            endpoint_totals (dict): Expected record count per endpoint.
-            owns_tasks (bool): Whether this call owns the progress tasks and should stop/remove them.
-
-        Returns:
-            dict: ``{endpoint_name: [records]}`` populated as futures complete.
-        """
-        future_map = {endpoint: futures[endpoint] for endpoint, _label in components if endpoint in futures}
-        pending = set(future_map.keys())
-        records_by_endpoint = {}
-        if preload_job:
-            already_done = pending & preload_job.get("finished_endpoints", set())
-            # Collect results and stop tasks for endpoints already finalised by pump_preload_progress.
-            for endpoint_name in already_done:
-                try:
-                    records_by_endpoint[endpoint_name] = future_map[endpoint_name].result()
-                except Exception as exc:
-                    self.handle.log(f"Preload failed for {endpoint_name}: {exc}")
-                    raise
-                if endpoint_name in task_ids:
-                    try:
-                        final_total = max(
-                            endpoint_totals.get(endpoint_name) or 0,
-                            len(records_by_endpoint[endpoint_name]),
-                            1,
-                        )
-                        if owns_tasks:
-                            progress.update(
-                                task_ids[endpoint_name],
-                                total=final_total,
-                                completed=final_total,
-                            )
-                            progress.stop_task(task_ids[endpoint_name])
-                            progress.remove_task(task_ids[endpoint_name])
-                    except Exception:
-                        pass
-            # Exclude from pending to avoid double stop_task.
-            pending -= already_done
-        self._drain_pending(
-            pending,
-            future_map,
-            progress,
-            task_ids,
-            progress_updates,
-            endpoint_totals,
-            records_by_endpoint,
-            owns_tasks=owns_tasks,
-        )
-        return records_by_endpoint
-
-    def _drain_pending(
-        self,
-        pending,
-        future_map,
-        progress,
-        task_ids,
-        progress_updates,
-        endpoint_totals,
-        records_by_endpoint,
-        owns_tasks=True,
-    ):
-        """Wait for pending endpoint futures to complete, collecting results and updating progress.
-
-        Continuously loops until all pending futures are resolved, advancing the progress
-        display as results arrive and handling blocking waits when no updates are available.
-
-        Args:
-            pending (set): Endpoint names whose futures have not yet been collected.
-            future_map (dict): Mapping of endpoint name to Future.
-            progress: Rich Progress instance for task updates.
-            task_ids (dict): Mapping of endpoint name to progress task ID.
-            progress_updates (queue.Queue | None): Queue of ``(endpoint_name, advance)`` tuples.
-            endpoint_totals (dict): Expected record count per endpoint.
-            records_by_endpoint (dict): Accumulator dict updated in-place with results.
-            owns_tasks (bool): Whether this call owns the progress tasks and should stop/remove them.
-        """
-        while pending:
-            had_updates = self._apply_progress_updates(
-                progress_updates,
-                progress,
-                task_ids,
-                allowed_endpoints=pending,
-            )
-            done_now = [ep for ep in pending if future_map[ep].done()]
-            for endpoint_name in done_now:
-                pending.remove(endpoint_name)
-                try:
-                    records_by_endpoint[endpoint_name] = future_map[endpoint_name].result()
-                except Exception as exc:
-                    self.handle.log(f"Preload failed for {endpoint_name}: {exc}")
-                    raise
-                final_total = max(
-                    endpoint_totals.get(endpoint_name) or 0,
-                    len(records_by_endpoint[endpoint_name]),
-                    1,
-                )
-                task_id = task_ids.get(endpoint_name)
-                if task_id is not None and owns_tasks:
-                    progress.update(task_id, total=final_total, completed=final_total)
-                    progress.stop_task(task_id)
-                    progress.remove_task(task_id)
-            if pending and not had_updates:
-                if progress_updates is not None:
-                    try:
-                        endpoint_name, advance = progress_updates.get(timeout=0.1)
-                        if endpoint_name not in pending:
-                            # Drop: endpoint already finalised; no task to advance.
-                            continue
-                        task_id = task_ids.get(endpoint_name)
-                        if task_id is not None and advance != 0:
-                            if advance < 0:
-                                task = next(
-                                    (t for t in progress.tasks if t.id == task_id),
-                                    None,
-                                )
-                                if task is not None:
-                                    new_completed = max(0, task.completed + advance)
-                                    progress.update(task_id, completed=new_completed)
-                            else:
-                                progress.update(task_id, advance=advance)
-                    except queue.Empty:
-                        pass
-                else:
-                    concurrent.futures.wait(
-                        [future_map[ep] for ep in pending],
-                        timeout=0.1,
-                        return_when=concurrent.futures.FIRST_COMPLETED,
-                    )
-
-    def _preload_no_progress(self, components, futures):
-        """Collect preload results sequentially without any progress display.
-
-        Waits for each endpoint's future in order, logging verbose messages as each
-        completes, and accumulates results for the cache-merging step.
-
-        Args:
-            components (list): Sequence of ``(endpoint_name, label)`` pairs.
-            futures (dict): Mapping of endpoint name to submitted Future.
-
-        Returns:
-            dict: ``{endpoint_name: [records]}`` populated as each future resolves.
-        """
-        records_by_endpoint = {}
-        for endpoint, label in components:
-            self.handle.verbose_log(f"Pre-fetching {label}...")
-            try:
-                records_by_endpoint[endpoint] = futures[endpoint].result()
-            except Exception as exc:
-                self.handle.log(f"Preload failed for {label}: {exc}")
-                raise
-        return records_by_endpoint
-
-    def _preload_global(
-        self,
-        components,
-        progress_wrapper=None,
-        preload_job=None,
-        progress=None,
-        manufacturer_slug=None,
-        task_registry=None,
-    ):
-        """Fetch all component templates, optionally scoped to a single manufacturer."""
-        own_executor = preload_job is None
-        if preload_job:
-            executor = preload_job.get("executor")
-            futures = preload_job.get("futures", {})
-            progress_updates = preload_job.get("progress_updates")
-            endpoint_totals = preload_job.get("endpoint_totals", {})
-        else:
-            max_workers = max(1, min(len(components), self.max_threads))
-            endpoint_totals = {endpoint_name: None for endpoint_name, _label in components}
-            executor = None
-            futures = {}
-            progress_updates = None
-
-        try:
-            if own_executor:
-                executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
-                if progress is not None:
-                    progress_updates = queue.Queue()
-
-                    def update_progress(endpoint_name, advance):
-                        """Put a progress update onto the queue for the main-thread pump to consume."""
-                        progress_updates.put((endpoint_name, advance))
-
-                    futures = {
-                        endpoint: executor.submit(
-                            self._fetch_global_endpoint_records,
-                            endpoint,
-                            update_progress,
-                            manufacturer_slug,
-                        )
-                        for endpoint, _label in components
-                    }
-                else:
-                    futures = {
-                        endpoint: executor.submit(
-                            self._fetch_global_endpoint_records,
-                            endpoint,
-                            None,
-                            manufacturer_slug,
-                        )
-                        for endpoint, _label in components
-                    }
-            if progress is not None:
-                task_ids = preload_job.get("task_ids") if preload_job else None
-                owns_tasks = preload_job.get("owns_tasks", True) if preload_job else (task_registry is None)
-                if not task_ids:
-                    task_ids = {}
-                    for endpoint, label in components:
-                        desc = f"Caching {label}"
-                        if task_registry is not None:
-                            if desc not in task_registry:
-                                task_registry[desc] = progress.add_task(desc, total=None)
-                            task_ids[endpoint] = task_registry[desc]
-                        else:
-                            task_ids[endpoint] = progress.add_task(desc, total=None)
-                records_by_endpoint = self._preload_track_progress(
-                    components,
-                    futures,
-                    progress,
-                    task_ids,
-                    preload_job,
-                    progress_updates,
-                    endpoint_totals,
-                    owns_tasks=owns_tasks,
-                )
-            else:
-                records_by_endpoint = self._preload_no_progress(components, futures)
-            for endpoint, label in components:
-                all_items = records_by_endpoint.get(endpoint, [])
-                cache, count = self._build_component_cache(all_items)
-                # Merge to preserve entries from prior incremental preloads.
-                self.cached_components.setdefault(endpoint, {}).update(cache)
-                self.handle.verbose_log(f"Cached {count} {label}.")
-        finally:
-            if executor:
-                if own_executor:
-                    executor.shutdown(wait=True)
-                elif preload_job and preload_job.get("executor") is executor:
-                    executor.shutdown(wait=True)
-                    preload_job["executor"] = None
-
-    def _fetch_global_endpoint_records(self, endpoint_name, progress_callback=None, manufacturer_slug=None):
-        """Fetch all records for *endpoint_name* from NetBox.
-
-        Most endpoints are fetched via GraphQL for speed.  Endpoints listed in
-        :attr:`REST_ONLY_ENDPOINTS` are fetched via the pynetbox REST client
-        instead because their GraphQL schema is missing fields that are required
-        for accurate change detection.
-
-        ``front_port_templates`` records are always wrapped in
-        :class:`_FrontPortRecordWithMappings` after fetching so that
-        :class:`~change_detector.ChangeDetector` can access ``_mappings_canonical``
-        regardless of whether the server returned ``mappings`` (>= 4.5) or the
-        legacy ``rear_port_position`` scalar (< 4.5).
-
-        Args:
-            endpoint_name (str): Component template endpoint name (e.g. ``"interface_templates"``).
-            progress_callback (callable | None): Called with ``(endpoint_name, advance)``
-                once per page during the GraphQL fetch (or once after the batch fetch
-                completes for REST endpoints).  *advance* is a positive integer equal to
-                the number of records on that page.
-            manufacturer_slug (str | None): When provided, only templates belonging to
-                device types or module types of this manufacturer are fetched.
-
-        Returns:
-            list: All component template records.
-        """
-        use_rest = endpoint_name in self.REST_ONLY_ENDPOINTS
-
-        if use_rest:
-            endpoint = getattr(self.netbox.dcim, endpoint_name)
-            records = list(endpoint.all())
-            if progress_callback is not None and records:
-                progress_callback(endpoint_name, len(records))
-            return records
-
-        def _live_advance(n):
-            if progress_callback is not None and n:
-                progress_callback(endpoint_name, n)
-
-        on_page = _live_advance if progress_callback is not None else None
-        records = self.graphql.get_component_templates(
-            endpoint_name, manufacturer_slug=manufacturer_slug, on_page=on_page
-        )
-        if endpoint_name == "front_port_templates":
-            records = [_FrontPortRecordWithMappings(r) for r in records]
-
-        return records
-
-    @staticmethod
-    def _build_component_cache(items):
-        """Organise a flat list of component records into a nested cache structure.
-
-        Args:
-            items (list): pynetbox records; each must have a ``device_type`` or ``module_type`` attribute.
-
-        Returns:
-            tuple[dict, int]: Cache ``{(parent_type, parent_id): {name: record}}`` and the total
-                number of items successfully indexed.
-        """
-        cache = {}
-        count = 0
-        for item in items:
-            parent_id = None
-            parent_type = None
-
-            if getattr(item, "device_type", None):
-                parent_id = item.device_type.id
-                parent_type = "device"
-            elif getattr(item, "module_type", None):
-                parent_id = item.module_type.id
-                parent_type = "module"
-
-            if not parent_id:
-                continue
-
-            key = (parent_type, parent_id)
-            if key not in cache:
-                cache[key] = {}
-            cache[key][item.name] = item
-            count += 1
-
-        return cache, count
-
-    def _verify_component_cache_integrity(self, vendor_dt_ids: set, vendor_mt_ids: set) -> bool:
-        """Check that cached component records belong to the current vendor.
-
-        For each endpoint in :attr:`cached_components`, verifies that at least one
-        record has a parent ID (``device_type.id`` or ``module_type.id``) that
-        appears in *vendor_dt_ids* or *vendor_mt_ids* respectively.  A non-empty
-        endpoint whose records contain **no** matching IDs is treated as garbage
-        data and cleared.
-
-        Args:
-            vendor_dt_ids (set): Device type IDs belonging to the current vendor.
-            vendor_mt_ids (set): Module type IDs belonging to the current vendor.
-
-        Returns:
-            bool: ``True`` if all non-empty endpoints passed the check,
-                ``False`` if any were cleared.
-        """
-        all_ok = True
-        for endpoint_name, entries in list(self.cached_components.items()):
-            if not entries:
-                continue
-            has_valid = any(
-                (parent_type == "device" and parent_id in vendor_dt_ids)
-                or (parent_type == "module" and parent_id in vendor_mt_ids)
-                for (parent_type, parent_id) in entries
-            )
-            if not has_valid:
-                self.handle.log(
-                    f"ERROR: Cached {endpoint_name} contains no records matching the current vendor — "
-                    "clearing to prevent cross-vendor contamination."
-                )
-                self.cached_components[endpoint_name] = {}
-                all_ok = False
-        return all_ok
-
-    def _rest_count_chunked(self, rest_endpoint, filter_key, ids, chunk_size=100):
-        """Return REST count for *ids* using *filter_key*, chunked to avoid URL-length limits.
-
-        Args:
-            rest_endpoint: pynetbox endpoint object (e.g. ``self.netbox.dcim.interface_templates``).
-            filter_key (str): Filter parameter name (e.g. ``"device_type_id"``).
-            ids (list): List of integer IDs to filter by.
-            chunk_size (int): Maximum IDs per REST request.
-
-        Returns:
-            int: Total count across all chunks.
-        """
-        total = 0
-        for i in range(0, len(ids), chunk_size):
-            chunk = ids[i : i + chunk_size]
-            total += rest_endpoint.count(**{filter_key: chunk})
-        return total
-
-    def _check_component_counts_against_rest(self, vendor_dt_ids: set, vendor_mt_ids: set):
-        """Verify that GraphQL-cached component counts match REST API counts for this vendor.
-
-        For each preloaded component endpoint, counts cached records belonging to the
-        current vendor and compares with pynetbox REST counts.  A discrepancy means
-        GraphQL silently truncated the fetch and the import should not proceed.
-
-        Args:
-            vendor_dt_ids: Device type IDs for the current vendor.
-            vendor_mt_ids: Module type IDs for the current vendor.
-
-        Raises:
-            GraphQLCountMismatchError: If any endpoint's cached count differs from REST.
-        """
-        dt_filter_key = device_type_filter_key(self.new_filters)
-        mt_filter_key = module_type_filter_key(self.new_filters)
-        dt_ids = list(vendor_dt_ids)
-        mt_ids = list(vendor_mt_ids)
-
-        for endpoint_name, _label in self._component_preload_targets():
-            if endpoint_name in self.REST_ONLY_ENDPOINTS:
-                # REST-only endpoints are fetched via REST already — comparing REST
-                # count to REST count is tautological and adds no value.
-                continue
-
-            endpoint_cache = self.cached_components.get(endpoint_name, {})
-            cached_count = sum(
-                len(records)
-                for (parent_type, parent_id), records in endpoint_cache.items()
-                if (parent_type == "device" and parent_id in vendor_dt_ids)
-                or (parent_type == "module" and parent_id in vendor_mt_ids)
-            )
-
-            rest_ep = getattr(self.netbox.dcim, endpoint_name)
-            rest_count = 0
-            if dt_ids:
-                rest_count += self._rest_count_chunked(rest_ep, dt_filter_key, dt_ids)
-            if mt_ids and endpoint_name not in self._NO_MODULE_TYPE_ENDPOINTS:
-                rest_count += self._rest_count_chunked(rest_ep, mt_filter_key, mt_ids)
-
-            if cached_count != rest_count:
-                raise GraphQLCountMismatchError(
-                    f"{endpoint_name}: GraphQL returned {cached_count} records "
-                    f"but REST reports {rest_count} — "
-                    "GraphQL may have silently truncated the result set."
-                )
-
-    def _get_filter_kwargs(self, parent_id, parent_type="device"):
-        """Build endpoint filter keyword arguments for the given parent type and ID.
-
-        Delegates to :mod:`core.compat` helpers so the version-compat logic
-        lives in exactly one place.
-
-        Args:
-            parent_id (int): ID of the device type or module type.
-            parent_type (str): ``"device"`` or ``"module"``.
-
-        Returns:
-            dict: Filter kwargs to pass to a pynetbox endpoint's ``filter()`` method.
-        """
-        if parent_type == "device":
-            return device_type_filter_kwargs(parent_id, new_filters=self.new_filters)
-        else:
-            return module_type_filter_kwargs(parent_id, new_filters=self.new_filters)
-
-    def _get_cached_or_fetch(self, cache_name, parent_id, parent_type, endpoint):
-        """Return cached components or fall back to a targeted REST filter.
-
-        The global preload (``preload_all_components``) populates most entries before
-        any create/update operations.  A cache miss therefore occurs only for newly
-        created device types (not yet in the preload snapshot) or after a cache entry
-        has been invalidated following a mutation.  In both cases a targeted
-        ``endpoint.filter()`` call is fast and returns only the relevant records.
-
-        Args:
-            cache_name: Key in self.cached_components (e.g. "rear_port_templates")
-            parent_id: Device type or module type ID
-            parent_type: "device" or "module"
-            endpoint: pynetbox endpoint proxy used for the targeted REST filter
-
-        Returns:
-            Dict mapping component name -> record
-        """
-        cache_key = (parent_type, parent_id)
-        if cache_name in self.cached_components:
-            if cache_key in self.cached_components[cache_name]:
-                return self.cached_components[cache_name][cache_key]
-
-        # Cache miss: targeted REST filter (fast for both device and module types)
-        filter_kwargs = self._get_filter_kwargs(parent_id, parent_type)
-        records = list(endpoint.filter(**filter_kwargs))
-        result = {item.name: item for item in records}
-        self.cached_components.setdefault(cache_name, {})[cache_key] = result
-        return result
-
-    def preload_module_type_components(self, module_type_ids, component_keys):
-        """Bulk-fetch components for module types and populate the cache.
-
-        For each component endpoint referenced by *component_keys*, issues one
-        ``filter()`` call per chunk of up to ``FILTER_CHUNK_SIZE`` module-type IDs
-        (filtering by module_type_id=[...]) and distributes the returned items into
-        per-module-type cache entries so that subsequent ``_get_cached_or_fetch``
-        calls hit the cache.  All component types are fetched in parallel.
-        """
-        if not module_type_ids:
-            return
-
-        seen_endpoints = set()
-        targets = []
-        for component_key in component_keys:
-            endpoint_attr, cache_name = ENDPOINT_CACHE_MAP[component_key]
-            if endpoint_attr in seen_endpoints:
-                continue
-            seen_endpoints.add(endpoint_attr)
-            targets.append((endpoint_attr, cache_name))
-
-        filter_key = module_type_filter_key(self.new_filters)
-        id_list = sorted(module_type_ids)
-
-        # Pre-populate empty entries so cache hits return {} for IDs with no components.
-        for _, cache_name in targets:
-            cache = self.cached_components.setdefault(cache_name, {})
-            for mid in id_list:
-                cache.setdefault(("module", mid), {})
-
-        def _fetch_one(endpoint_attr, cache_name):
-            """Fetch all module-type component records for *endpoint_attr* and populate *cache_name*."""
-            endpoint = getattr(self.netbox.dcim, endpoint_attr)
-            results = []
-            for chunk in _chunked(id_list, FILTER_CHUNK_SIZE):
-                for item in endpoint.filter(**{filter_key: chunk}):
-                    module_type = getattr(item, "module_type", None)
-                    if module_type is None:
-                        continue
-                    if cache_name == "front_port_templates":
-                        item = _FrontPortRecordWithMappings(item)
-                    results.append((module_type.id, item))
-            return cache_name, results
-
-        max_workers = max(1, min(len(targets), self.max_threads))
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {executor.submit(_fetch_one, ea, cn): (ea, cn) for ea, cn in targets}
-            for future in concurrent.futures.as_completed(futures):
-                cache_name, results = future.result()
-                cache = self.cached_components[cache_name]
-                for mid, item in results:
-                    cache.setdefault(("module", mid), {})[item.name] = item
 
     def _create_generic(
         self,
@@ -3002,10 +2146,10 @@ class DeviceTypes:
             parent_type (str): ``"device"`` or ``"module"``; determines parent key and counter key.
             post_process (callable | None): Optional ``(items, parent_id)`` callback run before creation.
             context (str | None): Optional context string appended to error log messages.
-            cache_name (str | None): Key in ``self.cached_components``; entry is invalidated after creation.
+            cache_name (str | None): Cache entry invalidated after creation, or None to skip.
         """
         # Look up existing components via cache or API fallback
-        existing = self._get_cached_or_fetch(cache_name, parent_id, parent_type, endpoint)
+        existing = self.components.get(cache_name, parent_id, parent_type, endpoint)
 
         to_create = [x for x in items if x["name"] not in existing]
         parent_key = "device_type" if parent_type == "device" else "module_type"
@@ -3026,10 +2170,8 @@ class DeviceTypes:
                     count = self.handle.log_module_ports_created(created, component_name)
                     self.counter.update({"components_added": count})
 
-                # Invalidate cache so subsequent lookups re-fetch with new records
-                if cache_name and cache_name in self.cached_components:
-                    cache_key = (parent_type, parent_id)
-                    self.cached_components[cache_name].pop(cache_key, None)
+                if cache_name:
+                    self.components.invalidate(cache_name, parent_type, parent_id)
             except pynetbox.RequestError as excep:
                 context_str = f" (Context: {context})" if context else ""
                 if isinstance(excep.error, list):
@@ -3062,7 +2204,7 @@ class DeviceTypes:
         Returns:
             list | None: ``rear_ports`` payload list, or ``None`` if resolution failed.
         """
-        existing_rp = self._get_cached_or_fetch(
+        existing_rp = self.components.get(
             "rear_port_templates",
             device_type_id,
             parent_type,
@@ -3131,7 +2273,7 @@ class DeviceTypes:
                 rp_pos = first_yaml.get("rear_port_position", 1)
             else:
                 rp_name, _fp_pos, rp_pos = first
-            rps = self._get_cached_or_fetch(
+            rps = self.components.get(
                 "rear_port_templates",
                 device_type_id,
                 parent_type,
@@ -3167,7 +2309,7 @@ class DeviceTypes:
         if not endpoint:
             return
 
-        existing = self._get_cached_or_fetch(cache_name, device_type_id, parent_type, endpoint)
+        existing = self.components.get(cache_name, device_type_id, parent_type, endpoint)
 
         updates = []
         for change in changes:
@@ -3210,10 +2352,7 @@ class DeviceTypes:
             self.counter.update({"components_updated": success_count})
             self.handle.verbose_log(f"Updated {success_count} {comp_type}")
 
-            # Invalidate cache so subsequent lookups re-fetch with updated records
-            if cache_name in self.cached_components:
-                cache_key = (parent_type, device_type_id)
-                self.cached_components[cache_name].pop(cache_key, None)
+            self.components.invalidate(cache_name, parent_type, device_type_id)
 
     def _apply_additions_for_type(self, comp_type, changes, yaml_data, device_type_id, parent_type):
         """Create new component templates of a single type based on detected additions.
@@ -3328,7 +2467,7 @@ class DeviceTypes:
             if not endpoint:
                 continue
 
-            existing = self._get_cached_or_fetch(cache_name, device_type_id, parent_type, endpoint)
+            existing = self.components.get(cache_name, device_type_id, parent_type, endpoint)
 
             ids_to_delete = []
             for change in changes:
@@ -3354,10 +2493,7 @@ class DeviceTypes:
                 self.counter.update({"components_removed": success_count})
                 self.handle.log(f"Removed {success_count} {comp_type}")
 
-                # Invalidate cache so subsequent lookups re-fetch without deleted records
-                if cache_name in self.cached_components:
-                    cache_key = (parent_type, device_type_id)
-                    self.cached_components[cache_name].pop(cache_key, None)
+                self.components.invalidate(cache_name, parent_type, device_type_id)
 
     def create_interfaces(self, interfaces, device_type, context=None):
         """Create interface templates for a device type, handling bridge references.
@@ -3387,7 +2523,7 @@ class DeviceTypes:
         )
 
         if bridged_interfaces:
-            all_interfaces = self._get_cached_or_fetch(
+            all_interfaces = self.components.get(
                 "interface_templates",
                 device_type,
                 "device",
@@ -3447,7 +2583,7 @@ class DeviceTypes:
 
         def link_ports(items, pid):
             """Resolve power-port name references in *items* and persist the outlet templates for device type *pid*."""
-            existing_pp = self._get_cached_or_fetch(
+            existing_pp = self.components.get(
                 "power_port_templates",
                 pid,
                 "device",
@@ -3535,7 +2671,7 @@ class DeviceTypes:
         name cannot be resolved are skipped with a log entry.
 
         Args:
-            parent_type (str): ``"device"`` or ``"module"`` — passed to :meth:`_get_cached_or_fetch`.
+            parent_type (str): ``"device"`` or ``"module"``, passed to the component cache.
             label (str): Human-readable label for log messages (e.g. ``"Front Port"``).
             context (str | None): Optional context string appended to log messages.
         """
@@ -3543,7 +2679,7 @@ class DeviceTypes:
 
         def link_rear_ports(items, pid):
             """Resolve rear-port position references in *items* and persist the front port templates for *pid*."""
-            existing_rp = self._get_cached_or_fetch(
+            existing_rp = self.components.get(
                 "rear_port_templates",
                 pid,
                 parent_type,
@@ -3706,7 +2842,7 @@ class DeviceTypes:
 
         def link_ports(items, pid):
             """Resolve power-port name references in *items* and persist the outlet templates for module type *pid*."""
-            existing_pp = self._get_cached_or_fetch(
+            existing_pp = self.components.get(
                 "power_port_templates",
                 pid,
                 "module",

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -503,11 +503,12 @@ def _process_device_types(
             handle.verbose_log("No new device types to create.")
         return
 
-    handle.verbose_log("Caching NetBox data for comparison (concurrent API requests started after parsing)...")
-    netbox.device_types.ensure_components_ready(manufacturer_slug=vendor_slug)
-
     if not device_types:
         handle.verbose_log("No device types matched filters.")
+        return
+
+    handle.verbose_log("Caching NetBox data for comparison (concurrent API requests started after parsing)...")
+    netbox.device_types.ensure_components_ready(manufacturer_slug=vendor_slug)
 
     detector = ChangeDetector(
         netbox.device_types,

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -10,6 +10,7 @@ from core.netbox_api import NetBox, _fmt_connection_error
 from core.log_handler import LogHandler
 from core.repo import DTLRepo
 from core.change_detector import ChangeDetector, ChangeType, IMAGE_PROPERTIES
+from core.component_cache import NullTaskDisplay, RichTaskDisplay
 from core.graphql_client import GraphQLError
 from pynetbox.core.query import RequestError as NetBoxRequestError
 import requests
@@ -398,6 +399,17 @@ def should_only_create_new_modules(config):
     return config.only_new or not config.update
 
 
+def _cache_display(progress, task_registry):
+    """Return the progress sink the component cache reports through.
+
+    The registry keeps the "Caching X" tasks cumulative across vendors, so the
+    display leaves them for :func:`_finalize_task_registry` to close.
+    """
+    if progress is None:
+        return NullTaskDisplay()
+    return RichTaskDisplay(progress, registry=task_registry)
+
+
 @contextmanager
 def _image_progress_scope(progress, device_types, total=0):
     """Context manager that wires up image-upload progress tracking.
@@ -450,7 +462,6 @@ def _process_device_types(
     handle,
     progress,
     device_types,
-    cache_preload_job,
     vendor_slug=None,
     task_registry=None,
 ):
@@ -466,13 +477,8 @@ def _process_device_types(
         handle (LogHandler): Logging handler used to emit progress messages.
         progress: Rich Progress instance for progress display, or None.
         device_types (list[dict]): Parsed device-type dicts to process.
-        cache_preload_job: Background component-cache preload job, or None.
         vendor_slug (str | None): Manufacturer slug for scoped integrity checks.
         task_registry (dict | None): Shared cumulative progress task registry.
-
-    Returns:
-        The updated *cache_preload_job*: ``None`` if the job was consumed by
-        ``preload_all_components``; otherwise the original value.
     """
     if config.only_new:
         new_device_types = filter_new_device_types(
@@ -495,20 +501,10 @@ def _process_device_types(
                 )
         else:
             handle.verbose_log("No new device types to create.")
-        return cache_preload_job
+        return
 
-    # Non-only_new path: always consume the preload job if one was started.
-    # This is required even when device_types is empty (e.g. module-type-only vendor)
-    # so that _global_preload_done is set before _process_module_types runs.
-    if cache_preload_job is not None:
-        handle.verbose_log("Caching NetBox data for comparison (concurrent API requests started after parsing)...")
-        netbox.device_types.preload_all_components(
-            progress=progress,
-            preload_job=cache_preload_job,
-            manufacturer_slug=vendor_slug,
-            task_registry=task_registry,
-        )
-        cache_preload_job = None
+    handle.verbose_log("Caching NetBox data for comparison (concurrent API requests started after parsing)...")
+    netbox.device_types.ensure_components_ready(manufacturer_slug=vendor_slug)
 
     if not device_types:
         handle.verbose_log("No device types matched filters.")
@@ -565,8 +561,6 @@ def _process_device_types(
                 )
         else:
             handle.verbose_log("No new device types or missing images to process.")
-
-    return cache_preload_job
 
 
 def _process_module_types(config, netbox, handle, progress, module_types, task_registry=None):
@@ -910,7 +904,7 @@ def _run_vendor_loop(
     vendor_task_id,
 ) -> None:
     """Process all selected vendors and finalize preload/progress teardown."""
-    cache_preload_job = None
+    cache = netbox.device_types.components
     try:
         for vendor in vendors_to_process:
             parsed_device_types, parsed_module_types, parsed_rack_types = _parse_vendor_types(
@@ -923,35 +917,28 @@ def _run_vendor_loop(
                 continue
 
             netbox.load_vendor(vendor["slug"])
-            cache_preload_job = None
 
             if (parsed_device_types or parsed_module_types) and not config.only_new:
-                cache_preload_job = netbox.device_types.start_component_preload(
+                cache.begin_prefetch(
                     manufacturer_slug=vendor["slug"],
-                    progress=progress,
-                    task_registry=task_registry,
+                    display=_cache_display(progress, task_registry),
                 )
 
-            def _pump():
-                if cache_preload_job and progress is not None:
-                    netbox.device_types.pump_preload_progress(cache_preload_job, progress)
-
             handle.verbose_log(f"{len(parsed_device_types)} Device-Types Found")
-            _pump()
+            cache.pump()
             netbox.create_manufacturers([vendor])
-            _pump()
+            cache.pump()
 
-            cache_preload_job = _process_device_types(
+            _process_device_types(
                 config,
                 netbox,
                 handle,
                 progress,
                 parsed_device_types,
-                cache_preload_job,
                 vendor_slug=vendor["slug"],
                 task_registry=task_registry,
             )
-            _pump()
+            cache.pump()
 
             if netbox.modules:
                 _process_module_types(
@@ -962,7 +949,7 @@ def _run_vendor_loop(
                     parsed_module_types,
                     task_registry=task_registry,
                 )
-                _pump()
+                cache.pump()
 
             _process_rack_types(
                 config,
@@ -972,17 +959,13 @@ def _run_vendor_loop(
                 parsed_rack_types,
                 task_registry=task_registry,
             )
-            _pump()
-
-            if cache_preload_job:
-                netbox.device_types.stop_component_preload(cache_preload_job, progress=progress)
-                cache_preload_job = None
+            cache.pump()
+            cache.close()
 
             if vendor_task_id is not None:
                 progress.advance(vendor_task_id)
     finally:
-        if cache_preload_job:
-            netbox.device_types.stop_component_preload(cache_preload_job, progress=progress)
+        cache.close()
         _finalize_task_registry(progress, task_registry)
         handle.set_console(None)
 

--- a/tests/test_change_detector.py
+++ b/tests/test_change_detector.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from core.component_cache import ComponentCache
 from core.graphql_client import DotDict
 from core.change_detector import (
     ChangeDetector,
@@ -10,6 +11,24 @@ from core.change_detector import (
     DeviceTypeChange,
     PropertyChange,
 )
+
+
+def _cache(**records):
+    """Build a real ComponentCache holding *records*, keyed by endpoint name.
+
+    Populating through the real object means these tests read the same index the
+    importer builds, rather than a dict that merely looks like it.
+    """
+    cache = ComponentCache(MagicMock(), MagicMock(), MagicMock(), new_filters=True, max_threads=1)
+    for endpoint_name, items in records.items():
+        cache.populate(endpoint_name, items)
+    return cache
+
+
+def _component(name, parent_id=1, parent_type="device", **fields):
+    """Build a component-template record the cache can index by its parent."""
+    parent_key = "device_type" if parent_type == "device" else "module_type"
+    return DotDict({"name": name, parent_key: DotDict({"id": parent_id}), **fields})
 
 
 class TestDeviceTypeChangeProperties:
@@ -99,49 +118,41 @@ class TestCompareDeviceTypeProperties:
 class TestCompareComponents:
     """Tests for TestCompareComponents."""
 
-    def _make_detector(self, cached_components=None):
+    def _make_detector(self, cache=None):
         dt_instance = MagicMock()
-        dt_instance.cached_components = cached_components or {}
+        dt_instance.components = cache or _cache()
         handle = MagicMock()
         return ChangeDetector(dt_instance, handle)
 
     def test_component_added_when_missing_in_netbox(self):
         detector = self._make_detector()
-        detector.device_types.cached_components = {"interface_templates": {("device", 1): {}}}
         yaml_data = {"interfaces": [{"name": "eth0", "type": "virtual"}]}
         changes = detector._compare_components(yaml_data, 1)
         assert any(c.component_name == "eth0" and c.change_type == ChangeType.COMPONENT_ADDED for c in changes)
 
     def test_component_removed_when_missing_in_yaml(self):
-        existing_comp = DotDict({"name": "eth99"})
-        detector = self._make_detector()
-        detector.device_types.cached_components = {"interface_templates": {("device", 1): {"eth99": existing_comp}}}
+        detector = self._make_detector(_cache(interface_templates=[_component("eth99")]))
         yaml_data = {"interfaces": []}  # key present but empty → removal detected
         changes = detector._compare_components(yaml_data, 1)
         assert any(c.component_name == "eth99" and c.change_type == ChangeType.COMPONENT_REMOVED for c in changes)
 
     def test_no_removal_when_key_absent(self):
-        existing_comp = DotDict({})
-        detector = self._make_detector()
-        detector.device_types.cached_components = {"interface_templates": {("device", 1): {"eth99": existing_comp}}}
+        detector = self._make_detector(_cache(interface_templates=[_component("eth99")]))
         yaml_data = {}  # 'interfaces' key absent → YAML doesn't manage this type
         changes = detector._compare_components(yaml_data, 1)
         assert not any(c.component_name == "eth99" for c in changes)
 
     def test_removal_when_key_absent_with_remove_unmanaged_types(self):
         """remove_unmanaged_types=True flags removals even when the YAML omits the section entirely."""
-        existing_comp = DotDict({"name": "eth99"})
         dt_instance = MagicMock()
-        dt_instance.cached_components = {"interface_templates": {("device", 1): {"eth99": existing_comp}}}
+        dt_instance.components = _cache(interface_templates=[_component("eth99")])
         detector = ChangeDetector(dt_instance, MagicMock(), remove_unmanaged_types=True)
         yaml_data = {}  # 'interfaces' key absent
         changes = detector._compare_components(yaml_data, 1)
         assert any(c.component_name == "eth99" and c.change_type == ChangeType.COMPONENT_REMOVED for c in changes)
 
     def test_component_changed_when_property_differs(self):
-        existing_comp = DotDict({"type": "virtual"})
-        detector = self._make_detector()
-        detector.device_types.cached_components = {"interface_templates": {("device", 1): {"eth0": existing_comp}}}
+        detector = self._make_detector(_cache(interface_templates=[_component("eth0", type="virtual")]))
         yaml_data = {"interfaces": [{"name": "eth0", "type": "1000base-t"}]}
         changes = detector._compare_components(yaml_data, 1)
         assert any(c.component_name == "eth0" and c.change_type == ChangeType.COMPONENT_CHANGED for c in changes)
@@ -149,7 +160,6 @@ class TestCompareComponents:
     def test_component_without_name_is_skipped(self):
         """YAML component entry with no 'name' key must be skipped (line 350 continue)."""
         detector = self._make_detector()
-        detector.device_types.cached_components = {"interface_templates": {("device", 1): {}}}
         yaml_data = {"interfaces": [{"type": "virtual"}]}  # no 'name' key
         changes = detector._compare_components(yaml_data, 1)
         assert changes == []
@@ -184,11 +194,11 @@ class TestCompareComponentProperties:
 class TestDetectChanges:
     """Tests for TestDetectChanges."""
 
-    def _make_detector_with_cache(self, existing_by_model=None, existing_by_slug=None, cached_components=None):
+    def _make_detector_with_cache(self, existing_by_model=None, existing_by_slug=None, cache=None):
         dt_instance = MagicMock()
         dt_instance.existing_device_types = existing_by_model or {}
         dt_instance.existing_device_types_by_slug = existing_by_slug or {}
-        dt_instance.cached_components = cached_components or {}
+        dt_instance.components = cache or _cache()
         handle = MagicMock()
         return ChangeDetector(dt_instance, handle)
 
@@ -203,7 +213,6 @@ class TestDetectChanges:
         existing = DotDict({"id": 1})
         detector = self._make_detector_with_cache(
             existing_by_model={("cisco", "X"): existing},
-            cached_components={},
         )
         dt_data = [{"manufacturer": {"slug": "cisco"}, "model": "X", "slug": "x"}]
         report = detector.detect_changes(dt_data)
@@ -214,7 +223,6 @@ class TestDetectChanges:
         existing = DotDict({"id": 1, "u_height": 1})
         detector = self._make_detector_with_cache(
             existing_by_model={("cisco", "X"): existing},
-            cached_components={},
         )
         dt_data = [
             {
@@ -232,7 +240,6 @@ class TestDetectChanges:
         detector = self._make_detector_with_cache(
             existing_by_model={},
             existing_by_slug={("cisco", "x"): existing},
-            cached_components={},
         )
         dt_data = [{"manufacturer": {"slug": "cisco"}, "model": "NewName", "slug": "x"}]
         report = detector.detect_changes(dt_data)
@@ -246,7 +253,7 @@ class TestLogChangeReport:
         dt_instance = MagicMock()
         dt_instance.existing_device_types = {}
         dt_instance.existing_device_types_by_slug = {}
-        dt_instance.cached_components = {}
+        dt_instance.components = _cache()
         handle = MagicMock()
         handle.args = SimpleNamespace(verbose=verbose)
         return ChangeDetector(dt_instance, handle)

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -5,15 +5,19 @@ real ComponentCache, so the prefetch, the index and the fallbacks are the code u
 test rather than a mock's idea of them.
 """
 
+import time
+
 import pytest
 
 from core.component_cache import (
     ComponentCache,
+    NO_MODULE_TYPE_ENDPOINTS,
     NullTaskDisplay,
+    PRELOAD_TARGETS,
     RichTaskDisplay,
     _chunked,
 )
-from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError
+from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError, _NO_MODULE_TYPE
 
 
 # ── Fakes ─────────────────────────────────────────────────────────────────────
@@ -87,9 +91,11 @@ class FakeGraphQL:
         self.records = records or {}
         self.module_types = module_types or {}
         self.module_types_error = module_types_error
+        self.endpoints_seen = []
         self.slugs_seen = []
 
     def get_component_templates(self, endpoint_name, manufacturer_slug=None, on_page=None):
+        self.endpoints_seen.append(endpoint_name)
         self.slugs_seen.append(manufacturer_slug)
         records = self.records.get(endpoint_name, [])
         if on_page is not None and records:
@@ -191,6 +197,10 @@ def test_chunked_of_nothing_yields_nothing():
     assert list(_chunked([], 3)) == []
 
 
+def test_device_only_endpoints_share_the_graphql_source():
+    assert NO_MODULE_TYPE_ENDPOINTS is _NO_MODULE_TYPE
+
+
 # ── Index ─────────────────────────────────────────────────────────────────────
 
 
@@ -243,7 +253,7 @@ class TestLookupFallback:
         cache.populate("interface_templates", [Record("eth0", device_type=1)])
         endpoint = FakeEndpoint()
 
-        result = cache.get("interface_templates", 1, "device", endpoint)
+        result = cache.get("interface_templates", "device", 1, endpoint)
 
         assert set(result) == {"eth0"}
         assert endpoint.filter_calls == []
@@ -252,8 +262,8 @@ class TestLookupFallback:
         cache = make_cache()
         endpoint = FakeEndpoint([Record("eth0", device_type=1)])
 
-        first = cache.get("interface_templates", 1, "device", endpoint)
-        second = cache.get("interface_templates", 1, "device", endpoint)
+        first = cache.get("interface_templates", "device", 1, endpoint)
+        second = cache.get("interface_templates", "device", 1, endpoint)
 
         assert set(first) == {"eth0"} and first == second
         assert endpoint.filter_calls == [{"device_type_id": 1}]
@@ -262,7 +272,7 @@ class TestLookupFallback:
         cache = make_cache()
         endpoint = FakeEndpoint()
 
-        cache.get("interface_templates", 5, "module", endpoint)
+        cache.get("interface_templates", "module", 5, endpoint)
 
         assert endpoint.filter_calls == [{"module_type_id": 5}]
 
@@ -270,7 +280,7 @@ class TestLookupFallback:
         cache = make_cache(new_filters=False)
         endpoint = FakeEndpoint()
 
-        cache.get("interface_templates", 1, "device", endpoint)
+        cache.get("interface_templates", "device", 1, endpoint)
 
         assert endpoint.filter_calls == [{"devicetype_id": 1}]
 
@@ -279,8 +289,8 @@ class TestLookupFallback:
         cache = make_cache()
         endpoint = FakeEndpoint([])
 
-        cache.get("interface_templates", 1, "device", endpoint)
-        cache.get("interface_templates", 1, "device", endpoint)
+        cache.get("interface_templates", "device", 1, endpoint)
+        cache.get("interface_templates", "device", 1, endpoint)
 
         assert len(endpoint.filter_calls) == 1
 
@@ -290,7 +300,7 @@ class TestLookupFallback:
         endpoint = FakeEndpoint([Record("eth1", device_type=1)])
 
         cache.invalidate("interface_templates", "device", 1)
-        result = cache.get("interface_templates", 1, "device", endpoint)
+        result = cache.get("interface_templates", "device", 1, endpoint)
 
         assert set(result) == {"eth1"}
 
@@ -349,7 +359,16 @@ class TestPrefetch:
         cache.begin_prefetch()
         cache.ensure_ready()
 
-        assert len(graphql.slugs_seen) == 9
+        assert len(graphql.slugs_seen) == len(PRELOAD_TARGETS)
+
+    def test_a_prefetch_cannot_be_collected_for_another_vendor(self):
+        cache = make_cache()
+        cache.begin_prefetch(manufacturer_slug="cisco")
+
+        with pytest.raises(ValueError, match="cisco.*juniper"):
+            cache.ensure_ready(manufacturer_slug="juniper")
+
+        cache.close()
 
     def test_begin_prefetch_after_ready_is_a_no_op(self):
         graphql = FakeGraphQL()
@@ -442,18 +461,21 @@ class TestPrefetchProgress:
         cache.begin_prefetch(display=RichTaskDisplay(progress))
         cache.ensure_ready()
 
-        # Every task finished, so an owning display removed all nine.
-        assert len(progress.removed) == 9
+        # Every task finished, so an owning display removed all tasks.
+        assert len(progress.removed) == len(PRELOAD_TARGETS)
 
     def test_pump_returns_true_once_an_endpoint_finishes(self):
-        cache = make_cache()
-        cache.begin_prefetch()
+        with make_cache() as cache:
+            cache.begin_prefetch()
 
-        for _ in range(200):
-            if cache.pump():
-                break
-        else:
-            pytest.fail("no endpoint completed")
+            for _ in range(200):
+                if cache.pump():
+                    break
+                time.sleep(0.001)
+            else:
+                pytest.fail("no endpoint completed")
+
+        assert cache._job is None
 
     def test_a_run_without_a_display_still_drains_the_update_queue(self):
         graphql = FakeGraphQL({"interface_templates": [Record("eth0", device_type=1)]})
@@ -573,6 +595,14 @@ class TestRichTaskDisplay:
 
         display.discard("interface_templates")
 
+    def test_a_non_key_error_while_clearing_a_task_propagates(self):
+        class BrokenProgress(FakeProgress):
+            def stop_task(self, task_id):
+                raise RuntimeError("display failed")
+
+        with pytest.raises(RuntimeError, match="display failed"):
+            RichTaskDisplay(BrokenProgress())._clear(1)
+
     def test_the_null_display_accepts_every_call(self):
         display = NullTaskDisplay()
 
@@ -620,7 +650,7 @@ class TestFetching:
         cache.ensure_ready()
 
         assert set(cache.entries("interface_templates", "device", 1)) == {"eth0"}
-        assert "interface_templates" not in graphql.records
+        assert "interface_templates" not in graphql.endpoints_seen
 
     def test_a_rest_only_endpoint_with_no_records_reports_no_progress(self, monkeypatch):
         import core.component_cache as module
@@ -686,6 +716,17 @@ class TestVendorGuards:
         )
 
         with pytest.raises(GraphQLCountMismatchError, match="interface_templates"):
+            cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
+
+        assert cache.ready is False
+
+    def test_a_mismatch_after_foreign_records_are_cleared_names_the_scope_failure(self):
+        cache = self._cache_for(
+            {"interface_templates": [Record("eth0", device_type=99)]},
+            counts={"interface_templates": 1},
+        )
+
+        with pytest.raises(GraphQLCountMismatchError, match="cross-vendor contamination"):
             cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
 
     def test_module_types_of_the_vendor_count_towards_the_check(self):

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -1,0 +1,744 @@
+"""Tests for core/component_cache.py — the component-template cache.
+
+The fakes here stand in for NetBox and Rich, not for the cache: every test drives a
+real ComponentCache, so the prefetch, the index and the fallbacks are the code under
+test rather than a mock's idea of them.
+"""
+
+import pytest
+
+from core.component_cache import (
+    ComponentCache,
+    NullTaskDisplay,
+    RichTaskDisplay,
+    _chunked,
+)
+from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError
+
+
+# ── Fakes ─────────────────────────────────────────────────────────────────────
+
+
+class Record:
+    """A component-template record, as GraphQL and pynetbox both present one."""
+
+    def __init__(self, name, device_type=None, module_type=None):
+        """Build a record owned by a device type or a module type."""
+        self.name = name
+        self.device_type = _Parent(device_type) if device_type else None
+        self.module_type = _Parent(module_type) if module_type else None
+
+
+class _Parent:
+    """The nested ``{"id": n}`` shape both APIs return for a parent."""
+
+    def __init__(self, id):
+        """Hold the parent *id*."""
+        self.id = id
+
+
+class FakeEndpoint:
+    """A pynetbox endpoint proxy that answers from a fixed record list."""
+
+    def __init__(self, records=(), count=0):
+        """Answer filters with *records* and counts with *count*."""
+        self.records = list(records)
+        self._count = count
+        self.filter_calls = []
+        self.count_calls = []
+
+    def filter(self, **kwargs):
+        self.filter_calls.append(kwargs)
+        return list(self.records)
+
+    def all(self):
+        return list(self.records)
+
+    def count(self, **kwargs):
+        self.count_calls.append(kwargs)
+        return self._count
+
+
+class FakeDcim:
+    """The ``api.dcim`` namespace, creating an empty endpoint on first access."""
+
+    def __init__(self, endpoints):
+        """Serve endpoints out of the *endpoints* mapping."""
+        self._endpoints = endpoints
+
+    def __getattr__(self, name):
+        return self._endpoints.setdefault(name, FakeEndpoint())
+
+
+class FakeNetBox:
+    """A pynetbox API object holding only the dcim endpoints these tests use."""
+
+    def __init__(self, endpoints=None):
+        """Expose *endpoints* under ``dcim``."""
+        self.endpoints = endpoints if endpoints is not None else {}
+        self.dcim = FakeDcim(self.endpoints)
+
+
+class FakeGraphQL:
+    """GraphQL client returning canned component templates and module types."""
+
+    def __init__(self, records=None, module_types=None, module_types_error=None):
+        """Return *records* per endpoint, and *module_types* or *module_types_error* for the guard."""
+        self.records = records or {}
+        self.module_types = module_types or {}
+        self.module_types_error = module_types_error
+        self.slugs_seen = []
+
+    def get_component_templates(self, endpoint_name, manufacturer_slug=None, on_page=None):
+        self.slugs_seen.append(manufacturer_slug)
+        records = self.records.get(endpoint_name, [])
+        if on_page is not None and records:
+            on_page(len(records))
+        return records
+
+    def get_module_types(self, manufacturer_slugs=None):
+        if self.module_types_error is not None:
+            raise self.module_types_error
+        return self.module_types
+
+
+class FakeHandle:
+    """A log handler that keeps what it was told."""
+
+    def __init__(self):
+        """Start with no messages."""
+        self.logged = []
+        self.verbose = []
+
+    def log(self, message):
+        self.logged.append(message)
+
+    def verbose_log(self, message):
+        self.verbose.append(message)
+
+
+class FakeTask:
+    """One row of the progress display."""
+
+    def __init__(self, task_id, description, total):
+        """Create the task with its *description* and starting *total*."""
+        self.id = task_id
+        self.description = description
+        self.total = total
+        self.completed = 0
+
+
+class FakeProgress:
+    """The slice of Rich's Progress that RichTaskDisplay uses."""
+
+    def __init__(self):
+        """Start with an empty task table."""
+        self.tasks = []
+        self._next_id = 0
+        self.removed = []
+        self.stopped = []
+
+    def add_task(self, description, total=None):
+        self._next_id += 1
+        self.tasks.append(FakeTask(self._next_id, description, total))
+        return self._next_id
+
+    def _task(self, task_id):
+        return next((t for t in self.tasks if t.id == task_id), None)
+
+    def update(self, task_id, total=None, completed=None, advance=None):
+        task = self._task(task_id)
+        if task is None:
+            raise KeyError(task_id)
+        if total is not None:
+            task.total = total
+        if completed is not None:
+            task.completed = completed
+        if advance is not None:
+            task.completed += advance
+
+    def stop_task(self, task_id):
+        self.stopped.append(task_id)
+
+    def remove_task(self, task_id):
+        task = self._task(task_id)
+        if task is None:
+            raise KeyError(task_id)
+        self.tasks.remove(task)
+        self.removed.append(task_id)
+
+
+def make_cache(netbox=None, graphql=None, handle=None, **kwargs):
+    """Build a real ComponentCache over fakes."""
+    return ComponentCache(
+        netbox or FakeNetBox(),
+        graphql or FakeGraphQL(),
+        handle or FakeHandle(),
+        kwargs.pop("new_filters", True),
+        kwargs.pop("max_threads", 4),
+        **kwargs,
+    )
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def test_chunked_splits_and_keeps_the_remainder():
+    assert list(_chunked([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+
+
+def test_chunked_of_nothing_yields_nothing():
+    assert list(_chunked([], 3)) == []
+
+
+# ── Index ─────────────────────────────────────────────────────────────────────
+
+
+class TestIndexing:
+    """populate() turns a flat record list into the per-parent index lookups read."""
+
+    def test_records_are_indexed_under_their_parent(self):
+        cache = make_cache()
+
+        count = cache.populate(
+            "interface_templates",
+            [Record("eth0", device_type=1), Record("eth1", device_type=1), Record("xe-0", module_type=7)],
+        )
+
+        assert count == 3
+        assert set(cache.entries("interface_templates", "device", 1)) == {"eth0", "eth1"}
+        assert set(cache.entries("interface_templates", "module", 7)) == {"xe-0"}
+
+    def test_a_record_with_no_parent_is_skipped(self):
+        cache = make_cache()
+
+        assert cache.populate("interface_templates", [Record("orphan")]) == 0
+
+    def test_a_second_populate_merges_rather_than_replaces(self):
+        cache = make_cache()
+
+        cache.populate("interface_templates", [Record("eth0", device_type=1)])
+        cache.populate("interface_templates", [Record("eth1", device_type=2)])
+
+        assert cache.entries("interface_templates", "device", 1)
+        assert cache.entries("interface_templates", "device", 2)
+
+    def test_entries_returns_empty_for_an_unknown_parent(self):
+        assert make_cache().entries("interface_templates", "device", 999) == {}
+
+    def test_record_stores_a_known_empty_set(self):
+        """An empty entry means "no components", which must read as a hit."""
+        cache = make_cache()
+
+        cache.record("interface_templates", "device", 1, {})
+
+        assert cache.entries("interface_templates", "device", 1) == {}
+
+
+class TestLookupFallback:
+    """get() reaches NetBox only on a miss, and remembers the answer."""
+
+    def test_a_hit_does_not_touch_netbox(self):
+        cache = make_cache()
+        cache.populate("interface_templates", [Record("eth0", device_type=1)])
+        endpoint = FakeEndpoint()
+
+        result = cache.get("interface_templates", 1, "device", endpoint)
+
+        assert set(result) == {"eth0"}
+        assert endpoint.filter_calls == []
+
+    def test_a_miss_filters_by_device_type_and_caches_the_answer(self):
+        cache = make_cache()
+        endpoint = FakeEndpoint([Record("eth0", device_type=1)])
+
+        first = cache.get("interface_templates", 1, "device", endpoint)
+        second = cache.get("interface_templates", 1, "device", endpoint)
+
+        assert set(first) == {"eth0"} and first == second
+        assert endpoint.filter_calls == [{"device_type_id": 1}]
+
+    def test_a_miss_filters_by_module_type_for_a_module_parent(self):
+        cache = make_cache()
+        endpoint = FakeEndpoint()
+
+        cache.get("interface_templates", 5, "module", endpoint)
+
+        assert endpoint.filter_calls == [{"module_type_id": 5}]
+
+    def test_old_netbox_filter_names_are_used_when_asked(self):
+        cache = make_cache(new_filters=False)
+        endpoint = FakeEndpoint()
+
+        cache.get("interface_templates", 1, "device", endpoint)
+
+        assert endpoint.filter_calls == [{"devicetype_id": 1}]
+
+    def test_an_empty_result_still_becomes_a_hit(self):
+        """Otherwise every parent with no components is re-read on each lookup."""
+        cache = make_cache()
+        endpoint = FakeEndpoint([])
+
+        cache.get("interface_templates", 1, "device", endpoint)
+        cache.get("interface_templates", 1, "device", endpoint)
+
+        assert len(endpoint.filter_calls) == 1
+
+    def test_invalidate_forces_the_next_lookup_to_re_read(self):
+        cache = make_cache()
+        cache.populate("interface_templates", [Record("eth0", device_type=1)])
+        endpoint = FakeEndpoint([Record("eth1", device_type=1)])
+
+        cache.invalidate("interface_templates", "device", 1)
+        result = cache.get("interface_templates", 1, "device", endpoint)
+
+        assert set(result) == {"eth1"}
+
+    def test_invalidating_an_absent_entry_is_harmless(self):
+        make_cache().invalidate("interface_templates", "device", 1)
+
+
+# ── Prefetch ──────────────────────────────────────────────────────────────────
+
+
+class TestPrefetch:
+    """The cache owns the futures, so callers never sequence them by hand."""
+
+    def test_ensure_ready_fetches_every_endpoint_and_indexes_it(self):
+        graphql = FakeGraphQL({"interface_templates": [Record("eth0", device_type=1)]})
+        cache = make_cache(graphql=graphql)
+
+        cache.ensure_ready()
+
+        assert cache.ready is True
+        assert set(cache.entries("interface_templates", "device", 1)) == {"eth0"}
+
+    def test_ensure_ready_starts_the_prefetch_when_none_is_in_flight(self):
+        """The self-healing path: a later stage may be the first to need the data."""
+        graphql = FakeGraphQL({"interface_templates": [Record("eth0", device_type=1)]})
+        cache = make_cache(graphql=graphql)
+
+        cache.ensure_ready()
+
+        assert cache.entries("interface_templates", "device", 1)
+
+    def test_ensure_ready_is_idempotent(self):
+        graphql = FakeGraphQL({"interface_templates": [Record("eth0", device_type=1)]})
+        cache = make_cache(graphql=graphql)
+
+        cache.ensure_ready()
+        fetches = len(graphql.slugs_seen)
+        cache.ensure_ready()
+
+        assert len(graphql.slugs_seen) == fetches
+
+    def test_begin_prefetch_scopes_the_fetch_to_one_vendor(self):
+        graphql = FakeGraphQL()
+        cache = make_cache(graphql=graphql)
+
+        cache.begin_prefetch(manufacturer_slug="cisco")
+        cache.ensure_ready()
+
+        assert set(graphql.slugs_seen) == {"cisco"}
+
+    def test_begin_prefetch_twice_does_not_start_a_second_job(self):
+        graphql = FakeGraphQL()
+        cache = make_cache(graphql=graphql)
+
+        cache.begin_prefetch()
+        cache.begin_prefetch()
+        cache.ensure_ready()
+
+        assert len(graphql.slugs_seen) == 9
+
+    def test_begin_prefetch_after_ready_is_a_no_op(self):
+        graphql = FakeGraphQL()
+        cache = make_cache(graphql=graphql)
+        cache.ensure_ready()
+
+        cache.begin_prefetch()
+
+        assert cache._job is None
+
+    def test_a_failed_endpoint_is_logged_and_raised(self):
+        class Boom(FakeGraphQL):
+            def get_component_templates(self, endpoint_name, manufacturer_slug=None, on_page=None):
+                raise RuntimeError("upstream is down")
+
+        handle = FakeHandle()
+        cache = make_cache(graphql=Boom(), handle=handle)
+
+        with pytest.raises(RuntimeError, match="upstream is down"):
+            cache.ensure_ready()
+
+        assert any("Preload failed for" in message for message in handle.logged)
+
+    def test_reset_drops_everything_so_the_next_vendor_starts_clean(self):
+        graphql = FakeGraphQL({"interface_templates": [Record("eth0", device_type=1)]})
+        cache = make_cache(graphql=graphql)
+        cache.ensure_ready()
+
+        cache.reset()
+
+        assert cache.ready is False
+        assert cache.entries("interface_templates", "device", 1) == {}
+
+    def test_close_without_a_prefetch_is_harmless(self):
+        make_cache().close()
+
+    def test_close_cancels_a_prefetch_still_in_flight(self):
+        cache = make_cache()
+        cache.begin_prefetch()
+
+        cache.close()
+
+        assert cache._job is None
+
+    def test_the_cache_can_scope_a_prefetch_to_a_with_block(self):
+        with make_cache() as cache:
+            cache.begin_prefetch()
+
+        assert cache._job is None
+
+    def test_begin_prefetch_releases_the_executor_when_submitting_fails(self, monkeypatch):
+        import core.component_cache as module
+
+        class Broken:
+            """An executor that refuses to submit."""
+
+            def __init__(self, max_workers=None):
+                """Record itself so the test can inspect the shutdown."""
+                self.shutdown_calls = []
+                Broken.instance = self
+
+            def submit(self, *args, **kwargs):
+                raise RuntimeError("no threads")
+
+            def shutdown(self, wait=True, cancel_futures=False):
+                self.shutdown_calls.append(cancel_futures)
+
+        monkeypatch.setattr(module.concurrent.futures, "ThreadPoolExecutor", Broken)
+        progress = FakeProgress()
+        cache = make_cache()
+
+        with pytest.raises(RuntimeError, match="no threads"):
+            cache.begin_prefetch(display=RichTaskDisplay(progress))
+
+        assert Broken.instance.shutdown_calls == [True]
+        assert progress.tasks == []
+
+
+class TestPrefetchProgress:
+    """Progress leaves through the display, so the cache never imports Rich."""
+
+    def test_pump_without_a_prefetch_reports_nothing(self):
+        assert make_cache().pump() is False
+
+    def test_pump_advances_and_completes_each_endpoint(self):
+        graphql = FakeGraphQL({"interface_templates": [Record("eth0", device_type=1)]})
+        cache = make_cache(graphql=graphql)
+        progress = FakeProgress()
+
+        cache.begin_prefetch(display=RichTaskDisplay(progress))
+        cache.ensure_ready()
+
+        # Every task finished, so an owning display removed all nine.
+        assert len(progress.removed) == 9
+
+    def test_pump_returns_true_once_an_endpoint_finishes(self):
+        cache = make_cache()
+        cache.begin_prefetch()
+
+        for _ in range(200):
+            if cache.pump():
+                break
+        else:
+            pytest.fail("no endpoint completed")
+
+    def test_a_run_without_a_display_still_drains_the_update_queue(self):
+        graphql = FakeGraphQL({"interface_templates": [Record("eth0", device_type=1)]})
+        cache = make_cache(graphql=graphql)
+
+        cache.begin_prefetch(display=NullTaskDisplay())
+        cache.ensure_ready()
+
+        assert cache.ready is True
+
+
+class TestRichTaskDisplay:
+    """The Rich adapter, including the shared-registry mode that keeps tasks on screen."""
+
+    def test_a_task_is_created_per_endpoint(self):
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress)
+
+        display.add("interface_templates", "Interfaces")
+
+        assert [t.description for t in progress.tasks] == ["Caching Interfaces"]
+
+    def test_a_registry_reuses_one_task_across_vendors(self):
+        progress = FakeProgress()
+        registry = {}
+
+        RichTaskDisplay(progress, registry=registry).add("interface_templates", "Interfaces")
+        RichTaskDisplay(progress, registry=registry).add("interface_templates", "Interfaces")
+
+        assert len(progress.tasks) == 1
+
+    def test_a_registry_owner_keeps_the_task_after_it_finishes(self):
+        """The caller finalizes cumulative tasks, so the display must not remove them."""
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress, registry={})
+        display.add("interface_templates", "Interfaces")
+
+        display.finish("interface_templates", 5)
+
+        assert len(progress.tasks) == 1
+        assert progress.removed == []
+
+    def test_advance_moves_the_bar_forward(self):
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress)
+        display.add("interface_templates", "Interfaces")
+
+        display.advance("interface_templates", 3)
+
+        assert progress.tasks[0].completed == 3
+
+    def test_a_rewind_clamps_at_zero(self):
+        """A retry rewinds the count; a negative bar would be nonsense."""
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress)
+        display.add("interface_templates", "Interfaces")
+        display.advance("interface_templates", 2)
+
+        display.advance("interface_templates", -5)
+
+        assert progress.tasks[0].completed == 0
+
+    def test_advancing_an_unknown_or_zero_amount_does_nothing(self):
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress)
+        display.add("interface_templates", "Interfaces")
+
+        display.advance("power_port_templates", 4)
+        display.advance("interface_templates", 0)
+
+        assert progress.tasks[0].completed == 0
+
+    def test_a_rewind_of_an_already_removed_task_is_ignored(self):
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress)
+        display.add("interface_templates", "Interfaces")
+        progress.tasks.clear()
+
+        display.advance("interface_templates", -1)
+
+    def test_finish_completes_and_removes_an_owned_task(self):
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress)
+        display.add("interface_templates", "Interfaces")
+
+        display.finish("interface_templates", 12)
+
+        assert progress.tasks == []
+        assert progress.stopped == [1]
+
+    def test_finishing_an_unknown_endpoint_is_ignored(self):
+        RichTaskDisplay(FakeProgress()).finish("interface_templates", 1)
+
+    def test_discard_drops_an_owned_task(self):
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress)
+        display.add("interface_templates", "Interfaces")
+
+        display.discard("interface_templates")
+
+        assert progress.tasks == []
+
+    def test_discard_leaves_a_registry_task_alone(self):
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress, registry={})
+        display.add("interface_templates", "Interfaces")
+
+        display.discard("interface_templates")
+
+        assert len(progress.tasks) == 1
+
+    def test_a_display_that_already_dropped_the_task_does_not_raise(self):
+        progress = FakeProgress()
+        display = RichTaskDisplay(progress)
+        display.add("interface_templates", "Interfaces")
+        progress.tasks.clear()
+
+        display.discard("interface_templates")
+
+    def test_the_null_display_accepts_every_call(self):
+        display = NullTaskDisplay()
+
+        display.add("k", "Label")
+        display.advance("k", 1)
+        display.finish("k", 2)
+        display.discard("k")
+
+
+# ── Fetching ──────────────────────────────────────────────────────────────────
+
+
+class TestFetching:
+    """Where each endpoint is read from, and what wraps the result."""
+
+    def test_front_port_records_are_wrapped(self):
+        """Change detection needs one mappings shape across NetBox versions."""
+
+        class Wrapped:
+            """Stand-in for the front-port mappings wrapper."""
+
+            def __init__(self, record):
+                """Keep the fields the index reads."""
+                self.record = record
+                self.name = record.name
+                self.device_type = record.device_type
+                self.module_type = record.module_type
+
+        graphql = FakeGraphQL({"front_port_templates": [Record("fp0", device_type=1)]})
+        cache = make_cache(graphql=graphql, wrap_record=Wrapped)
+
+        cache.ensure_ready()
+
+        assert isinstance(cache.entries("front_port_templates", "device", 1)["fp0"], Wrapped)
+
+    def test_a_rest_only_endpoint_is_read_over_rest(self, monkeypatch):
+        import core.component_cache as module
+
+        monkeypatch.setattr(module, "REST_ONLY_ENDPOINTS", frozenset({"interface_templates"}))
+        endpoint = FakeEndpoint([Record("eth0", device_type=1)])
+        netbox = FakeNetBox({"interface_templates": endpoint})
+        graphql = FakeGraphQL()
+        cache = make_cache(netbox=netbox, graphql=graphql)
+
+        cache.ensure_ready()
+
+        assert set(cache.entries("interface_templates", "device", 1)) == {"eth0"}
+        assert "interface_templates" not in graphql.records
+
+    def test_a_rest_only_endpoint_with_no_records_reports_no_progress(self, monkeypatch):
+        import core.component_cache as module
+
+        monkeypatch.setattr(module, "REST_ONLY_ENDPOINTS", frozenset({"interface_templates"}))
+        netbox = FakeNetBox({"interface_templates": FakeEndpoint([])})
+        cache = make_cache(netbox=netbox)
+
+        cache.ensure_ready()
+
+        assert cache.ready is True
+
+    def test_records_arrive_unwrapped_when_no_wrapper_is_given(self):
+        graphql = FakeGraphQL({"front_port_templates": [Record("fp0", device_type=1)]})
+        cache = make_cache(graphql=graphql)
+
+        cache.ensure_ready()
+
+        assert cache.entries("front_port_templates", "device", 1)["fp0"].name == "fp0"
+
+
+# ── Vendor-scoped guards ──────────────────────────────────────────────────────
+
+
+class TestVendorGuards:
+    """Cross-vendor contamination and silent GraphQL truncation both corrupt a run."""
+
+    def _cache_for(self, records, module_types=None, counts=None, **kwargs):
+        endpoints = {name: FakeEndpoint(count=count) for name, count in (counts or {}).items()}
+        return make_cache(
+            netbox=FakeNetBox(endpoints),
+            graphql=FakeGraphQL(records, module_types=module_types or {}),
+            **kwargs,
+        )
+
+    def test_a_matching_vendor_keeps_its_records(self):
+        cache = self._cache_for(
+            {"interface_templates": [Record("eth0", device_type=1)]},
+            counts={"interface_templates": 1},
+        )
+
+        cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
+
+        assert set(cache.entries("interface_templates", "device", 1)) == {"eth0"}
+
+    def test_records_from_another_vendor_are_cleared(self):
+        handle = FakeHandle()
+        cache = self._cache_for(
+            {"interface_templates": [Record("eth0", device_type=99)]},
+            handle=handle,
+        )
+
+        cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
+
+        assert cache.entries("interface_templates", "device", 99) == {}
+        assert any("cross-vendor contamination" in message for message in handle.logged)
+
+    def test_a_truncated_fetch_stops_the_run(self):
+        """Fewer cached records than REST reports means GraphQL dropped some silently."""
+        cache = self._cache_for(
+            {"interface_templates": [Record("eth0", device_type=1)]},
+            counts={"interface_templates": 7},
+        )
+
+        with pytest.raises(GraphQLCountMismatchError, match="interface_templates"):
+            cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
+
+    def test_module_types_of_the_vendor_count_towards_the_check(self):
+        cache = self._cache_for(
+            {"interface_templates": [Record("xe-0", module_type=8)]},
+            module_types={"cisco": {"M1": _Parent(8)}},
+            counts={"interface_templates": 1},
+        )
+
+        cache.ensure_ready(manufacturer_slug="cisco", device_type_ids=set())
+
+        assert set(cache.entries("interface_templates", "module", 8)) == {"xe-0"}
+
+    def test_device_bays_are_not_counted_against_module_types(self):
+        """device_bay_templates has no module-type path, so a module filter would 404."""
+        cache = self._cache_for({}, module_types={"cisco": {"M1": _Parent(8)}})
+
+        cache.ensure_ready(manufacturer_slug="cisco", device_type_ids=set())
+
+        assert cache.netbox.endpoints["device_bay_templates"].count_calls == []
+
+    def test_a_rejected_schema_skips_the_guard_with_a_warning(self):
+        handle = FakeHandle()
+        cache = make_cache(
+            graphql=FakeGraphQL(module_types_error=GraphQLSchemaError("unknown field")),
+            handle=handle,
+        )
+
+        cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
+
+        assert any("integrity check skipped" in message for message in handle.logged)
+
+    def test_a_transport_failure_does_not_skip_the_guard(self):
+        """Only a rejected query shape is safe to ignore; a dead connection is not."""
+        cache = make_cache(graphql=FakeGraphQL(module_types_error=ConnectionError("refused")))
+
+        with pytest.raises(ConnectionError):
+            cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
+
+    def test_rest_counts_are_chunked_to_keep_the_url_short(self):
+        cache = self._cache_for({}, counts={"interface_templates": 0})
+
+        cache.ensure_ready(manufacturer_slug="cisco", device_type_ids=set(range(250)))
+
+        chunks = [call["device_type_id"] for call in cache.netbox.endpoints["interface_templates"].count_calls]
+        assert [len(chunk) for chunk in chunks] == [100, 100, 50]
+
+    def test_a_rest_only_endpoint_is_not_compared_with_itself(self, monkeypatch):
+        import core.component_cache as module
+
+        monkeypatch.setattr(module, "REST_ONLY_ENDPOINTS", frozenset({"interface_templates"}))
+        cache = self._cache_for({}, counts={"interface_templates": 99})
+
+        cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
+
+        assert cache.netbox.endpoints["interface_templates"].count_calls == []

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -1229,6 +1229,19 @@ class TestPerVendorLoop:
         mock_repo.get_devices.side_effect = _get_devices_se
         mock_repo.parse_files.side_effect = _parse_files_se
 
+        netbox_class = nb_dt_import.NetBox
+
+        def _filter_actionable(module_types, all_module_types, only_new=False):
+            return netbox_class.filter_actionable_module_types(
+                mock_nb,
+                module_types,
+                all_module_types,
+                only_new=only_new,
+            )
+
+        mock_nb._fetch_module_type_existing_images.return_value = {}
+        mock_nb.filter_actionable_module_types.side_effect = _filter_actionable
+
         self._run_main(["nb-dt-import.py"], mock_repo, mock_nb, nb_dt_import)
 
         cache = mock_nb.device_types.components
@@ -1236,10 +1249,31 @@ class TestPerVendorLoop:
         assert cache.begin_prefetch.call_args.kwargs.get("manufacturer_slug") == "acbel"
 
         # An unscoped readiness call fetches every vendor, which is the regression.
+        assert mock_nb.device_types.ensure_components_ready.call_args_list
         for call in mock_nb.device_types.ensure_components_ready.call_args_list:
             assert call.kwargs.get("manufacturer_slug") is not None, (
                 "ensure_components_ready called without manufacturer_slug (global fetch triggered)"
             )
+
+    def test_empty_device_type_list_returns_before_cache_readiness(self, nb_dt_import):
+        class DeviceTypes:
+            def ensure_components_ready(self, manufacturer_slug=None):
+                raise AssertionError("empty input must not populate the component cache")
+
+        class Handle:
+            def __init__(self):
+                self.messages = []
+
+            def verbose_log(self, message):
+                self.messages.append(message)
+
+        handle = Handle()
+        config = SimpleNamespace(only_new=False)
+        netbox = SimpleNamespace(device_types=DeviceTypes())
+
+        nb_dt_import._process_device_types(config, netbox, handle, None, [], vendor_slug="cisco")
+
+        assert handle.messages == ["No device types matched filters."]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -1231,14 +1231,14 @@ class TestPerVendorLoop:
 
         self._run_main(["nb-dt-import.py"], mock_repo, mock_nb, nb_dt_import)
 
-        mock_nb.device_types.start_component_preload.assert_called_once()
-        call_kwargs = mock_nb.device_types.start_component_preload.call_args
-        assert call_kwargs.kwargs.get("manufacturer_slug") == "acbel"
+        cache = mock_nb.device_types.components
+        cache.begin_prefetch.assert_called_once()
+        assert cache.begin_prefetch.call_args.kwargs.get("manufacturer_slug") == "acbel"
 
-        # The unscoped preload_all_components (no manufacturer_slug) must NOT be called
-        for call in mock_nb.device_types.preload_all_components.call_args_list:
+        # An unscoped readiness call fetches every vendor, which is the regression.
+        for call in mock_nb.device_types.ensure_components_ready.call_args_list:
             assert call.kwargs.get("manufacturer_slug") is not None, (
-                "preload_all_components called without manufacturer_slug (global fetch triggered)"
+                "ensure_components_ready called without manufacturer_slug (global fetch triggered)"
             )
 
 
@@ -1763,7 +1763,6 @@ class TestMainAdditionalCoverage:
         )
         mock_repo.parse_files.side_effect = _parse_files
         mock_nb = _make_mock_netbox()
-        mock_nb.device_types.start_component_preload.return_value = "job-1"
         progress = MagicMock()
         progress.console = object()
 
@@ -1779,7 +1778,7 @@ class TestMainAdditionalCoverage:
             patch("nb_dt_import.DTLRepo", return_value=mock_repo),
             patch("nb_dt_import.NetBox", return_value=mock_nb),
             patch("nb_dt_import.ChangeDetector") as MockDetector,
-            patch("nb_dt_import._process_device_types", return_value="job-1"),
+            patch("nb_dt_import._process_device_types"),
             patch("sys.stdout") as mock_stdout,
             patch("nb_dt_import.get_progress_panel", return_value=_Ctx()),
         ):
@@ -1787,8 +1786,8 @@ class TestMainAdditionalCoverage:
             MockDetector.return_value.detect_changes.return_value = _empty_change_report()
             nb_dt_import.main()
 
-        mock_nb.device_types.pump_preload_progress.assert_called()
-        mock_nb.device_types.stop_component_preload.assert_called_with("job-1", progress=progress)
+        mock_nb.device_types.components.pump.assert_called()
+        mock_nb.device_types.components.close.assert_called()
 
     def test_main_stops_preload_job_in_finally_on_error(self, nb_dt_import):
         mock_repo = _make_mock_repo()
@@ -1800,7 +1799,6 @@ class TestMainAdditionalCoverage:
             [{"manufacturer": {"slug": "cisco"}, "model": "X", "slug": "x"}] if files == ["device.yaml"] else []
         )
         mock_nb = _make_mock_netbox()
-        mock_nb.device_types.start_component_preload.return_value = "job-2"
         progress = MagicMock()
         progress.console = object()
 
@@ -1821,7 +1819,7 @@ class TestMainAdditionalCoverage:
             with pytest.raises(RuntimeError, match="boom"):
                 nb_dt_import.main()
 
-        mock_nb.device_types.stop_component_preload.assert_called_with("job-2", progress=progress)
+        mock_nb.device_types.components.close.assert_called()
 
     def test_build_argument_parser_sets_expected_defaults_and_flags(self, nb_dt_import):
         parser = config_module.build_argument_parser({})
@@ -1890,7 +1888,6 @@ class TestMainAdditionalCoverage:
             else []
         )
         netbox = _make_mock_netbox(modules=True)
-        netbox.device_types.start_component_preload.return_value = "job-1"
         slug_resolved = {
             "device_files": {"empty": [], "cisco": ["resolved.yaml"]},
             "module_vendors": {"cisco"},
@@ -1902,7 +1899,7 @@ class TestMainAdditionalCoverage:
                 "nb_dt_import._parse_vendor_racks",
                 side_effect=[[], [{"manufacturer": {"slug": "cisco"}, "model": "R", "slug": "r"}]],
             ),
-            patch("nb_dt_import._process_device_types", return_value="job-1") as mock_process_device_types,
+            patch("nb_dt_import._process_device_types") as mock_process_device_types,
             patch("nb_dt_import._process_module_types") as mock_process_module_types,
             patch("nb_dt_import._process_rack_types") as mock_process_rack_types,
             patch("nb_dt_import._finalize_task_registry") as mock_finalize,
@@ -1923,16 +1920,12 @@ class TestMainAdditionalCoverage:
             )
 
         netbox.load_vendor.assert_called_once_with("cisco")
-        netbox.device_types.start_component_preload.assert_called_once_with(
-            manufacturer_slug="cisco",
-            progress=progress,
-            task_registry={},
-        )
-        # pump is now called after preload start, after create_manufacturers,
-        # and after each of the three process_*_types steps → 5 calls total
-        assert netbox.device_types.pump_preload_progress.call_count == 5
-        netbox.device_types.pump_preload_progress.assert_called_with("job-1", progress)
-        netbox.device_types.stop_component_preload.assert_called_once_with("job-1", progress=progress)
+        netbox.device_types.components.begin_prefetch.assert_called_once()
+        assert netbox.device_types.components.begin_prefetch.call_args.kwargs["manufacturer_slug"] == "cisco"
+        # pump runs after the prefetch starts, after create_manufacturers, and after
+        # each of the three process_*_types steps → 5 calls
+        assert netbox.device_types.components.pump.call_count == 5
+        netbox.device_types.components.close.assert_called()
         netbox.create_manufacturers.assert_called_once_with([{"slug": "cisco", "name": "Cisco"}])
         mock_process_device_types.assert_called_once()
         assert mock_process_device_types.call_args.args[4] == [
@@ -1960,7 +1953,6 @@ class TestMainAdditionalCoverage:
             [{"manufacturer": {"slug": "cisco"}, "model": "X", "slug": "x"}] if files == ["device.yaml"] else []
         )
         netbox = _make_mock_netbox()
-        netbox.device_types.start_component_preload.return_value = "job-2"
 
         with (
             patch("nb_dt_import._parse_vendor_racks", return_value=[]),
@@ -1983,7 +1975,7 @@ class TestMainAdditionalCoverage:
                     vendor_task_id=8,
                 )
 
-        netbox.device_types.stop_component_preload.assert_called_once_with("job-2", progress=progress)
+        netbox.device_types.components.close.assert_called()
         mock_finalize.assert_called_once_with(progress, {})
 
 

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -1,4 +1,3 @@
-import queue
 import threading
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -92,6 +91,20 @@ def make_device_types(mock_settings, mock_handle, graphql_client):
         )
 
     return _factory
+
+
+class _NoComponents:
+    """GraphQL stand-in whose component endpoints are all empty."""
+
+    def get_component_templates(self, endpoint_name, manufacturer_slug=None, on_page=None):
+        """Return no records for any endpoint."""
+        return []
+
+
+def _mark_cache_ready(device_types):
+    """Run the real prefetch against an empty NetBox, so later lookups do not start one."""
+    device_types.components.graphql = _NoComponents()
+    device_types.components.ensure_ready()
 
 
 def test_netbox_init(mock_settings, mock_pynetbox, mock_handle):
@@ -214,432 +227,6 @@ def test_redundant_image_upload(mock_settings, mock_pynetbox, mock_handle):
     nb.device_types.upload_images.assert_not_called()
 
 
-def test_preload_global_builds_component_cache(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-):
-    mock_nb_api = mock_pynetbox.api.return_value
-
-    mock_graphql_requests.side_effect = _make_graphql_dispatch(
-        {
-            "device_type_list": {
-                "data": {
-                    "device_type_list": [
-                        {
-                            "id": "1",
-                            "model": "ModelA",
-                            "slug": "model-a",
-                            "manufacturer": {
-                                "id": "10",
-                                "name": "Cisco",
-                                "slug": "cisco",
-                            },
-                            "front_image": None,
-                            "rear_image": None,
-                        }
-                    ]
-                }
-            },
-            "interface_template_list": {
-                "data": {
-                    "interface_template_list": [
-                        {
-                            "id": "100",
-                            "name": "eth0",
-                            "type": "1000base-t",
-                            "label": "",
-                            "mgmt_only": False,
-                            "enabled": True,
-                            "poe_mode": None,
-                            "poe_type": None,
-                            "device_type": {"id": "1"},
-                            "module_type": None,
-                        }
-                    ]
-                }
-            },
-        }
-    )
-
-    dt = make_device_types(nb_api=mock_nb_api)
-    dt.preload_all_components(progress_wrapper=None)
-
-    assert "interface_templates" in dt.cached_components
-    assert ("device", 1) in dt.cached_components["interface_templates"]
-    assert dt.cached_components["interface_templates"][("device", 1)]["eth0"].name == "eth0"
-
-
-def test_fetch_global_endpoint_records_uses_graphql(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-):
-    mock_nb_api = mock_pynetbox.api.return_value
-
-    mock_graphql_requests.side_effect = _make_graphql_dispatch(
-        {
-            "device_type_list": {"data": {"device_type_list": []}},
-            "interface_template_list": {
-                "data": {
-                    "interface_template_list": [
-                        {
-                            "id": "1",
-                            "name": "xe-0/0/0",
-                            "type": "10gbase-x-sfpp",
-                            "label": "",
-                            "mgmt_only": False,
-                            "enabled": True,
-                            "poe_mode": None,
-                            "poe_type": None,
-                            "device_type": {"id": "5"},
-                            "module_type": None,
-                        },
-                        {
-                            "id": "2",
-                            "name": "xe-0/0/1",
-                            "type": "10gbase-x-sfpp",
-                            "label": "",
-                            "mgmt_only": False,
-                            "enabled": True,
-                            "poe_mode": None,
-                            "poe_type": None,
-                            "device_type": {"id": "5"},
-                            "module_type": None,
-                        },
-                        {
-                            "id": "3",
-                            "name": "xe-0/0/2",
-                            "type": "10gbase-x-sfpp",
-                            "label": "",
-                            "mgmt_only": False,
-                            "enabled": True,
-                            "poe_mode": None,
-                            "poe_type": None,
-                            "device_type": {"id": "5"},
-                            "module_type": None,
-                        },
-                    ]
-                }
-            },
-        }
-    )
-
-    dt = make_device_types(nb_api=mock_nb_api)
-    updates = []
-
-    records = dt._fetch_global_endpoint_records(
-        "interface_templates",
-        progress_callback=lambda endpoint, advance: updates.append((endpoint, advance)),
-    )
-
-    assert len(records) == 3
-    assert records[0].name == "xe-0/0/0"
-    # REST endpoint should NOT be called
-    mock_nb_api.dcim.interface_templates.all.assert_not_called()
-    assert updates == [("interface_templates", 3)]
-
-
-def test_fetch_global_endpoint_records_progress_emits_live_per_page(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-):
-    """Progress callback must fire per page during the fetch, not in one batch at the end.
-
-    Regression: an earlier implementation buffered per-attempt advances and only
-    flushed them after the fetch completed.  For large endpoints (e.g. 100k+
-    interfaces) the bar appeared frozen at 0 for the whole fetch, then jumped
-    to 100% at the end.
-    """
-    from unittest.mock import patch as _patch
-    from core.graphql_client import DotDict
-
-    mock_nb_api = mock_pynetbox.api.return_value
-    dt = make_device_types(nb_api=mock_nb_api)
-
-    pages = [
-        [DotDict({"id": "1", "name": "a", "device_type": {"id": "5"}, "module_type": None})],
-        [DotDict({"id": "2", "name": "b", "device_type": {"id": "5"}, "module_type": None})],
-        [DotDict({"id": "3", "name": "c", "device_type": {"id": "5"}, "module_type": None})],
-    ]
-
-    advances_during_fetch = []
-
-    def fake_get(endpoint_name, manufacturer_slug=None, on_page=None):
-        # Stream pages and verify that the consumer-facing callback was invoked
-        # before the next page is yielded.
-        all_records = []
-        for idx, page in enumerate(pages, start=1):
-            all_records.extend(page)
-            if on_page is not None:
-                on_page(len(page))
-                assert len(advances_during_fetch) == idx
-        return all_records
-
-    def progress_cb(endpoint, advance):
-        advances_during_fetch.append((endpoint, advance))
-
-    with _patch.object(dt.graphql, "get_component_templates", side_effect=fake_get):
-        records = dt._fetch_global_endpoint_records(
-            "interface_templates",
-            progress_callback=progress_cb,
-        )
-
-    assert len(records) == 3
-    # Live emission: one callback per page, not a single batched flush.
-    assert advances_during_fetch == [
-        ("interface_templates", 1),
-        ("interface_templates", 1),
-        ("interface_templates", 1),
-    ]
-
-
-def test_fetch_global_endpoint_records_passes_manufacturer_slug(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-):
-    """manufacturer_slug is forwarded to get_component_templates."""
-    from unittest.mock import patch as _patch
-
-    mock_nb_api = mock_pynetbox.api.return_value
-    dt = make_device_types(nb_api=mock_nb_api)
-
-    received_slugs = []
-
-    def fake_get(endpoint_name, manufacturer_slug=None, on_page=None):
-        received_slugs.append(manufacturer_slug)
-        return []
-
-    with _patch.object(dt.graphql, "get_component_templates", side_effect=fake_get):
-        dt._fetch_global_endpoint_records("interface_templates", manufacturer_slug="cisco")
-
-    assert received_slugs == ["cisco"]
-
-
-def test_fetch_global_endpoint_records_progress_skipped_when_empty(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-):
-    mock_nb_api = mock_pynetbox.api.return_value
-
-    mock_graphql_requests.side_effect = _make_graphql_dispatch(
-        {
-            "device_type_list": {"data": {"device_type_list": []}},
-            "interface_template_list": {"data": {"interface_template_list": []}},
-        }
-    )
-
-    dt = make_device_types(nb_api=mock_nb_api)
-    updates = []
-
-    fetched = dt._fetch_global_endpoint_records(
-        "interface_templates",
-        progress_callback=lambda endpoint, advance: updates.append((endpoint, advance)),
-    )
-
-    assert fetched == []
-    assert updates == []
-
-
-def test_fetch_global_endpoint_records_returns_all_records_without_retry(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-):
-    """_fetch_global_endpoint_records returns all GraphQL records; no retry logic."""
-    from unittest.mock import patch as _patch
-    from core.graphql_client import DotDict
-
-    mock_nb_api = mock_pynetbox.api.return_value
-    dt = make_device_types(nb_api=mock_nb_api)
-
-    iface1 = DotDict({"id": "1", "name": "xe-0/0/0", "device_type": {"id": "5"}, "module_type": None})
-    iface2 = DotDict({"id": "2", "name": "xe-0/0/1", "device_type": {"id": "5"}, "module_type": None})
-
-    call_count = {"n": 0}
-
-    def fake_get(endpoint_name, manufacturer_slug=None, on_page=None):
-        call_count["n"] += 1
-        return [iface1, iface2]
-
-    with _patch.object(dt.graphql, "get_component_templates", side_effect=fake_get):
-        records = dt._fetch_global_endpoint_records("interface_templates")
-
-    assert len(records) == 2
-    assert call_count["n"] == 1  # exactly one call, no retry
-
-
-def test_fetch_global_endpoint_records_no_warning_logged(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-):
-    """No warnings are logged by _fetch_global_endpoint_records on a normal fetch."""
-    mock_nb_api = mock_pynetbox.api.return_value
-    mock_graphql_requests.side_effect = _make_graphql_dispatch(
-        {
-            "device_type_list": {"data": {"device_type_list": []}},
-            "interface_template_list": {
-                "data": {
-                    "interface_template_list": [
-                        {
-                            "id": "1",
-                            "name": "xe-0/0/0",
-                            "type": "10gbase-x-sfpp",
-                            "label": "",
-                            "mgmt_only": False,
-                            "enabled": True,
-                            "poe_mode": None,
-                            "poe_type": None,
-                            "device_type": {"id": "5"},
-                            "module_type": None,
-                        }
-                    ]
-                }
-            },
-        }
-    )
-
-    dt = make_device_types(nb_api=mock_nb_api)
-    logged = []
-    dt.handle.log = lambda msg: logged.append(msg)
-
-    records = dt._fetch_global_endpoint_records("interface_templates")
-
-    assert len(records) == 1
-    assert not any("WARNING" in m for m in logged)
-
-
-def test_preload_always_global_caches_all_vendors(
-    mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-):
-    """Preload always fetches all components globally, regardless of vendor filter."""
-    mock_nb_api = mock_pynetbox.api.return_value
-
-    mock_graphql_requests.side_effect = _make_graphql_dispatch(
-        {
-            "device_type_list": {
-                "data": {
-                    "device_type_list": [
-                        {
-                            "id": "1",
-                            "model": "ModelA",
-                            "slug": "model-a",
-                            "manufacturer": {
-                                "id": "10",
-                                "name": "Cisco",
-                                "slug": "cisco",
-                            },
-                            "front_image": None,
-                            "rear_image": None,
-                        },
-                        {
-                            "id": "2",
-                            "model": "ModelB",
-                            "slug": "model-b",
-                            "manufacturer": {
-                                "id": "20",
-                                "name": "Juniper",
-                                "slug": "juniper",
-                            },
-                            "front_image": None,
-                            "rear_image": None,
-                        },
-                    ]
-                }
-            },
-            "interface_template_list": {
-                "data": {
-                    "interface_template_list": [
-                        {
-                            "id": "100",
-                            "name": "eth0",
-                            "type": "1000base-t",
-                            "label": "",
-                            "mgmt_only": False,
-                            "enabled": True,
-                            "poe_mode": None,
-                            "poe_type": None,
-                            "device_type": {"id": "1"},
-                            "module_type": None,
-                        },
-                        {
-                            "id": "200",
-                            "name": "xe-0/0/0",
-                            "type": "10gbase-x-sfpp",
-                            "label": "",
-                            "mgmt_only": False,
-                            "enabled": True,
-                            "poe_mode": None,
-                            "poe_type": None,
-                            "device_type": {"id": "2"},
-                            "module_type": None,
-                        },
-                    ]
-                }
-            },
-        }
-    )
-
-    dt = make_device_types(nb_api=mock_nb_api)
-    dt.preload_all_components(progress_wrapper=None)
-
-    # Both vendors are cached because global fetch returns everything
-    assert ("device", 1) in dt.cached_components["interface_templates"]
-    assert ("device", 2) in dt.cached_components["interface_templates"]
-
-
-def test_start_component_preload_global_job_can_be_consumed(
-    mock_settings, mock_pynetbox, graphql_client, make_device_types
-):
-    mock_nb_api = mock_pynetbox.api.return_value
-
-    dt = make_device_types(nb_api=mock_nb_api)
-    preload_job = dt.start_component_preload()
-
-    assert preload_job["mode"] == "global"
-    dt.preload_all_components(progress_wrapper=None, preload_job=preload_job)
-    assert preload_job["executor"] is None
-
-
-def test_preload_tolerates_none_endpoint_totals(mock_settings, mock_pynetbox, graphql_client, make_device_types):
-    """``_preload_track_progress`` must not raise TypeError when a total is ``None``.
-
-    ``endpoint_totals`` may contain ``None`` sentinels when a count is unavailable.
-    Internal ``max(endpoint_totals.get(name, 0), ...)`` calls would raise ``TypeError``
-    on ``None`` because ``dict.get`` returns the stored ``None`` instead of the default.
-    The fix uses ``endpoint_totals.get(name) or 0`` to coerce ``None`` to ``0`` for
-    the ``max()`` comparison.
-    """
-    from concurrent.futures import Future
-
-    dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
-
-    components = [("interface_templates", "Interfaces")]
-    fut = Future()
-    fut.set_result([])
-    futures = {"interface_templates": fut}
-
-    progress = MagicMock()
-    task_ids = {"interface_templates": "task-1"}
-    endpoint_totals = {"interface_templates": None}
-
-    import queue
-
-    progress_updates = queue.Queue()
-    # Exercise BOTH branches: the already-finished branch (where the
-    # endpoint_totals.get(name) or 0 fallback runs) and the pending-future
-    # branch (covered by another test).  Marking interface_templates finished
-    # routes through the already_done code path with a None total.
-    preload_job = {"finished_endpoints": {"interface_templates"}}
-
-    # Must not raise TypeError on max(None, ...).
-    result = dt._preload_track_progress(
-        components,
-        futures,
-        progress,
-        task_ids,
-        preload_job,
-        progress_updates,
-        endpoint_totals,
-    )
-
-    assert result == {"interface_templates": []}
-    # The already_done branch must update the task to completed==total.
-    # With an empty result list and a None REST count, final_total = max(0, 0, 1) = 1
-    # (the max(..., 1) floor prevents a 0/0 bar in the Rich progress UI).
-    progress.update.assert_called_once_with("task-1", total=1, completed=1)
-
-
 def test_upload_images_success_logs_verbose_only(
     mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path, mock_handle
 ):
@@ -681,99 +268,6 @@ def test_filter_new_module_types_returns_only_missing_items(mock_settings, mock_
     ]
 
 
-def test_filter_actionable_module_types_skips_unchanged_existing_module(
-    mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
-):
-    mock_nb_api = mock_pynetbox.api.return_value
-    mock_nb_api.version = "3.5"
-
-    mock_graphql_requests.side_effect = paginate_dispatch(
-        {
-            "manufacturer_list": [],
-            "device_type_list": [],
-            "module_type_list": [
-                {
-                    "id": "42",
-                    "model": "Linecard 1",
-                    "manufacturer": {"id": "20", "name": "Juniper", "slug": "juniper"},
-                }
-            ],
-            "image_attachment_list": [],
-        }
-    )
-
-    existing_interface = MagicMock()
-    existing_interface.name = "xe-0/0/0"
-
-    nb = NetBox(mock_settings, mock_handle)
-    # Simulate the global GraphQL preload having already populated the cache for module 42.
-    nb.device_types._global_preload_done = True
-    nb.device_types.cached_components["interface_templates"] = {("module", 42): {"xe-0/0/0": existing_interface}}
-
-    module_types = [
-        {
-            "manufacturer": {"slug": "juniper"},
-            "model": "Linecard 1",
-            "slug": "linecard-1",
-            "interfaces": [{"name": "xe-0/0/0"}],
-            "src": "/tmp/repo/module-types/juniper/linecard-1.yaml",
-        }
-    ]
-
-    with patch("glob.glob", return_value=[]):
-        actionable, _, _ = nb.filter_actionable_module_types(
-            module_types,
-            nb.get_existing_module_types(),
-            only_new=False,
-        )
-
-    assert actionable == []
-
-
-def test_filter_actionable_module_types_includes_module_with_missing_component(
-    mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
-):
-    mock_nb_api = mock_pynetbox.api.return_value
-    mock_nb_api.version = "3.5"
-
-    mock_graphql_requests.side_effect = paginate_dispatch(
-        {
-            "manufacturer_list": [],
-            "device_type_list": [],
-            "module_type_list": [
-                {
-                    "id": "42",
-                    "model": "Linecard 1",
-                    "manufacturer": {"id": "20", "name": "Juniper", "slug": "juniper"},
-                }
-            ],
-            "image_attachment_list": [],
-        }
-    )
-
-    nb = NetBox(mock_settings, mock_handle)
-    # Global preload done; module 42 has no interfaces cached → component is missing.
-    nb.device_types._global_preload_done = True
-    nb.device_types.cached_components["interface_templates"] = {("module", 42): {}}
-
-    module_type = {
-        "manufacturer": {"slug": "juniper"},
-        "model": "Linecard 1",
-        "slug": "linecard-1",
-        "interfaces": [{"name": "xe-0/0/0"}],
-        "src": "/tmp/repo/module-types/juniper/linecard-1.yaml",
-    }
-
-    with patch("glob.glob", return_value=[]):
-        actionable, _, _ = nb.filter_actionable_module_types(
-            [module_type],
-            nb.get_existing_module_types(),
-            only_new=False,
-        )
-
-    assert actionable == [module_type]
-
-
 def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox, graphql_client, make_device_types):
     """On NetBox 4.5+, _mappings updates should rebuild the full M2M rear_ports array."""
     from core.change_detector import ChangeType, ComponentChange, PropertyChange
@@ -790,10 +284,8 @@ def test_update_components_m2m_front_port_mappings(mock_settings, mock_pynetbox,
     rp.id = 99
 
     # Cache both front port templates and rear port templates
-    dt.cached_components = {
-        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
-        "rear_port_templates": {("device", 1): {"RP1": rp}},
-    }
+    dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
+    dt.components.record("rear_port_templates", "device", 1, {"RP1": rp})
 
     # new_value is a frozenset of (rear_port_name, fp_pos, rp_pos) tuples
     new_mappings_set = frozenset({("RP1", 1, 2), ("RP1", 2, 1)})
@@ -835,10 +327,8 @@ def test_update_components_m2m_no_mapping_warns(
     existing_fp.id = 10
     existing_fp.name = "FP1"
 
-    dt.cached_components = {
-        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
-        "rear_port_templates": {("device", 1): {}},  # Empty: rear port missing
-    }
+    dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
+    dt.components.record("rear_port_templates", "device", 1, {})
 
     new_mappings_set = frozenset({("MISSING_RP", 1, 1)})
     old_mappings_set = frozenset()
@@ -877,10 +367,8 @@ def test_update_components_legacy_mapping_translates_to_fields(
     rp = MagicMock()
     rp.id = 99
 
-    dt.cached_components = {
-        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
-        "rear_port_templates": {("device", 1): {"RP1": rp}},
-    }
+    dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
+    dt.components.record("rear_port_templates", "device", 1, {"RP1": rp})
 
     new_mappings_set = frozenset({("RP1", 1, 3)})
     old_mappings_set = frozenset({("RP1", 1, 1)})
@@ -920,10 +408,8 @@ def test_update_components_legacy_mapping_missing_rear_port_warns(
     existing_fp.id = 10
     existing_fp.name = "FP1"
 
-    dt.cached_components = {
-        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
-        "rear_port_templates": {("device", 1): {}},  # Empty cache
-    }
+    dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
+    dt.components.record("rear_port_templates", "device", 1, {})
 
     new_mappings_set = frozenset({("MISSING_RP", 1, 1)})
     old_mappings_set = frozenset()
@@ -962,10 +448,8 @@ def test_update_components_legacy_mapping_two_tuple_warns_and_skips(
     existing_fp = MagicMock()
     existing_fp.id = 10
     existing_fp.name = "FP1"
-    dt.cached_components = {
-        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
-        "rear_port_templates": {("device", 1): {}},
-    }
+    dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
+    dt.components.record("rear_port_templates", "device", 1, {})
 
     # 2-tuple: legacy ChangeDetector cannot include rp_name
     new_mappings_set = frozenset({(1, 3)})
@@ -1010,10 +494,8 @@ def test_update_components_legacy_mapping_two_tuple_uses_yaml_fallback(
     rp = MagicMock()
     rp.id = 99
 
-    dt.cached_components = {
-        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
-        "rear_port_templates": {("device", 1): {"RP1": rp}},
-    }
+    dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
+    dt.components.record("rear_port_templates", "device", 1, {"RP1": rp})
 
     # 2-tuple: legacy ChangeDetector cannot include rp_name
     new_mappings_set = frozenset({(1, 3)})
@@ -1062,9 +544,7 @@ def test_update_components_legacy_mapping_empty_clears_rear_port(
     existing_fp = MagicMock()
     existing_fp.id = 10
     existing_fp.name = "FP1"
-    dt.cached_components = {
-        "front_port_templates": {("device", 1): {"FP1": existing_fp}},
-    }
+    dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
 
     changes = [
         ComponentChange(
@@ -1177,114 +657,6 @@ class TestFrontPortRecordWithMappings:
         assert wrapped.name == "FP1"
 
 
-class TestStopComponentPreload:
-    """Tests for TestStopComponentPreload."""
-
-    def test_noop_on_none(self):
-        DeviceTypes.stop_component_preload(None)  # should not raise
-
-    def test_cancels_pending_futures_and_shuts_down(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        mock_nb_api = mock_pynetbox.api.return_value
-        make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        future.done.return_value = False
-        executor = MagicMock()
-        preload_job = {
-            "futures": {"interface_templates": future},
-            "executor": executor,
-        }
-        DeviceTypes.stop_component_preload(preload_job)
-        future.cancel.assert_called_once()
-        executor.shutdown.assert_called_once()
-        assert preload_job["executor"] is None
-
-
-class TestApplyProgressUpdates:
-    """Tests for TestApplyProgressUpdates."""
-
-    def test_returns_false_when_no_progress(self):
-        result = DeviceTypes._apply_progress_updates(None, None, None)
-        assert result is False
-
-    def test_drains_queue_and_advances(self):
-        progress = MagicMock()
-        task_ids = {"interface_templates": 1}
-        q = queue.Queue()
-        q.put(("interface_templates", 5))
-        result = DeviceTypes._apply_progress_updates(q, progress, task_ids)
-        assert result is True
-        progress.update.assert_called_once_with(1, advance=5)
-
-    def test_drops_disallowed_endpoints(self):
-        progress = MagicMock()
-        task_ids = {"interface_templates": 1}
-        q = queue.Queue()
-        q.put(("other_endpoint", 5))
-        result = DeviceTypes._apply_progress_updates(q, progress, task_ids, allowed_endpoints={"interface_templates"})
-        assert result is False
-
-
-class TestBuildComponentCache:
-    """Tests for TestBuildComponentCache."""
-
-    def test_device_type_indexed(self):
-        item = MagicMock()
-        item.device_type = MagicMock(id=10)
-        item.module_type = None
-        item.name = "eth0"
-        cache, count = DeviceTypes._build_component_cache([item])
-        assert ("device", 10) in cache
-        assert "eth0" in cache[("device", 10)]
-        assert count == 1
-
-    def test_module_type_indexed(self):
-        item = MagicMock()
-        item.device_type = None
-        item.module_type = MagicMock(id=20)
-        item.name = "xe-0"
-        cache, count = DeviceTypes._build_component_cache([item])
-        assert ("module", 20) in cache
-        assert count == 1
-
-    def test_item_without_parent_skipped(self):
-        item = MagicMock()
-        item.device_type = None
-        item.module_type = None
-        cache, count = DeviceTypes._build_component_cache([item])
-        assert count == 0
-
-
-class TestGetFilterKwargs:
-    """Tests for TestGetFilterKwargs."""
-
-    def test_device_old_filter(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.new_filters = False
-        assert dt._get_filter_kwargs(1, "device") == {"devicetype_id": 1}
-
-    def test_device_new_filter(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.new_filters = True
-        assert dt._get_filter_kwargs(1, "device") == {"device_type_id": 1}
-
-    def test_module_new_filter(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.new_filters = True
-        assert dt._get_filter_kwargs(5, "module") == {"module_type_id": 5}
-
-    def test_module_old_filter(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.new_filters = False
-        assert dt._get_filter_kwargs(5, "module") == {"moduletype_id": 5}
-
-
 class TestCreateGenericError:
     """Tests for TestCreateGenericError."""
 
@@ -1296,7 +668,7 @@ class TestCreateGenericError:
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
+        dt.components.record("interface_templates", "device", 1, {})
 
         endpoint = MagicMock()
         err = real_pynb.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
@@ -1321,7 +693,7 @@ class TestCreateGenericError:
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
+        dt.components.record("interface_templates", "device", 1, {})
 
         endpoint = MagicMock()
         err = real_pynb.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
@@ -1350,7 +722,7 @@ class TestRemoveComponents:
 
         existing_comp = MagicMock()
         existing_comp.id = 99
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": existing_comp}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": existing_comp})
 
         from core.change_detector import ChangeType, ComponentChange
 
@@ -1363,7 +735,7 @@ class TestRemoveComponents:
     def test_skips_component_not_in_cache(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
+        dt.components.record("interface_templates", "device", 1, {})
 
         from core.change_detector import ChangeType, ComponentChange
 
@@ -1387,7 +759,7 @@ class TestCreatePowerConsolePorts:
     ):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"power_port_templates": {("device", 1): {}}}
+        dt.components.record("power_port_templates", "device", 1, {})
         dt.create_power_ports([{"name": "PSU1"}], 1)
         mock_nb_api.dcim.power_port_templates.create.assert_called_once()
 
@@ -1396,7 +768,7 @@ class TestCreatePowerConsolePorts:
     ):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"console_port_templates": {("device", 1): {}}}
+        dt.components.record("console_port_templates", "device", 1, {})
         dt.create_console_ports([{"name": "Con1"}], 1)
         mock_nb_api.dcim.console_port_templates.create.assert_called_once()
 
@@ -1405,7 +777,7 @@ class TestCreatePowerConsolePorts:
     ):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"rear_port_templates": {("device", 1): {}}}
+        dt.components.record("rear_port_templates", "device", 1, {})
         dt.create_rear_ports([{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
         mock_nb_api.dcim.rear_port_templates.create.assert_called_once()
 
@@ -1414,7 +786,7 @@ class TestCreatePowerConsolePorts:
     ):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"device_bay_templates": {("device", 1): {}}}
+        dt.components.record("device_bay_templates", "device", 1, {})
         dt.create_device_bays([{"name": "Bay1"}], 1)
         mock_nb_api.dcim.device_bay_templates.create.assert_called_once()
 
@@ -1436,10 +808,8 @@ class TestCreateDeviceTypesNewDT:
         created_dt.model = "TestSwitch"
         mock_nb_api.dcim.device_types.create.return_value = created_dt
 
-        dt.cached_components = {
-            "interface_templates": {("device", 1): {}},
-            "power_port_templates": {("device", 1): {}},
-        }
+        dt.components.record("interface_templates", "device", 1, {})
+        dt.components.record("power_port_templates", "device", 1, {})
 
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = dt
@@ -1657,67 +1027,13 @@ class TestUpdateComponentsAdditions:
 
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
+        dt.components.record("interface_templates", "device", 1, {})
 
         changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_ADDED)]
         yaml_data = {"interfaces": [{"name": "eth0", "type": "virtual"}]}
         dt.update_components(yaml_data, 1, changes, parent_type="device")
 
         mock_nb_api.dcim.interface_templates.create.assert_called_once()
-
-
-class TestFetchGlobalEndpointRestPath:
-    """Tests for TestFetchGlobalEndpointRestPath."""
-
-    def test_front_port_templates_uses_graphql_and_wraps(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_graphql_requests
-    ):
-        """front_port_templates always uses GraphQL and wraps records with _FrontPortRecordWithMappings."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.m2m_front_ports = True  # no longer affects front_port_templates path
-
-        fp_record = {
-            "id": "1",
-            "name": "FP1",
-            "type": "8p8c",
-            "label": "",
-            "mappings": [],
-            "device_type": {"id": "42"},
-            "module_type": None,
-        }
-
-        # First call returns one record; second call returns empty to stop pagination.
-        resp1 = MagicMock()
-        resp1.raise_for_status = MagicMock()
-        resp1.json.return_value = {"data": {"front_port_template_list": [fp_record]}}
-        resp2 = MagicMock()
-        resp2.raise_for_status = MagicMock()
-        resp2.json.return_value = {"data": {"front_port_template_list": []}}
-        mock_graphql_requests.side_effect = [resp1, resp2]
-
-        records = dt._fetch_global_endpoint_records("front_port_templates")
-        # REST endpoint should NOT be called
-        mock_nb_api.dcim.front_port_templates.all.assert_not_called()
-        assert len(records) == 1
-        assert isinstance(records[0], _FrontPortRecordWithMappings)
-
-    def test_rest_only_endpoint_with_progress_callback(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.REST_ONLY_ENDPOINTS = frozenset(["interface_templates"])
-
-        raw = MagicMock()
-        mock_nb_api.dcim.interface_templates.all.return_value = [raw]
-
-        updates = []
-        dt._fetch_global_endpoint_records(
-            "interface_templates",
-            progress_callback=lambda e, n: updates.append((e, n)),
-        )
-        assert updates == [("interface_templates", 1)]
 
 
 class TestCountDeviceTypeImages:
@@ -1880,15 +1196,13 @@ class TestCreateModuleTypesBody:
         created_mt.model = "LC"
         nb.netbox.dcim.module_types.create.return_value = created_mt
 
-        nb.device_types.cached_components = {
-            "interface_templates": {("module", 5): {}},
-            "power_port_templates": {("module", 5): {}},
-            "console_port_templates": {("module", 5): {}},
-            "power_outlet_templates": {("module", 5): {}},
-            "console_server_port_templates": {("module", 5): {}},
-            "rear_port_templates": {("module", 5): {}},
-            "front_port_templates": {("module", 5): {}},
-        }
+        nb.device_types.components.record("interface_templates", "module", 5, {})
+        nb.device_types.components.record("power_port_templates", "module", 5, {})
+        nb.device_types.components.record("console_port_templates", "module", 5, {})
+        nb.device_types.components.record("power_outlet_templates", "module", 5, {})
+        nb.device_types.components.record("console_server_port_templates", "module", 5, {})
+        nb.device_types.components.record("rear_port_templates", "module", 5, {})
+        nb.device_types.components.record("front_port_templates", "module", 5, {})
 
         module_type = {
             "manufacturer": {"slug": "cisco"},
@@ -1910,35 +1224,35 @@ class TestCreateModuleComponents:
     def test_create_module_interfaces(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"interface_templates": {("module", 1): {}}}
+        dt.components.record("interface_templates", "module", 1, {})
         dt.create_module_interfaces([{"name": "xe-0"}], 1)
         mock_nb_api.dcim.interface_templates.create.assert_called_once()
 
     def test_create_module_power_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"power_port_templates": {("module", 1): {}}}
+        dt.components.record("power_port_templates", "module", 1, {})
         dt.create_module_power_ports([{"name": "PSU1"}], 1)
         mock_nb_api.dcim.power_port_templates.create.assert_called_once()
 
     def test_create_module_console_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"console_port_templates": {("module", 1): {}}}
+        dt.components.record("console_port_templates", "module", 1, {})
         dt.create_module_console_ports([{"name": "Con1"}], 1)
         mock_nb_api.dcim.console_port_templates.create.assert_called_once()
 
     def test_create_module_console_server_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"console_server_port_templates": {("module", 1): {}}}
+        dt.components.record("console_server_port_templates", "module", 1, {})
         dt.create_module_console_server_ports([{"name": "CSP1"}], 1)
         mock_nb_api.dcim.console_server_port_templates.create.assert_called_once()
 
     def test_create_module_rear_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"rear_port_templates": {("module", 1): {}}}
+        dt.components.record("rear_port_templates", "module", 1, {})
         dt.create_module_rear_ports([{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
         mock_nb_api.dcim.rear_port_templates.create.assert_called_once()
 
@@ -2101,7 +1415,7 @@ class TestCreateConsoleServerPorts:
     ):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"console_server_port_templates": {("device", 1): {}}}
+        dt.components.record("console_server_port_templates", "device", 1, {})
         dt.create_console_server_ports([{"name": "CSP1"}], 1)
         mock_nb_api.dcim.console_server_port_templates.create.assert_called_once()
 
@@ -2114,7 +1428,7 @@ class TestCreateModuleBays:
     ):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"module_bay_templates": {("device", 1): {}}}
+        dt.components.record("module_bay_templates", "device", 1, {})
         dt.create_module_bays([{"name": "MB1"}], 1)
         mock_nb_api.dcim.module_bay_templates.create.assert_called_once()
 
@@ -3149,7 +2463,7 @@ class TestFilterActionableModuleTypesEdge:
             }
         )
         nb = NetBox(mock_settings, mock_handle)
-        nb.device_types._global_preload_done = True  # isolate from preload side-effects
+        _mark_cache_ready(nb.device_types)
 
         existing_mt = MagicMock()
         existing_mt.id = 42
@@ -3201,7 +2515,7 @@ class TestFilterActionableModuleTypesEdge:
         )
         nb = NetBox(mock_settings, mock_handle)
         # Skip the GraphQL preload — these tests isolate scalar/image diffs.
-        nb.device_types._global_preload_done = True
+        _mark_cache_ready(nb.device_types)
 
         existing_mt = DotDict(
             {"id": 42, "model": "IOM-s-3.0T", "part_number": "OLD_PN", "manufacturer": {"slug": "nokia"}}
@@ -3254,7 +2568,7 @@ class TestFilterActionableModuleTypesEdge:
         )
         nb = NetBox(mock_settings, mock_handle)
         # Skip the GraphQL preload — these tests isolate scalar/image diffs.
-        nb.device_types._global_preload_done = True
+        _mark_cache_ready(nb.device_types)
 
         existing_mt = DotDict(
             {"id": 42, "model": "IOM-s-3.0T", "part_number": "OLD_PN", "manufacturer": {"slug": "nokia"}}
@@ -3310,7 +2624,7 @@ class TestFilterActionableModuleTypesEdge:
         )
         nb = NetBox(mock_settings, mock_handle)
         # Skip the GraphQL preload — these tests isolate scalar/image diffs.
-        nb.device_types._global_preload_done = True
+        _mark_cache_ready(nb.device_types)
 
         existing_mt = DotDict(
             {"id": 42, "model": "IOM-s-3.0T", "part_number": "3HE16474AA", "manufacturer": {"slug": "nokia"}}
@@ -3355,7 +2669,7 @@ class TestFilterActionableModuleTypesEdge:
         )
         nb = NetBox(mock_settings, mock_handle)
         # Skip the GraphQL preload — these tests isolate scalar/image diffs.
-        nb.device_types._global_preload_done = True
+        _mark_cache_ready(nb.device_types)
 
         existing_mt = DotDict(
             {"id": 42, "model": "IOM-s-3.0T", "part_number": "3HE16474AA", "manufacturer": {"slug": "nokia"}}
@@ -3592,20 +2906,12 @@ class TestCreateModuleTypesEdge:
         all_module_types = {"nokia": {"IOM-s-3.0T": existing_mt}}
 
         # Cache shows interface with no description; YAML has a description → COMPONENT_CHANGED
-        nb.device_types.cached_components = {
-            "interface_templates": {
-                ("module", 5): {
-                    "xe-0": DotDict(
-                        {
-                            "id": "10",
-                            "name": "xe-0",
-                            "description": "",
-                            "type": {"value": "10gbase-x-sfpp"},
-                        }
-                    )
-                }
-            },
-        }
+        nb.device_types.components.record(
+            "interface_templates",
+            "module",
+            5,
+            {"xe-0": DotDict({"id": "10", "name": "xe-0", "description": "", "type": {"value": "10gbase-x-sfpp"}})},
+        )
 
         module_type = {
             "manufacturer": {"slug": "nokia"},
@@ -3662,20 +2968,12 @@ class TestCreateModuleTypesEdge:
         )
         all_module_types = {"nokia": {"IOM-s-3.0T": existing_mt}}
 
-        nb.device_types.cached_components = {
-            "interface_templates": {
-                ("module", 5): {
-                    "xe-0": DotDict(
-                        {
-                            "id": "10",
-                            "name": "xe-0",
-                            "description": "",
-                            "type": {"value": "10gbase-x-sfpp"},
-                        }
-                    )
-                }
-            },
-        }
+        nb.device_types.components.record(
+            "interface_templates",
+            "module",
+            5,
+            {"xe-0": DotDict({"id": "10", "name": "xe-0", "description": "", "type": {"value": "10gbase-x-sfpp"}})},
+        )
 
         module_type = {
             "manufacturer": {"slug": "nokia"},
@@ -3734,16 +3032,15 @@ class TestCreateModuleTypesEdge:
         all_module_types = {"nokia": {"IOM-s-3.0T": existing_mt}}
 
         # Cache has an interface that YAML doesn't have → COMPONENT_REMOVED
-        nb.device_types.cached_components = {
-            "interface_templates": {
-                ("module", 5): {
-                    "xe-0": DotDict(
-                        {"id": "10", "name": "xe-0", "description": "", "type": {"value": "10gbase-x-sfpp"}}
-                    ),
-                    "xe-extra": DotDict({"id": "11", "name": "xe-extra", "description": ""}),
-                }
+        nb.device_types.components.record(
+            "interface_templates",
+            "module",
+            5,
+            {
+                "xe-0": DotDict({"id": "10", "name": "xe-0", "description": "", "type": {"value": "10gbase-x-sfpp"}}),
+                "xe-extra": DotDict({"id": "11", "name": "xe-extra", "description": ""}),
             },
-        }
+        )
 
         module_type = {
             "manufacturer": {"slug": "nokia"},
@@ -3795,13 +3092,12 @@ class TestCreateModuleTypesEdge:
         all_module_types = {"nokia": {"IOM-s-3.0T": existing_mt}}
 
         # Cache has an extra interface not in YAML → COMPONENT_REMOVED
-        nb.device_types.cached_components = {
-            "interface_templates": {
-                ("module", 5): {
-                    "xe-extra": DotDict({"id": "11", "name": "xe-extra", "description": ""}),
-                }
-            },
-        }
+        nb.device_types.components.record(
+            "interface_templates",
+            "module",
+            5,
+            {"xe-extra": DotDict({"id": "11", "name": "xe-extra", "description": ""})},
+        )
 
         module_type = {
             "manufacturer": {"slug": "nokia"},
@@ -3922,87 +3218,9 @@ class TestUploadModuleTypeImages:
 # ---------------------------------------------------------------------------
 
 
-class TestStartComponentPreloadProgress:
-    """Tests for start_component_preload with a progress object."""
-
-    def test_with_progress_creates_task_ids(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """start_component_preload with a progress object creates task IDs."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        preload_job = dt.start_component_preload(progress=progress)
-        assert preload_job["task_ids"] is not None
-        progress.add_task.assert_called()
-        dt.stop_component_preload(preload_job)
-
-    def test_exception_shuts_down_executor(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """If _component_preload_targets raises, executor is shut down and exception re-raised."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        with patch.object(dt, "_component_preload_targets", side_effect=RuntimeError("oops")):
-            with pytest.raises(RuntimeError, match="oops"):
-                dt.start_component_preload()
-
-
 # ---------------------------------------------------------------------------
 # pump_preload_progress (lines 996-1025)
 # ---------------------------------------------------------------------------
-
-
-class TestPumpPreloadProgress:
-    """Tests for pump_preload_progress."""
-
-    def test_returns_false_when_no_preload_job(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """pump_preload_progress returns False when preload_job is None."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        assert dt.pump_preload_progress(None, MagicMock()) is False
-
-    def test_marks_done_futures(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Completed futures are moved to finished_endpoints and advanced=True returned."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        future.done.return_value = True
-        future.result.return_value = [MagicMock(), MagicMock()]
-
-        progress = MagicMock()
-        task_id = 99
-        preload_job = {
-            "futures": {"interface_templates": future},
-            "progress_updates": queue.Queue(),
-            "task_ids": {"interface_templates": task_id},
-            "finished_endpoints": set(),
-        }
-        result = dt.pump_preload_progress(preload_job, progress)
-        assert result is True
-        assert "interface_templates" in preload_job["finished_endpoints"]
-        progress.stop_task.assert_called_with(task_id)
-
-    def test_future_exception_sets_final_total_1(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """When future.result() raises, final_total defaults to 1."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        future.done.return_value = True
-        future.result.side_effect = RuntimeError("fetch failed")
-
-        progress = MagicMock()
-        preload_job = {
-            "futures": {"interface_templates": future},
-            "progress_updates": queue.Queue(),
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": set(),
-        }
-        result = dt.pump_preload_progress(preload_job, progress)
-        assert result is True
-        progress.update.assert_called()
 
 
 # ---------------------------------------------------------------------------
@@ -4010,116 +3228,9 @@ class TestPumpPreloadProgress:
 # ---------------------------------------------------------------------------
 
 
-class TestPreloadGlobalWithProgress:
-    """Tests for _preload_global with various progress/preload_job configurations."""
-
-    def test_own_executor_with_progress(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """_preload_global with progress and no preload_job (own executor path)."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_graphql_requests.side_effect = _make_graphql_dispatch(
-            {
-                "device_type_list": {"data": {"device_type_list": []}},
-                "interface_template_list": {"data": {"interface_template_list": []}},
-            }
-        )
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-        # Run only one component to keep the test fast
-        components = [("interface_templates", "Interface Templates")]
-        dt._preload_global(components, progress_wrapper=None, progress=progress)
-        progress.add_task.assert_called()
-
-    def test_preload_global_no_progress_future_failure(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types, mock_handle
-    ):
-        """When no progress and a future raises, the exception is logged and re-raised."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        broken_future = MagicMock()
-        broken_future.result.side_effect = RuntimeError("network error")
-
-        mock_handle.log.reset_mock()
-        mock_handle.verbose_log.reset_mock()
-
-        with patch.object(dt, "_fetch_global_endpoint_records", return_value=[]):
-            preload_job = {
-                "executor": None,
-                "futures": {"interface_templates": broken_future},
-                "progress_updates": None,
-                "endpoint_totals": {},
-                "task_ids": None,
-                "finished_endpoints": set(),
-            }
-            components = [("interface_templates", "Interface Templates")]
-            with pytest.raises(RuntimeError, match="network error"):
-                dt._preload_global(components, preload_job=preload_job, progress=None)
-
-        mock_handle.log.assert_any_call("Preload failed for Interface Templates: network error")
-
-    def test_preload_global_with_preload_job_already_finished(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """_preload_global with preload_job that has already-finished endpoints."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_graphql_requests.side_effect = _make_graphql_dispatch(
-            {"device_type_list": {"data": {"device_type_list": []}}}
-        )
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        future.done.return_value = True
-        future.result.return_value = []
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": queue.Queue(),
-            "endpoint_totals": {"interface_templates": 0},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": {"interface_templates"},  # already done
-        }
-        components = [("interface_templates", "Interface Templates")]
-        dt._preload_global(components, preload_job=preload_job, progress=progress)
-        # Already-done endpoint should still have its task stopped
-        progress.stop_task.assert_called()
-
-
 # ---------------------------------------------------------------------------
 # preload_module_type_components (lines 1346, 1353, 1370)
 # ---------------------------------------------------------------------------
-
-
-class TestPreloadModuleTypeComponents:
-    """Tests for preload_module_type_components edge cases."""
-
-    def test_empty_ids_returns_immediately(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Empty module_type_ids → return immediately."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.preload_module_type_components(set(), ["interfaces"])
-        mock_nb_api.dcim.interface_templates.filter.assert_not_called()
-
-    def test_item_with_no_module_type_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Items where item.module_type is None are skipped."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        item_no_mt = MagicMock()
-        item_no_mt.module_type = None
-        item_no_mt.name = "xe-0"
-        mock_nb_api.dcim.interface_templates.filter.return_value = [item_no_mt]
-
-        dt.preload_module_type_components({1}, ["interfaces"])
-        # No item indexed; cache entry is empty dict
-        assert dt.cached_components["interface_templates"][("module", 1)] == {}
 
 
 # ---------------------------------------------------------------------------
@@ -4134,7 +3245,7 @@ class TestCreateGenericPostProcess:
         """post_process callback is invoked before endpoint.create."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"power_outlet_templates": {("device", 1): {}}}
+        dt.components.record("power_outlet_templates", "device", 1, {})
 
         post_calls = []
 
@@ -4214,7 +3325,7 @@ class TestUpdateComponentsMiscBranches:
 
         existing = MagicMock()
         existing.id = 10
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": existing}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": existing})
 
         changes = [
             ComponentChange(
@@ -4242,7 +3353,7 @@ class TestUpdateComponentsMiscBranches:
 
         existing = MagicMock()
         existing.id = 10
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": existing}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": existing})
 
         err = real_pynb2.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
         mock_nb_api.dcim.interface_templates.update.side_effect = err
@@ -4300,7 +3411,7 @@ class TestUpdateComponentsAdditionsBranches:
 
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
+        dt.components.record("interface_templates", "device", 1, {})
 
         # yaml has "interfaces" but the name doesn't match the change
         changes = [ComponentChange("interfaces", "nonexistent", ChangeType.COMPONENT_ADDED)]
@@ -4317,7 +3428,7 @@ class TestUpdateComponentsAdditionsBranches:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.create_front_ports = MagicMock()
-        dt.cached_components = {"front_port_templates": {("device", 1): {}}}
+        dt.components.record("front_port_templates", "device", 1, {})
 
         changes = [ComponentChange("front-ports", "FP1", ChangeType.COMPONENT_ADDED)]
         yaml_data = {"front-ports": [{"name": "FP1"}]}
@@ -4333,7 +3444,7 @@ class TestUpdateComponentsAdditionsBranches:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.create_module_front_ports = MagicMock()
-        dt.cached_components = {"front_port_templates": {("module", 1): {}}}
+        dt.components.record("front_port_templates", "module", 1, {})
 
         changes = [ComponentChange("front-ports", "FP1", ChangeType.COMPONENT_ADDED)]
         yaml_data = {"front-ports": [{"name": "FP1"}]}
@@ -4384,7 +3495,7 @@ class TestRemoveComponentsBranches:
 
         existing_comp = MagicMock()
         existing_comp.id = 99
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": existing_comp}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": existing_comp})
 
         err = real_pynb2.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
         mock_nb_api.dcim.interface_templates.delete.side_effect = err
@@ -4409,7 +3520,7 @@ class TestCreateInterfacesBridge:
         """If bridge target interface is not found, handle.log is called."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
+        dt.components.record("interface_templates", "device", 1, {})
 
         # The created interface will be in cache; bridge target will not be.
         created = MagicMock()
@@ -4431,7 +3542,7 @@ class TestCreateInterfacesBridge:
         """Bridge key is extracted before _create_generic and removed from the dict."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
+        dt.components.record("interface_templates", "device", 1, {})
 
         mock_nb_api.dcim.interface_templates.create.return_value = []
         mock_nb_api.dcim.interface_templates.filter.return_value = []
@@ -4450,7 +3561,7 @@ class TestCreateInterfacesBridge:
         eth0.id = 10
         eth1 = MagicMock()
         eth1.id = 20
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": eth0, "eth1": eth1}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": eth0, "eth1": eth1})
 
         mock_nb_api.dcim.interface_templates.create.return_value = []
         mock_handle.verbose_log.reset_mock()
@@ -4477,7 +3588,7 @@ class TestCreateInterfacesBridge:
         eth0.id = 10
         eth1 = MagicMock()
         eth1.id = 20
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": eth0, "eth1": eth1}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": eth0, "eth1": eth1})
 
         mock_nb_api.dcim.interface_templates.create.return_value = []
         err = real_pynb2.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
@@ -4507,10 +3618,8 @@ class TestCreatePowerOutletsInvalidPort:
         """Power outlet referencing unknown power_port is logged and skipped."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {
-            "power_port_templates": {("device", 1): {}},  # no power ports
-            "power_outlet_templates": {("device", 1): {}},
-        }
+        dt.components.record("power_port_templates", "device", 1, {})
+        dt.components.record("power_outlet_templates", "device", 1, {})
         mock_nb_api.dcim.power_port_templates.filter.return_value = []
         mock_handle.log.reset_mock()
 
@@ -4528,10 +3637,8 @@ class TestCreatePowerOutletsInvalidPort:
 
         psu1 = MagicMock()
         psu1.id = 99
-        dt.cached_components = {
-            "power_port_templates": {("device", 1): {"PSU1": psu1}},
-            "power_outlet_templates": {("device", 1): {}},
-        }
+        dt.components.record("power_port_templates", "device", 1, {"PSU1": psu1})
+        dt.components.record("power_outlet_templates", "device", 1, {})
         mock_handle.log.reset_mock()
 
         power_outlets = [
@@ -4557,10 +3664,8 @@ class TestBuildLinkRearPorts:
         """Front port whose rear_port cannot be resolved is removed and logged."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {
-            "rear_port_templates": {("device", 1): {}},  # no rear ports
-            "front_port_templates": {("device", 1): {}},
-        }
+        dt.components.record("rear_port_templates", "device", 1, {})
+        dt.components.record("front_port_templates", "device", 1, {})
         mock_nb_api.dcim.rear_port_templates.filter.return_value = []
         mock_handle.log.reset_mock()
 
@@ -4576,10 +3681,8 @@ class TestBuildLinkRearPorts:
 
         rp = MagicMock()
         rp.id = 77
-        dt.cached_components = {
-            "rear_port_templates": {("device", 1): {"RP1": rp}},
-            "front_port_templates": {("device", 1): {}},
-        }
+        dt.components.record("rear_port_templates", "device", 1, {"RP1": rp})
+        dt.components.record("front_port_templates", "device", 1, {})
         mock_nb_api.dcim.front_port_templates.create.return_value = []
 
         front_ports = [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 1}]
@@ -4595,10 +3698,8 @@ class TestBuildLinkRearPorts:
 
         rp = MagicMock()
         rp.id = 77
-        dt.cached_components = {
-            "rear_port_templates": {("device", 1): {"RP1": rp}},
-            "front_port_templates": {("device", 1): {}},
-        }
+        dt.components.record("rear_port_templates", "device", 1, {"RP1": rp})
+        dt.components.record("front_port_templates", "device", 1, {})
         mock_nb_api.dcim.front_port_templates.create.return_value = []
 
         front_ports = [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 2}]
@@ -4617,10 +3718,8 @@ class TestBuildLinkRearPorts:
 
         rp = MagicMock()
         rp.id = 77
-        dt.cached_components = {
-            "rear_port_templates": {("device", 1): {"RP1": rp}},
-            "front_port_templates": {("device", 1): {}},
-        }
+        dt.components.record("rear_port_templates", "device", 1, {"RP1": rp})
+        dt.components.record("front_port_templates", "device", 1, {})
         mock_nb_api.dcim.front_port_templates.create.return_value = []
         mock_handle.log.reset_mock()
 
@@ -4652,10 +3751,8 @@ class TestCreateModuleFrontPorts:
 
         rp = MagicMock()
         rp.id = 55
-        dt.cached_components = {
-            "rear_port_templates": {("module", 5): {"RP1": rp}},
-            "front_port_templates": {("module", 5): {}},
-        }
+        dt.components.record("rear_port_templates", "module", 5, {"RP1": rp})
+        dt.components.record("front_port_templates", "module", 5, {})
         mock_nb_api.dcim.front_port_templates.create.return_value = []
 
         front_ports = [{"name": "FP1", "type": "8p8c", "rear_port": "RP1"}]
@@ -4678,10 +3775,8 @@ class TestCreateModulePowerOutletsInvalidPort:
         """Module power outlet with unknown power_port is logged and skipped."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {
-            "power_port_templates": {("module", 1): {}},
-            "power_outlet_templates": {("module", 1): {}},
-        }
+        dt.components.record("power_port_templates", "module", 1, {})
+        dt.components.record("power_outlet_templates", "module", 1, {})
         mock_nb_api.dcim.power_port_templates.filter.return_value = []
         mock_handle.log.reset_mock()
 
@@ -4698,10 +3793,8 @@ class TestCreateModulePowerOutletsInvalidPort:
 
         psu1 = MagicMock()
         psu1.id = 88
-        dt.cached_components = {
-            "power_port_templates": {("module", 1): {"PSU1": psu1}},
-            "power_outlet_templates": {("module", 1): {}},
-        }
+        dt.components.record("power_port_templates", "module", 1, {"PSU1": psu1})
+        dt.components.record("power_outlet_templates", "module", 1, {})
         mock_handle.log.reset_mock()
 
         power_outlets = [
@@ -4726,7 +3819,7 @@ class TestCreateModuleRearPorts:
         """create_module_rear_ports creates rear ports with module_type parent."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {"rear_port_templates": {("module", 3): {}}}
+        dt.components.record("rear_port_templates", "module", 3, {})
 
         rear_ports = [{"name": "RP1", "type": "8p8c", "positions": 8}]
         dt.create_module_rear_ports(rear_ports, 3, context="test.yaml")
@@ -5016,96 +4109,6 @@ class TestCreateModuleTypesCornerCases:
             )
         mock_fetch.assert_called_once()
 
-
-class TestPreloadGlobalCornerCases:
-    """Corner-case tests for _preload_global (cognitive complexity 26)."""
-
-    def test_wait_fallback_when_no_progress_updates_queue(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """When progress_updates is None and futures are pending, concurrent.futures.wait is called."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        # future that is initially not done, then done on second call
-        future = MagicMock()
-        done_sequence = [False, True]
-        future.done.side_effect = lambda: done_sequence.pop(0)
-        future.result.return_value = []
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": None,  # no queue → triggers wait() fallback
-            "endpoint_totals": {},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": set(),
-        }
-        components = [("interface_templates", "Interface Templates")]
-        with patch("concurrent.futures.wait") as mock_wait:
-            dt._preload_global(components, preload_job=preload_job, progress=progress)
-        # concurrent.futures.wait should have been called
-        mock_wait.assert_called()
-
-    def test_already_done_endpoint_has_task_stopped(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """Endpoint in finished_endpoints has its progress task stopped without double-processing."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        future.done.return_value = True
-        future.result.return_value = []
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": queue.Queue(),
-            "endpoint_totals": {},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": {"interface_templates"},
-        }
-        components = [("interface_templates", "Interface Templates")]
-        dt._preload_global(components, preload_job=preload_job, progress=progress)
-        progress.stop_task.assert_called_with(1)
-
-    def test_progress_update_dropped_for_finished_endpoint(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """Progress updates for already-finished endpoints are dropped when getting from queue."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        # First call: not done; second call: done
-        done_seq = [False, True]
-        future.done.side_effect = lambda: done_seq.pop(0)
-        future.result.return_value = []
-
-        q = queue.Queue()
-        # Add an update for a DIFFERENT (already-finished) endpoint
-        q.put(("other_endpoint", 5))
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": q,
-            "endpoint_totals": {},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": set(),
-        }
-        components = [("interface_templates", "Interface Templates")]
-        dt._preload_global(components, preload_job=preload_job, progress=progress)
         # "other_endpoint" update should be dropped (not in pending)
         # The test mainly verifies no exception is raised
 
@@ -5142,10 +4145,8 @@ class TestPowerOutletWithoutPowerPortKey:
         """Power outlet that has no 'power_port' key hits the continue at line 1723."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {
-            "power_outlet_templates": {("device", 1): {}},
-            "power_port_templates": {("device", 1): {}},
-        }
+        dt.components.record("power_outlet_templates", "device", 1, {})
+        dt.components.record("power_port_templates", "device", 1, {})
         # Outlet without "power_port" key → continue at line 1723
         power_outlets = [{"name": "PO1"}]  # no power_port key
         dt.create_power_outlets(power_outlets, 1)
@@ -5162,10 +4163,8 @@ class TestFrontPortWithoutRearPortKey:
         """Front port without 'rear_port' key hits the continue at line 1808."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {
-            "rear_port_templates": {("device", 1): {}},
-            "front_port_templates": {("device", 1): {}},
-        }
+        dt.components.record("rear_port_templates", "device", 1, {})
+        dt.components.record("front_port_templates", "device", 1, {})
         # Front port without rear_port key → continue at line 1808
         front_ports = [{"name": "FP1", "type": "8p8c"}]  # no rear_port key
         dt.create_front_ports(front_ports, 1)
@@ -5182,10 +4181,8 @@ class TestModulePowerOutletWithoutPowerPortKey:
         """Module power outlet without 'power_port' key hits the continue at line 1925."""
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = {
-            "power_outlet_templates": {("module", 1): {}},
-            "power_port_templates": {("module", 1): {}},
-        }
+        dt.components.record("power_outlet_templates", "module", 1, {})
+        dt.components.record("power_port_templates", "module", 1, {})
         power_outlets = [{"name": "PO1"}]  # no power_port key
         dt.create_module_power_outlets(power_outlets, 1)
         call_args = mock_nb_api.dcim.power_outlet_templates.create.call_args[0][0]
@@ -5215,260 +4212,7 @@ class TestUploadImageAttachmentExceptions:
         assert result is False
         assert mock_handle.log.called
 
-
-class TestPumpPreloadProgressFutureNotDone:
-    """Tests for pump_preload_progress when futures are still running."""
-
-    def test_pending_future_returns_false_when_no_updates(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """When future is not done and no progress updates, returns False (line 1013)."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        future.done.return_value = False  # not done yet
-
-        progress = MagicMock()
-        preload_job = {
-            "futures": {"interface_templates": future},
-            "progress_updates": queue.Queue(),  # empty queue
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": set(),
-        }
-        result = dt.pump_preload_progress(preload_job, progress)
-        # Future not done, no updates → no advancement
-        assert result is False
-        assert "interface_templates" not in preload_job["finished_endpoints"]
-
-
-class TestPreloadGlobalMissingLines:
-    """Targeted tests for remaining missing lines in _preload_global."""
-
-    def test_already_done_endpoint_with_future_exception(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types, mock_handle
-    ):
-        """already_done endpoint whose future raises → log + exception re-raised."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        future.done.return_value = True
-        future.result.side_effect = RuntimeError("fetch failed")
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        mock_handle.log.reset_mock()
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": queue.Queue(),
-            "endpoint_totals": {},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": {"interface_templates"},  # already done
-        }
-        components = [("interface_templates", "Interface Templates")]
-        with pytest.raises(RuntimeError, match="fetch failed"):
-            dt._preload_global(components, preload_job=preload_job, progress=progress)
-        mock_handle.log.assert_any_call("Preload failed for interface_templates: fetch failed")
-
-    def test_already_done_endpoint_progress_update_exception_swallowed(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """progress.stop_task raising for already_done endpoint is swallowed (1135-1136)."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        future.done.return_value = True
-        future.result.return_value = []
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-        progress.stop_task.side_effect = RuntimeError("task gone")
-
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": queue.Queue(),
-            "endpoint_totals": {},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": {"interface_templates"},
-        }
-        components = [("interface_templates", "Interface Templates")]
-        # Should not raise
-        dt._preload_global(components, preload_job=preload_job, progress=progress)
-
-    def test_pending_future_exception_logged(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types, mock_handle
-    ):
-        """Future raising while pending logs error and re-raises."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        future = MagicMock()
-        done_seq = [False, True]
-        future.done.side_effect = lambda: done_seq.pop(0) if done_seq else True
-        future.result.side_effect = RuntimeError("network error")
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        mock_handle.log.reset_mock()
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": queue.Queue(),
-            "endpoint_totals": {},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": set(),
-        }
-        components = [("interface_templates", "Interface Templates")]
-        with pytest.raises(RuntimeError, match="network error"):
-            dt._preload_global(components, preload_job=preload_job, progress=progress)
-        mock_handle.log.assert_any_call("Preload failed for interface_templates: network error")
-
-    def test_progress_updates_get_with_timeout_advances_task(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """progress_updates.get(timeout=0.1) returns item and updates progress (1172-1177)."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        # First call: not done (triggers the timeout-get path); second: done
-        done_seq = [False, True]
-        future = MagicMock()
-        future.done.side_effect = lambda: done_seq.pop(0) if done_seq else True
-        future.result.return_value = []
-
-        q = queue.Queue()
-        # Pre-load with an update for the pending endpoint
-        q.put(("interface_templates", 3))
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": q,
-            "endpoint_totals": {},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": set(),
-        }
-        components = [("interface_templates", "Interface Templates")]
-
-        # Force _apply_progress_updates to return False so the item stays in queue
-        # for progress_updates.get(timeout=0.1) to pick up
-        with patch.object(DeviceTypes, "_apply_progress_updates", return_value=False):
-            dt._preload_global(components, preload_job=preload_job, progress=progress)
-
-        # progress.update should have been called for the queued advance (line 1177)
-        progress.update.assert_called()
-
-    def test_progress_updates_get_drops_finished_endpoint(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """progress_updates.get returns item for finished endpoint → dropped (line 1172-1174)."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        # future not done first, then done
-        done_seq = [False, True]
-        future = MagicMock()
-        future.done.side_effect = lambda: done_seq.pop(0) if done_seq else True
-        future.result.return_value = []
-
-        q = queue.Queue()
-        # Update for a NON-pending endpoint → dropped at line 1172-1174
-        q.put(("other_endpoint", 5))
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        preload_job = {
-            "executor": MagicMock(),
-            "futures": {"interface_templates": future},
-            "progress_updates": q,
-            "endpoint_totals": {},
-            "task_ids": {"interface_templates": 1},
-            "finished_endpoints": set(),
-        }
-        components = [("interface_templates", "Interface Templates")]
-
-        with patch.object(DeviceTypes, "_apply_progress_updates", return_value=False):
-            dt._preload_global(components, preload_job=preload_job, progress=progress)
         # "other_endpoint" was dropped; no exception raised
-
-
-class TestStartComponentPreloadProgressCallback:
-    """Tests for the update_progress closure in start_component_preload (line 901)."""
-
-    def test_update_progress_called_when_records_available(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """update_progress callback is triggered when _fetch_global_endpoint_records has records."""
-        mock_nb_api = mock_pynetbox.api.return_value
-
-        # Mock _fetch_global_endpoint_records to call its callback
-        def fake_fetch(endpoint_name, progress_callback=None, manufacturer_slug=None):
-            records = [MagicMock(name="fake")]
-            if progress_callback is not None and records:
-                progress_callback(endpoint_name, len(records))
-            return records
-
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        with patch.object(dt, "_fetch_global_endpoint_records", side_effect=fake_fetch):
-            preload_job = dt.start_component_preload(progress=progress)
-            # Let the futures complete
-            dt.preload_all_components(preload_job=preload_job, progress=progress)
-
-        # update_progress was called, which put items in progress_updates queue
-        # pump_preload_progress or preload_all_components drained them
-        progress.add_task.assert_called()
-        # Assert the advance reached progress.update — guards against a regression
-        # where the callback path silently stops publishing advances.
-        update_calls = [c for c in progress.update.call_args_list if c.kwargs.get("advance")]
-        total_advance = sum(c.kwargs["advance"] for c in update_calls)
-        assert total_advance >= 1, "progress.update was never called with advance>=1"
-
-
-class TestPreloadGlobalOwnExecutorProgressCallback:
-    """Tests for _preload_global own-executor progress callback (line 1079)."""
-
-    def test_update_progress_callback_triggered(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """The update_progress closure in _preload_global is called when records exist."""
-        mock_nb_api = mock_pynetbox.api.return_value
-
-        def fake_fetch(endpoint_name, progress_callback=None, manufacturer_slug=None):
-            records = [MagicMock()]
-            if progress_callback is not None and records:
-                progress_callback(endpoint_name, len(records))
-            return records
-
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        progress = MagicMock()
-        progress.add_task.return_value = 1
-
-        components = [("interface_templates", "Interface Templates")]
-        with patch.object(dt, "_fetch_global_endpoint_records", side_effect=fake_fetch):
-            dt._preload_global(components, progress_wrapper=None, progress=progress)
-
-        progress.add_task.assert_called()
-        progress.stop_task.assert_called()
-        # Assert the advance reached progress.update — guards against a regression
-        # where the own-executor callback stops publishing advances.
-        update_calls = [c for c in progress.update.call_args_list if c.kwargs.get("advance")]
-        total_advance = sum(c.kwargs["advance"] for c in update_calls)
-        assert total_advance >= 1, "progress.update was never called with advance>=1"
 
 
 class TestUploadImagesRequestException:
@@ -5762,7 +4506,7 @@ class TestRegressionPortMappings:
         """
         dt = make_device_types()
         dt.m2m_front_ports = True
-        dt.cached_components = {"rear_port_templates": {("device", 1): {"RP1": MagicMock(id=99)}}}
+        dt.components.record("rear_port_templates", "device", 1, {"RP1": MagicMock(id=99)})
 
         # 2-tuple: legacy ChangeDetector format — should return None, not crash
         result = dt._build_mappings_patch("FP1", frozenset({(1, 2)}), 1, "device")
@@ -5780,7 +4524,7 @@ class TestRegressionPortMappings:
         dt.m2m_front_ports = False
 
         existing_fp = MagicMock(id=10, name="FP1")
-        dt.cached_components = {"front_port_templates": {("device", 1): {"FP1": existing_fp}}}
+        dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
 
         changes = [
             ComponentChange(
@@ -5812,10 +4556,8 @@ class TestRegressionPortMappings:
 
         existing_fp = MagicMock(id=10, name="FP1")
         mock_rp = MagicMock(id=99, name="RP1")
-        dt.cached_components = {
-            "front_port_templates": {("device", 1): {"FP1": existing_fp}},
-            "rear_port_templates": {("device", 1): {"RP1": mock_rp}},
-        }
+        dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
+        dt.components.record("rear_port_templates", "device", 1, {"RP1": mock_rp})
 
         yaml_data = {
             "front-ports": [
@@ -5852,7 +4594,7 @@ class TestRegressionPortMappings:
         dt.m2m_front_ports = False
 
         existing_fp = MagicMock(id=10, name="FP1")
-        dt.cached_components = {"front_port_templates": {("device", 1): {"FP1": existing_fp}}}
+        dt.components.record("front_port_templates", "device", 1, {"FP1": existing_fp})
 
         changes = [
             ComponentChange(
@@ -5885,7 +4627,7 @@ class TestBuildLinkRearPortsEdgeCases:
         """
         dt = make_device_types()
         mock_rp = MagicMock(id=99, name="RP1")
-        dt.cached_components = {"rear_port_templates": {("device", 1): {"RP1": mock_rp}}}
+        dt.components.record("rear_port_templates", "device", 1, {"RP1": mock_rp})
 
         post_process = dt._build_link_rear_ports("device", "Front Port")
         # Port with neither _mappings nor rear_port key
@@ -5905,9 +4647,7 @@ class TestBuildLinkRearPortsEdgeCases:
 
         mock_rp1 = MagicMock(id=99)
         mock_rp2 = MagicMock(id=100)
-        dt.cached_components = {
-            "rear_port_templates": {("device", 1): {"RP1": mock_rp1, "RP2": mock_rp2}},
-        }
+        dt.components.record("rear_port_templates", "device", 1, {"RP1": mock_rp1, "RP2": mock_rp2})
 
         post_process = dt._build_link_rear_ports("device", "Front Port", context="MyDevice")
         items = [
@@ -5936,6 +4676,22 @@ class TestBuildLinkRearPortsEdgeCases:
 class TestModuleTypeHasMissingComponents:
     """Tests for NetBox._module_type_has_missing_components()."""
 
+    def test_returns_false_when_no_components_in_yaml(
+        self, mock_settings, mock_pynetbox, make_device_types, mock_handle
+    ):
+        """Returns False when the module type dict has no components under the key."""
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "3.5"
+
+        nb = NetBox(mock_settings, mock_handle)
+        module_type = {}  # no "interfaces" key
+        existing_module = MagicMock()
+        existing_module.id = 99
+
+        result = nb._module_type_has_missing_components(module_type, existing_module, ["interfaces"])
+
+        assert result is False
+
     def test_returns_true_when_component_missing(self, mock_settings, mock_pynetbox, make_device_types, mock_handle):
         """Returns True when a YAML-defined component name is absent from the cache."""
         mock_nb_api = mock_pynetbox.api.return_value
@@ -5943,7 +4699,7 @@ class TestModuleTypeHasMissingComponents:
 
         nb = NetBox(mock_settings, mock_handle)
         # Pre-populate cache with an empty interface set for module 42.
-        nb.device_types.cached_components["interface_templates"] = {("module", 42): {}}
+        nb.device_types.components.record("interface_templates", "module", 42, {})
 
         module_type = {"interfaces": [{"name": "xe-0/0/0"}]}
         existing_module = MagicMock()
@@ -5963,7 +4719,7 @@ class TestModuleTypeHasMissingComponents:
         nb = NetBox(mock_settings, mock_handle)
         existing_iface = MagicMock()
         existing_iface.name = "xe-0/0/0"
-        nb.device_types.cached_components["interface_templates"] = {("module", 42): {"xe-0/0/0": existing_iface}}
+        nb.device_types.components.record("interface_templates", "module", 42, {"xe-0/0/0": existing_iface})
 
         module_type = {"interfaces": [{"name": "xe-0/0/0"}]}
         existing_module = MagicMock()
@@ -5973,85 +4729,10 @@ class TestModuleTypeHasMissingComponents:
 
         assert result is False
 
-    def test_returns_false_when_no_components_in_yaml(
-        self, mock_settings, mock_pynetbox, make_device_types, mock_handle
-    ):
-        """Returns False when the module type dict has no components under the key."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
-
-        nb = NetBox(mock_settings, mock_handle)
-        module_type = {}  # no "interfaces" key
-        existing_module = MagicMock()
-        existing_module.id = 99
-
-        result = nb._module_type_has_missing_components(module_type, existing_module, ["interfaces"])
-
-        assert result is False
-
 
 # ---------------------------------------------------------------------------
 # filter_actionable_module_types _MISSING skip (line 847)
 # ---------------------------------------------------------------------------
-
-
-class TestFilterActionableModuleTypesMissingAttr:
-    """Tests for the _MISSING guard in filter_actionable_module_types."""
-
-    def test_missing_netbox_field_is_not_treated_as_change(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
-    ):
-        """When existing module lacks an attribute, it's skipped — no false positive change."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
-
-        mock_graphql_requests.side_effect = paginate_dispatch(
-            {
-                "manufacturer_list": [],
-                "device_type_list": [],
-                "module_type_list": [
-                    {
-                        "id": "10",
-                        "model": "Linecard-A",
-                        "manufacturer": {"id": "5", "name": "Arista", "slug": "arista"},
-                    }
-                ],
-                "image_attachment_list": [],
-            }
-        )
-
-        nb = NetBox(mock_settings, mock_handle)
-        nb.device_types._global_preload_done = True
-
-        # existing_module is a spec=[] object so getattr(…, field, _MISSING) returns _MISSING
-        existing_module = MagicMock(spec=[])
-        existing_module.id = 10
-        existing_module.manufacturer = MagicMock()
-        existing_module.manufacturer.slug = "arista"
-        existing_module.model = "Linecard-A"
-
-        all_module_types = {"arista": {"Linecard-A": existing_module}}
-
-        module_type = {
-            "manufacturer": {"slug": "arista"},
-            "model": "Linecard-A",
-            "slug": "linecard-a",
-            "part_number": "LC-123",
-            "src": "/repo/module-types/arista/linecard-a.yaml",
-        }
-
-        with patch("glob.glob", return_value=[]):
-            actionable, _, changed_property_log = nb.filter_actionable_module_types(
-                [module_type],
-                all_module_types,
-                only_new=False,
-            )
-
-        # The _MISSING sentinel must prevent the module from being flagged for update.
-        # A MagicMock(spec=[]) has no attributes, so every field access returns _MISSING
-        # and the module should NOT appear in actionable or the change log.
-        assert actionable == []
-        assert changed_property_log == []
 
 
 # ---------------------------------------------------------------------------
@@ -6217,134 +4898,6 @@ class TestProcessSingleModuleTypeCreateRetryable:
 # ---------------------------------------------------------------------------
 
 
-class TestProcessSingleModuleTypeRemoveComponents:
-    """Tests that remove_components=True calls device_types.remove_components."""
-
-    def test_remove_components_is_called_when_flag_set(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, make_device_types, mock_handle
-    ):
-        """When remove_components=True and there are component changes, remove_components is called."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
-
-        nb = NetBox(mock_settings, mock_handle)
-
-        # Build a pre-existing module type so the "else" path (update) is taken.
-        existing_module = MagicMock()
-        existing_module.id = 55
-        existing_module.manufacturer.name = "Cisco"
-        existing_module.model = "CM-Remove"
-
-        all_module_types = {"cisco": {"CM-Remove": existing_module}}
-
-        # Populate cache so _compare_components returns a COMPONENT_REMOVED change.
-        stale_iface = MagicMock()
-        stale_iface.name = "xe-stale"
-        nb.device_types.cached_components["interface_templates"] = {("module", 55): {"xe-stale": stale_iface}}
-        nb.device_types._global_preload_done = True
-
-        curr_mt = {
-            "manufacturer": {"slug": "cisco"},
-            "model": "CM-Remove",
-            "slug": "cm-remove",
-            "interfaces": [],  # empty → xe-stale should be detected as removed
-        }
-
-        nb.device_types.remove_components = MagicMock()
-        nb.device_types.update_components = MagicMock()
-
-        result = nb._process_single_module_type(
-            curr_mt,
-            "test.yaml",
-            all_module_types,
-            {},
-            only_new=False,
-            remove_components=True,
-        )
-
-        assert result is True
-        nb.device_types.remove_components.assert_called_once()
-        # Verify the payload: exactly one COMPONENT_REMOVED change for "xe-stale".
-        from core.change_detector import ChangeType
-
-        removal_changes = nb.device_types.remove_components.call_args.args[1]
-        assert len(removal_changes) == 1
-        assert removal_changes[0].change_type == ChangeType.COMPONENT_REMOVED
-        assert removal_changes[0].component_name == "xe-stale"
-
-    def test_component_reconciliation_continues_when_scalar_patch_fails(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, make_device_types, mock_handle
-    ):
-        """A failed scalar PATCH must NOT skip subsequent component reconciliation.
-
-        Regression: previously the early ``return False`` on a failed
-        ``module_types.update`` left existing modules with property + component
-        diffs in a partial-sync state because component reconciliation was
-        skipped entirely.
-        """
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
-
-        nb = NetBox(mock_settings, mock_handle)
-
-        existing_module = MagicMock()
-        existing_module.id = 77
-        existing_module.manufacturer.name = "Cisco"
-        existing_module.model = "CM-Fail-Patch"
-        # Make the scalar diff non-empty so update() will be invoked and fail.
-        existing_module.part_number = "OLD_PN"
-
-        all_module_types = {"cisco": {"CM-Fail-Patch": existing_module}}
-
-        # Cache a stale interface so _compare_components yields a COMPONENT_REMOVED.
-        stale_iface = MagicMock()
-        stale_iface.name = "xe-stale"
-        nb.device_types.cached_components["interface_templates"] = {("module", 77): {"xe-stale": stale_iface}}
-        nb.device_types._global_preload_done = True
-
-        curr_mt = {
-            "manufacturer": {"slug": "cisco"},
-            "model": "CM-Fail-Patch",
-            "slug": "cm-fail-patch",
-            "part_number": "NEW_PN",  # forces a scalar diff
-            "interfaces": [],  # empty → xe-stale should be detected as removed
-        }
-
-        # Force the scalar PATCH to fail with a pynetbox RequestError.
-        # pynetbox is mocked at module level, so we restore the real exception
-        # class first (otherwise `except pynetbox.RequestError` raises TypeError).
-        import pynetbox as _real_pynb
-
-        mock_pynetbox.RequestError = _real_pynb.RequestError
-        request_error = _real_pynb.RequestError(MagicMock(status_code=400, content=b'{"detail":"boom"}'))
-        mock_nb_api.dcim.module_types.update = MagicMock(side_effect=request_error)
-
-        nb.device_types.update_components = MagicMock()
-        nb.device_types.remove_components = MagicMock()
-
-        result = nb._process_single_module_type(
-            curr_mt,
-            "test.yaml",
-            all_module_types,
-            {},
-            only_new=False,
-            remove_components=True,
-        )
-
-        # The failed PATCH should NOT prevent component reconciliation.
-        # Verify the failing PATCH was actually attempted (regression: scalar
-        # diff detection silently skipping update() would still pass without
-        # this assertion).
-        mock_nb_api.dcim.module_types.update.assert_called_once()
-        assert result is True
-        nb.device_types.remove_components.assert_called_once()
-        assert nb.counter["module_updated"] == 0
-        assert nb.counter["module_update_failed"] == 1
-        failures = nb.outcomes.failures()
-        assert len(failures) == 1
-        assert "CM-Fail-Patch" in failures[0].identity
-
-
 # ---------------------------------------------------------------------------
 # Task 6: DeviceTypes.load_for_vendor and NetBox.load_vendor
 # ---------------------------------------------------------------------------
@@ -6385,26 +4938,6 @@ class TestLoadForVendor:
         assert dt.existing_device_types == by_model
         assert dt.existing_device_types_by_slug == by_slug
 
-    def test_load_for_vendor_resets_state_before_fetch_on_failure(
-        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
-    ):
-        """State is reset before the fetch so a raised exception leaves a clean slate."""
-        from unittest.mock import patch as _patch
-        import pytest
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        dt._global_preload_done = True
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
-
-        with _patch.object(dt.graphql, "get_device_types", side_effect=RuntimeError("timeout")):
-            with pytest.raises(RuntimeError, match="timeout"):
-                dt.load_for_vendor("vendor-b")
-
-        assert dt._global_preload_done is False
-        assert dt.cached_components == {}
-
     def test_load_for_vendor_replaces_prior_data(
         self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
     ):
@@ -6435,6 +4968,26 @@ class TestLoadForVendor:
 
         assert ("cisco", "M1") not in dt.existing_device_types
         assert ("juniper", "M2") in dt.existing_device_types
+
+    def test_load_for_vendor_resets_state_before_fetch_on_failure(
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, make_device_types
+    ):
+        """State is reset before the fetch so a raised exception leaves a clean slate."""
+        from unittest.mock import patch as _patch
+        import pytest
+
+        mock_nb_api = mock_pynetbox.api.return_value
+        dt = make_device_types(nb_api=mock_nb_api)
+
+        _mark_cache_ready(dt)
+        dt.components.record("interface_templates", "device", 1, {})
+
+        with _patch.object(dt.graphql, "get_device_types", side_effect=RuntimeError("timeout")):
+            with pytest.raises(RuntimeError, match="timeout"):
+                dt.load_for_vendor("vendor-b")
+
+        assert dt.components.ready is False
+        assert dt.components.entries("interface_templates", "device", 1) == {}
 
 
 class TestNetBoxLoadVendor:
@@ -6472,30 +5025,6 @@ class TestNetBoxLoadVendor:
         assert nb._change_detector is not None
         assert nb._change_detector is not original_cd
 
-    def test_load_vendor_resets_preload_state_for_iteration(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """load_vendor resets _global_preload_done and cached_components between vendors."""
-        from unittest.mock import patch as _patch
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        # First call: simulate load for vendor-a
-        with _patch.object(dt.graphql, "get_device_types", return_value=({}, {})):
-            dt.load_for_vendor("vendor-a")
-
-        # Simulate state left behind after processing vendor-a
-        dt._global_preload_done = True
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
-
-        # Second call: load for vendor-b
-        with _patch.object(dt.graphql, "get_device_types", return_value=({}, {})):
-            dt.load_for_vendor("vendor-b")
-
-        assert dt._global_preload_done is False
-        assert dt.cached_components == {}
-
     def test_load_vendor_resets_module_image_details(self, mock_settings, mock_pynetbox, mock_handle):
         """load_vendor must clear _module_image_details so stale module entries from previous vendor don't persist."""
         nb = NetBox(mock_settings, mock_handle)
@@ -6506,54 +5035,34 @@ class TestNetBoxLoadVendor:
 
         assert nb._module_image_details == {}
 
+    def test_load_vendor_resets_preload_state_for_iteration(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
+        """load_vendor clears the component cache and its readiness between vendors."""
+        from unittest.mock import patch as _patch
+
+        mock_nb_api = mock_pynetbox.api.return_value
+        dt = make_device_types(nb_api=mock_nb_api)
+
+        # First call: simulate load for vendor-a
+        with _patch.object(dt.graphql, "get_device_types", return_value=({}, {})):
+            dt.load_for_vendor("vendor-a")
+
+        # Simulate state left behind after processing vendor-a
+        _mark_cache_ready(dt)
+        dt.components.record("interface_templates", "device", 1, {})
+
+        # Second call: load for vendor-b
+        with _patch.object(dt.graphql, "get_device_types", return_value=({}, {})):
+            dt.load_for_vendor("vendor-b")
+
+        assert dt.components.ready is False
+        assert dt.components.entries("interface_templates", "device", 1) == {}
+
 
 # ---------------------------------------------------------------------------
 # Task 7: start_component_preload with manufacturer_slug
 # ---------------------------------------------------------------------------
-
-
-class TestStartComponentPreloadManufacturerSlug:
-    """Tests for start_component_preload(manufacturer_slug=...) (Task 7)."""
-
-    def test_manufacturer_slug_passed_to_fetch(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """manufacturer_slug from start_component_preload is forwarded to _fetch_global_endpoint_records."""
-        from unittest.mock import patch as _patch
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        received_slugs = []
-
-        def fake_fetch(endpoint_name, progress_callback=None, manufacturer_slug=None):
-            received_slugs.append(manufacturer_slug)
-            return []
-
-        with _patch.object(dt, "_fetch_global_endpoint_records", side_effect=fake_fetch):
-            preload_job = dt.start_component_preload(manufacturer_slug="cisco")
-            dt.preload_all_components(preload_job=preload_job)
-
-        # Every endpoint should have received the vendor slug
-        assert all(slug == "cisco" for slug in received_slugs)
-        assert len(received_slugs) == len(dt._component_preload_targets())
-
-    def test_no_manufacturer_slug_passes_none(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Without manufacturer_slug, None is forwarded (global fetch)."""
-        from unittest.mock import patch as _patch
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        received_slugs = []
-
-        def fake_fetch(endpoint_name, progress_callback=None, manufacturer_slug=None):
-            received_slugs.append(manufacturer_slug)
-            return []
-
-        with _patch.object(dt, "_fetch_global_endpoint_records", side_effect=fake_fetch):
-            preload_job = dt.start_component_preload()
-            dt.preload_all_components(preload_job=preload_job)
-
-        assert all(slug is None for slug in received_slugs)
 
 
 # ---------------------------------------------------------------------------
@@ -6561,333 +5070,14 @@ class TestStartComponentPreloadManufacturerSlug:
 # ---------------------------------------------------------------------------
 
 
-class TestVerifyComponentCacheIntegrity:
-    """Tests for DeviceTypes._verify_component_cache_integrity (Task 8)."""
-
-    def test_returns_true_when_all_records_match_dt_ids(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """Returns True when cache records have device_type_ids in vendor_dt_ids."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        # Populate cache with records whose device_type id is 1 (in vendor set)
-        rec = MagicMock()
-        dt.cached_components = {
-            "interface_templates": {("device", 1): {"eth0": rec}},
-        }
-
-        result = dt._verify_component_cache_integrity(vendor_dt_ids={1}, vendor_mt_ids=set())
-        assert result is True
-        # Cache should be untouched
-        assert ("device", 1) in dt.cached_components["interface_templates"]
-
-    def test_returns_false_and_clears_cache_when_no_ids_match(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """Returns False and clears offending endpoint when no record belongs to vendor."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        rec = MagicMock()
-        # Cache has records for device_type id 99, but vendor only owns id 1
-        dt.cached_components = {
-            "interface_templates": {("device", 99): {"eth0": rec}},
-        }
-
-        logged = []
-        dt.handle.log = lambda msg: logged.append(msg)
-
-        result = dt._verify_component_cache_integrity(vendor_dt_ids={1}, vendor_mt_ids=set())
-        assert result is False
-        # Cache entry must be cleared
-        assert dt.cached_components["interface_templates"] == {}
-        assert any("ERROR" in m for m in logged)
-
-    def test_empty_endpoint_cache_not_flagged(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Empty endpoint cache entries are skipped — no false positives."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        dt.cached_components = {
-            "interface_templates": {},
-        }
-
-        result = dt._verify_component_cache_integrity(vendor_dt_ids={1}, vendor_mt_ids=set())
-        assert result is True
-
-    def test_module_type_records_pass_when_mt_ids_match(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """Module-type records pass when module_type_id is in vendor_mt_ids."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        rec = MagicMock()
-        dt.cached_components = {
-            "interface_templates": {("module", 5): {"mod-iface": rec}},
-        }
-
-        # vendor_mt_ids contains 5
-        result = dt._verify_component_cache_integrity(vendor_dt_ids=set(), vendor_mt_ids={5})
-        assert result is True
-
-    def test_mixed_valid_invalid_records_pass(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """If at least one record matches, the endpoint is considered valid."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        rec = MagicMock()
-        dt.cached_components = {
-            "interface_templates": {
-                ("device", 1): {"eth0": rec},  # valid
-                ("device", 99): {"eth1": rec},  # foreign but that's OK if 1 is valid
-            },
-        }
-
-        result = dt._verify_component_cache_integrity(vendor_dt_ids={1}, vendor_mt_ids=set())
-        assert result is True
-
-
 # ---------------------------------------------------------------------------
 # Issue 2: preload_all_components integrity check handles get_module_types errors
 # ---------------------------------------------------------------------------
 
 
-class TestPreloadAllComponentsIntegrityCheckError:
-    """preload_all_components skips the integrity check only for a rejected query shape."""
-
-    def test_get_module_types_transport_error_propagates(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """Any failure other than a schema rejection must reach the caller, guard unfinished."""
-        from unittest.mock import patch as _patch
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        with _patch.object(dt, "_preload_global"):
-            with _patch.object(dt.graphql, "get_module_types", side_effect=RuntimeError("network error")):
-                with pytest.raises(RuntimeError, match="network error"):
-                    dt.preload_all_components(manufacturer_slug="cisco")
-
-        assert dt._global_preload_done is False
-
-
 # ---------------------------------------------------------------------------
 # _check_component_counts_against_rest and _rest_count_chunked
 # ---------------------------------------------------------------------------
-
-
-class TestCheckComponentCountsAgainstRest:
-    """Tests for DeviceTypes._check_component_counts_against_rest."""
-
-    def _make_dt_with_cache(self, make_device_types, mock_nb_api, cached_components):
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.cached_components = cached_components
-        return dt
-
-    def test_matching_counts_does_not_raise(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """No exception when cached count equals REST count for all endpoints."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = self._make_dt_with_cache(
-            make_device_types,
-            mock_nb_api,
-            {
-                "interface_templates": {("device", 1): {"eth0": MagicMock(), "eth1": MagicMock()}},
-                "power_port_templates": {("device", 1): {"pwr": MagicMock()}},
-            },
-        )
-
-        # REST always returns matching count
-        mock_nb_api.dcim.interface_templates.count.return_value = 2
-        mock_nb_api.dcim.power_port_templates.count.return_value = 1
-
-        # Should not raise — all other endpoints return 0 from both REST and cache
-        def zero_count(**kwargs):
-            return 0
-
-        for endpoint_name, _ in dt._component_preload_targets():
-            ep = getattr(mock_nb_api.dcim, endpoint_name)
-            ep.count.side_effect = zero_count
-
-        mock_nb_api.dcim.interface_templates.count.side_effect = None
-        mock_nb_api.dcim.interface_templates.count.return_value = 2
-        mock_nb_api.dcim.power_port_templates.count.side_effect = None
-        mock_nb_api.dcim.power_port_templates.count.return_value = 1
-
-        dt._check_component_counts_against_rest(vendor_dt_ids={1}, vendor_mt_ids=set())
-
-    def test_mismatch_raises_graphql_count_mismatch_error(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """GraphQLCountMismatchError raised when REST count differs from cached count."""
-        from core.graphql_client import GraphQLCountMismatchError
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = self._make_dt_with_cache(
-            make_device_types,
-            mock_nb_api,
-            {
-                "interface_templates": {("device", 1): {"eth0": MagicMock()}},  # 1 cached
-            },
-        )
-
-        # Make all endpoints return 0 by default, then override interface_templates
-        for endpoint_name, _ in dt._component_preload_targets():
-            getattr(mock_nb_api.dcim, endpoint_name).count.return_value = 0
-
-        # REST says 5 for interface_templates, cache has 1 → mismatch
-        mock_nb_api.dcim.interface_templates.count.return_value = 5
-
-        with pytest.raises(GraphQLCountMismatchError, match="interface_templates"):
-            dt._check_component_counts_against_rest(vendor_dt_ids={1}, vendor_mt_ids=set())
-
-    def test_empty_dt_ids_skips_dt_count_call(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """When vendor_dt_ids is empty, REST count is not called for device-type path."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = self._make_dt_with_cache(make_device_types, mock_nb_api, {})
-
-        for endpoint_name, _ in dt._component_preload_targets():
-            getattr(mock_nb_api.dcim, endpoint_name).count.return_value = 0
-
-        dt._check_component_counts_against_rest(vendor_dt_ids=set(), vendor_mt_ids=set())
-
-        # count() should never be called when both ID sets are empty
-        for endpoint_name, _ in dt._component_preload_targets():
-            getattr(mock_nb_api.dcim, endpoint_name).count.assert_not_called()
-
-    def test_device_bay_templates_skips_module_type_path(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """device_bay_templates never queries the module-type count path."""
-        from core.compat import module_type_filter_key
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = self._make_dt_with_cache(make_device_types, mock_nb_api, {})
-
-        for endpoint_name, _ in dt._component_preload_targets():
-            getattr(mock_nb_api.dcim, endpoint_name).count.return_value = 0
-
-        dt._check_component_counts_against_rest(vendor_dt_ids={1}, vendor_mt_ids={5})
-
-        # device_bay_templates must only be called once (device path), not twice
-        calls = mock_nb_api.dcim.device_bay_templates.count.call_args_list
-        mt_filter_key = module_type_filter_key(dt.new_filters)
-        mt_calls = [c for c in calls if mt_filter_key in (c.kwargs or {})]
-        assert mt_calls == [], "device_bay_templates should not be queried with module_type filter"
-
-    def test_rest_only_endpoints_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Endpoints in REST_ONLY_ENDPOINTS are skipped (no tautological REST-vs-REST check)."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = self._make_dt_with_cache(make_device_types, mock_nb_api, {})
-
-        # Override REST_ONLY_ENDPOINTS to include interface_templates for this test
-        dt.REST_ONLY_ENDPOINTS = frozenset({"interface_templates"})
-
-        for endpoint_name, _ in dt._component_preload_targets():
-            getattr(mock_nb_api.dcim, endpoint_name).count.return_value = 0
-
-        dt._check_component_counts_against_rest(vendor_dt_ids={1}, vendor_mt_ids=set())
-
-        mock_nb_api.dcim.interface_templates.count.assert_not_called()
-
-
-class TestRestCountChunked:
-    """Tests for DeviceTypes._rest_count_chunked."""
-
-    def test_single_chunk(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """IDs that fit in one chunk make exactly one REST call."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        ep = MagicMock()
-        ep.count.return_value = 5
-
-        result = dt._rest_count_chunked(ep, "device_type_id", [1, 2, 3])
-
-        assert result == 5
-        ep.count.assert_called_once_with(device_type_id=[1, 2, 3])
-
-    def test_multiple_chunks_summed(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """IDs exceeding chunk_size are split into multiple calls whose counts are summed."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        ep = MagicMock()
-        ep.count.side_effect = [10, 7]  # two chunks return 10 and 7
-
-        ids = list(range(150))  # 150 IDs, default chunk_size=100 → 2 chunks
-        result = dt._rest_count_chunked(ep, "device_type_id", ids, chunk_size=100)
-
-        assert result == 17
-        assert ep.count.call_count == 2
-        ep.count.assert_any_call(device_type_id=ids[:100])
-        ep.count.assert_any_call(device_type_id=ids[100:])
-
-    def test_empty_ids_returns_zero(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Empty ID list returns 0 without making any REST calls."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        ep = MagicMock()
-
-        result = dt._rest_count_chunked(ep, "device_type_id", [])
-        assert result == 0
-        ep.count.assert_not_called()
-
-
-class TestPreloadAllComponentsCountCheck:
-    """preload_all_components calls count check and propagates GraphQLCountMismatchError."""
-
-    def test_count_check_called_when_manufacturer_slug_set(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """_check_component_counts_against_rest is called when manufacturer_slug is given."""
-        from unittest.mock import patch as _patch
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        with _patch.object(dt, "_preload_global"):
-            with _patch.object(dt.graphql, "get_module_types", return_value={}):
-                with _patch.object(dt, "_check_component_counts_against_rest") as mock_check:
-                    dt.preload_all_components(manufacturer_slug="cisco")
-
-        mock_check.assert_called_once()
-
-    def test_count_mismatch_propagates(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """GraphQLCountMismatchError from count check is not swallowed."""
-        from unittest.mock import patch as _patch
-        from core.graphql_client import GraphQLCountMismatchError
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        with _patch.object(dt, "_preload_global"):
-            with _patch.object(dt.graphql, "get_module_types", return_value={}):
-                with _patch.object(
-                    dt,
-                    "_check_component_counts_against_rest",
-                    side_effect=GraphQLCountMismatchError("mismatch"),
-                ):
-                    with pytest.raises(GraphQLCountMismatchError):
-                        dt.preload_all_components(manufacturer_slug="cisco")
-
-    def test_count_check_not_called_without_manufacturer_slug(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """When no manufacturer_slug, count check is not called (global preload)."""
-        from unittest.mock import patch as _patch
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        with _patch.object(dt, "_preload_global"):
-            with _patch.object(dt, "_check_component_counts_against_rest") as mock_check:
-                dt.preload_all_components()
-
-        mock_check.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -7754,26 +5944,6 @@ class TestAdditionalNetBoxCoverage:
         assert any("~ 1 changed component(s)" in c for c in logs)
         assert any("- 1 component(s) present in NetBox but absent from YAML" in c for c in logs)
 
-    def test_filter_actionable_module_types_marks_verify_images_module_actionable(
-        self, mock_settings, mock_pynetbox, mock_handle
-    ):
-        mock_pynetbox.api.return_value.version = "3.5"
-        nb = NetBox(mock_settings, mock_handle)
-        nb.verify_images = True
-        nb.device_types._global_preload_done = True
-        nb._fetch_module_type_existing_images = MagicMock(return_value={42: {"linecard.front"}})
-        nb._discover_module_image_files = MagicMock(return_value=["/repo/module-images/linecard.front.png"])
-        nb.change_detector._compare_components = MagicMock(return_value=[])
-
-        existing_module = MagicMock(id=42, model="LC")
-        existing_module.manufacturer.slug = "cisco"
-        all_module_types = {"cisco": {"LC": existing_module}}
-        module_type = {"manufacturer": {"slug": "cisco"}, "model": "LC", "src": "linecard.yaml"}
-
-        actionable, _, _ = nb.filter_actionable_module_types([module_type], all_module_types, only_new=False)
-
-        assert actionable == [module_type]
-
     def test_fetch_module_type_existing_images_uses_detailed_query_in_verify_mode(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
@@ -7803,6 +5973,26 @@ class TestAdditionalNetBoxCoverage:
         assert updated is False
         nb.netbox.dcim.module_types.update.assert_not_called()
 
+    def test_filter_actionable_module_types_marks_verify_images_module_actionable(
+        self, mock_settings, mock_pynetbox, mock_handle
+    ):
+        mock_pynetbox.api.return_value.version = "3.5"
+        nb = NetBox(mock_settings, mock_handle)
+        nb.verify_images = True
+        _mark_cache_ready(nb.device_types)
+        nb._fetch_module_type_existing_images = MagicMock(return_value={42: {"linecard.front"}})
+        nb._discover_module_image_files = MagicMock(return_value=["/repo/module-images/linecard.front.png"])
+        nb.change_detector._compare_components = MagicMock(return_value=[])
+
+        existing_module = MagicMock(id=42, model="LC")
+        existing_module.manufacturer.slug = "cisco"
+        all_module_types = {"cisco": {"LC": existing_module}}
+        module_type = {"manufacturer": {"slug": "cisco"}, "model": "LC", "src": "linecard.yaml"}
+
+        actionable, _, _ = nb.filter_actionable_module_types([module_type], all_module_types, only_new=False)
+
+        assert actionable == [module_type]
+
 
 class TestAdditionalModuleTypeCoverage:
     """Focused tests for uncovered module-type branches."""
@@ -7821,44 +6011,6 @@ class TestAdditionalModuleTypeCoverage:
         assert nb.counter["module_update_failed"] == 1
         assert nb.outcomes.failures()[0].reason == "Scalar PATCH failed; no component changes detected."
 
-    def test_apply_module_type_component_updates_records_failed_when_no_changes_apply(
-        self, mock_settings, mock_pynetbox, mock_handle
-    ):
-        from core.change_detector import ChangeType, ComponentChange
-
-        mock_pynetbox.api.return_value.version = "3.5"
-        nb = NetBox(mock_settings, mock_handle)
-        module_type_res = MagicMock(id=7, model="LC")
-        module_type_res.manufacturer.name = "Cisco"
-        nb.device_types._global_preload_done = True
-        nb.change_detector._compare_components = MagicMock(
-            return_value=[ComponentChange("interfaces", "xe-0", ChangeType.COMPONENT_REMOVED)]
-        )
-
-        nb._apply_module_type_component_updates({}, module_type_res, False, False, patch_ok=False)
-
-        assert nb.counter["module_update_failed"] == 1
-        assert nb.outcomes.failures()[0].reason == "Scalar PATCH failed; no component changes were actionable."
-
-    def test_apply_module_type_component_updates_marks_partial_when_properties_only_succeed(
-        self, mock_settings, mock_pynetbox, mock_handle
-    ):
-        from core.change_detector import ChangeType, ComponentChange
-
-        mock_pynetbox.api.return_value.version = "3.5"
-        nb = NetBox(mock_settings, mock_handle)
-        module_type_res = MagicMock(id=7, model="LC")
-        module_type_res.manufacturer.name = "Cisco"
-        nb.device_types._global_preload_done = True
-        nb.device_types.update_components = MagicMock()
-        nb.change_detector._compare_components = MagicMock(
-            return_value=[ComponentChange("interfaces", "xe-0", ChangeType.COMPONENT_CHANGED)]
-        )
-
-        nb._apply_module_type_component_updates({}, module_type_res, True, False, patch_ok=True)
-
-        assert nb.counter["module_partial_update"] == 1
-
     def test_apply_module_type_component_updates_marks_partial_on_partial_component_success(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
@@ -7868,7 +6020,7 @@ class TestAdditionalModuleTypeCoverage:
         nb = NetBox(mock_settings, mock_handle)
         module_type_res = MagicMock(id=7, model="LC")
         module_type_res.manufacturer.name = "Cisco"
-        nb.device_types._global_preload_done = True
+        _mark_cache_ready(nb.device_types)
 
         def update_some(*_args, **_kwargs):
             nb.counter["components_updated"] += 1
@@ -7885,6 +6037,44 @@ class TestAdditionalModuleTypeCoverage:
 
         assert nb.counter["module_partial_update"] == 1
 
+    def test_apply_module_type_component_updates_marks_partial_when_properties_only_succeed(
+        self, mock_settings, mock_pynetbox, mock_handle
+    ):
+        from core.change_detector import ChangeType, ComponentChange
+
+        mock_pynetbox.api.return_value.version = "3.5"
+        nb = NetBox(mock_settings, mock_handle)
+        module_type_res = MagicMock(id=7, model="LC")
+        module_type_res.manufacturer.name = "Cisco"
+        _mark_cache_ready(nb.device_types)
+        nb.device_types.update_components = MagicMock()
+        nb.change_detector._compare_components = MagicMock(
+            return_value=[ComponentChange("interfaces", "xe-0", ChangeType.COMPONENT_CHANGED)]
+        )
+
+        nb._apply_module_type_component_updates({}, module_type_res, True, False, patch_ok=True)
+
+        assert nb.counter["module_partial_update"] == 1
+
+    def test_apply_module_type_component_updates_records_failed_when_no_changes_apply(
+        self, mock_settings, mock_pynetbox, mock_handle
+    ):
+        from core.change_detector import ChangeType, ComponentChange
+
+        mock_pynetbox.api.return_value.version = "3.5"
+        nb = NetBox(mock_settings, mock_handle)
+        module_type_res = MagicMock(id=7, model="LC")
+        module_type_res.manufacturer.name = "Cisco"
+        _mark_cache_ready(nb.device_types)
+        nb.change_detector._compare_components = MagicMock(
+            return_value=[ComponentChange("interfaces", "xe-0", ChangeType.COMPONENT_REMOVED)]
+        )
+
+        nb._apply_module_type_component_updates({}, module_type_res, False, False, patch_ok=False)
+
+        assert nb.counter["module_update_failed"] == 1
+        assert nb.outcomes.failures()[0].reason == "Scalar PATCH failed; no component changes were actionable."
+
 
 class TestAdditionalDeviceTypesCoverage:
     """Focused tests for uncovered DeviceTypes branches."""
@@ -7895,122 +6085,6 @@ class TestAdditionalDeviceTypesCoverage:
 
         assert dt.get_device_types() == ({("cisco", "A"): 1}, {("cisco", "a"): 1})
 
-    def test_start_component_preload_populates_task_registry(self, mock_pynetbox, make_device_types):
-        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
-        progress = MagicMock()
-        progress.add_task.side_effect = range(1, 20)
-        task_registry = {}
-
-        preload_job = dt.start_component_preload(progress=progress, task_registry=task_registry)
-
-        assert task_registry
-        assert preload_job["task_ids"]
-        dt.stop_component_preload(preload_job)
-
-    def test_start_component_preload_shuts_down_executor_when_submit_fails(self, mock_pynetbox, make_device_types):
-        executor = MagicMock()
-        executor.submit.side_effect = RuntimeError("submit failed")
-        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
-
-        with patch("core.netbox_api.concurrent.futures.ThreadPoolExecutor", return_value=executor):
-            with pytest.raises(RuntimeError, match="submit failed"):
-                dt.start_component_preload()
-
-        executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
-
-    def test_stop_component_preload_swallows_progress_cleanup_errors(self):
-        progress = MagicMock()
-        progress.stop_task.side_effect = RuntimeError("gone")
-        preload_job = {"task_ids": {"interfaces": 1}, "owns_tasks": True}
-
-        DeviceTypes.stop_component_preload(preload_job, progress=progress)
-
-    def test_apply_progress_updates_ignores_zero_advance(self):
-        progress = MagicMock()
-        q = queue.Queue()
-        q.put(("interface_templates", 0))
-
-        result = DeviceTypes._apply_progress_updates(q, progress, {"interface_templates": 1})
-
-        assert result is False
-        progress.update.assert_not_called()
-
-    def test_apply_progress_updates_rewinds_negative_advance(self):
-        progress = MagicMock()
-        progress.tasks = [MagicMock(id=1, completed=5)]
-        q = queue.Queue()
-        q.put(("interface_templates", -3))
-
-        result = DeviceTypes._apply_progress_updates(q, progress, {"interface_templates": 1})
-
-        assert result is True
-        progress.update.assert_called_once_with(1, completed=2)
-
-    def test_drain_pending_rewinds_negative_progress_update(self, mock_pynetbox, make_device_types):
-        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
-        future = MagicMock()
-        done_states = [False, True]
-        future.done.side_effect = lambda: done_states.pop(0)
-        future.result.return_value = []
-        progress = MagicMock()
-        progress.tasks = [MagicMock(id=1, completed=4)]
-        updates = queue.Queue()
-        updates.put(("interface_templates", -2))
-        pending = {"interface_templates"}
-        records = {}
-
-        dt._drain_pending(
-            pending,
-            {"interface_templates": future},
-            progress,
-            {"interface_templates": 1},
-            updates,
-            {},
-            records,
-        )
-
-        assert progress.update.call_args_list[0].kwargs == {"completed": 2}
-
-    def test_preload_global_creates_tasks_from_registry_when_missing(self, mock_pynetbox, make_device_types):
-        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
-        progress = MagicMock()
-        progress.add_task.return_value = 7
-        task_registry = {}
-        preload_job = {
-            "executor": None,
-            "futures": {},
-            "progress_updates": queue.Queue(),
-            "endpoint_totals": {},
-            "task_ids": None,
-            "finished_endpoints": set(),
-        }
-
-        with patch.object(dt, "_preload_track_progress", return_value={"interface_templates": []}):
-            dt._preload_global(
-                [("interface_templates", "Interfaces")],
-                preload_job=preload_job,
-                progress=progress,
-                task_registry=task_registry,
-            )
-
-        assert task_registry["Caching Interfaces"] == 7
-
-    def test_preload_module_type_components_wraps_front_ports_and_deduplicates_targets(
-        self, mock_pynetbox, make_device_types
-    ):
-        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
-        item = MagicMock()
-        item.module_type = MagicMock(id=5)
-        item.name = "FP1"
-        item.mappings = []
-        dt.netbox.dcim.front_port_templates.filter.return_value = [item]
-
-        dt.preload_module_type_components({5}, ["front-ports", "front-ports"])
-
-        cached = dt.cached_components["front_port_templates"][("module", 5)]["FP1"]
-        assert isinstance(cached, _FrontPortRecordWithMappings)
-        dt.netbox.dcim.front_port_templates.filter.assert_called_once()
-
     def test_create_generic_logs_retryable_exception(
         self, mock_pynetbox, make_device_types, mock_settings, mock_handle
     ):
@@ -8019,7 +6093,7 @@ class TestAdditionalDeviceTypesCoverage:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
-        dt.cached_components = {"interface_templates": {("device", 1): {}}}
+        dt.components.record("interface_templates", "device", 1, {})
         endpoint = MagicMock()
         endpoint.create.side_effect = requests.exceptions.ConnectionError("offline")
 
@@ -8044,7 +6118,7 @@ class TestAdditionalDeviceTypesCoverage:
         mock_pynetbox.RequestError = real_pynb.RequestError
         dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
         existing = MagicMock(id=9, name="eth0")
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": existing}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": existing})
         dt.netbox.dcim.interface_templates.update.side_effect = requests.exceptions.ConnectionError("offline")
         changes = [
             ComponentChange(
@@ -8070,7 +6144,7 @@ class TestAdditionalDeviceTypesCoverage:
         mock_pynetbox.RequestError = real_pynb.RequestError
         dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
         existing = MagicMock(id=9, name="eth0")
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": existing}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": existing})
         dt.netbox.dcim.interface_templates.delete.side_effect = requests.exceptions.ConnectionError("offline")
         changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_REMOVED)]
 
@@ -8089,7 +6163,7 @@ class TestAdditionalDeviceTypesCoverage:
         dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
         eth0 = MagicMock(id=10)
         eth1 = MagicMock(id=20)
-        dt.cached_components = {"interface_templates": {("device", 1): {"eth0": eth0, "eth1": eth1}}}
+        dt.components.record("interface_templates", "device", 1, {"eth0": eth0, "eth1": eth1})
         dt.netbox.dcim.interface_templates.create.return_value = []
         dt.netbox.dcim.interface_templates.update.side_effect = requests.exceptions.ConnectionError("offline")
         interfaces = [{"name": "eth0", "type": "virtual", "bridge": "eth1"}, {"name": "eth1", "type": "virtual"}]
@@ -8210,41 +6284,6 @@ class TestRemainingCoverageBranches:
         nb.device_types.upload_image_attachment.assert_not_called()
         assert "mymodule.front" in existing_images[10]
         assert any("skipping upload to avoid duplicates" in str(c) for c in mock_handle.verbose_log.call_args_list)
-
-    def test_stop_component_preload_removes_tasks_when_owned(self):
-        progress = MagicMock()
-        preload_job = {"task_ids": {"interfaces": 1}, "owns_tasks": True}
-
-        DeviceTypes.stop_component_preload(preload_job, progress=progress)
-
-        progress.stop_task.assert_called_once_with(1)
-        progress.remove_task.assert_called_once_with(1)
-
-    def test_drain_pending_rewinds_negative_update_from_fallback_queue(self, mock_pynetbox, make_device_types):
-        dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
-        future = MagicMock()
-        done_states = [False, True]
-        future.done.side_effect = lambda: done_states.pop(0)
-        future.result.return_value = []
-        progress = MagicMock()
-        progress.tasks = [MagicMock(id=1, completed=4)]
-        updates = queue.Queue()
-        updates.put(("interface_templates", -2))
-        records = {}
-
-        with patch.object(dt, "_apply_progress_updates", return_value=False):
-            dt._drain_pending(
-                {"interface_templates"},
-                {"interface_templates": future},
-                progress,
-                {"interface_templates": 1},
-                updates,
-                {},
-                records,
-            )
-
-        assert progress.update.call_args_list[0].args == (1,)
-        assert progress.update.call_args_list[0].kwargs == {"completed": 2}
 
 
 # ---------------------------------------------------------------------------
@@ -8461,35 +6500,280 @@ class TestPreloadIntegrityGuard:
             max_threads=2,
         )
 
-    def test_transport_failure_does_not_skip_the_truncation_guard(self):
-        """A failed request must not silently disable the check that catches truncated results."""
-        from core.graphql_client import GraphQLError
 
-        url, server = self._serve((403, '{"detail": "forbidden"}'))
-        handle = MagicMock()
-        try:
-            device_types = self._device_types(url, handle)
-            with pytest.raises(GraphQLError):
-                device_types.preload_all_components(manufacturer_slug="acme")
-        finally:
-            server.shutdown()
+def test_filter_actionable_module_types_skips_unchanged_existing_module(
+    mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
+):
+    mock_nb_api = mock_pynetbox.api.return_value
+    mock_nb_api.version = "3.5"
 
-        logged = " ".join(str(call) for call in handle.log.call_args_list)
-        assert "integrity check skipped" not in logged
-        assert device_types._global_preload_done is False
+    mock_graphql_requests.side_effect = paginate_dispatch(
+        {
+            "manufacturer_list": [],
+            "device_type_list": [],
+            "module_type_list": [
+                {
+                    "id": "42",
+                    "model": "Linecard 1",
+                    "manufacturer": {"id": "20", "name": "Juniper", "slug": "juniper"},
+                }
+            ],
+            "image_attachment_list": [],
+        }
+    )
 
-    def test_schema_rejection_skips_the_guard_with_a_warning(self):
-        """A server that cannot answer the query shape may skip the check, and says so."""
-        import json as _json
+    existing_interface = MagicMock()
+    existing_interface.name = "xe-0/0/0"
 
-        rejection = _json.dumps({"errors": [{"message": "Cannot query field 'weight' on type 'ModuleTypeType'."}]})
-        url, server = self._serve((200, rejection))
-        handle = MagicMock()
-        try:
-            device_types = self._device_types(url, handle)
-            device_types.preload_all_components(manufacturer_slug="acme")
-        finally:
-            server.shutdown()
+    nb = NetBox(mock_settings, mock_handle)
+    # Simulate the global GraphQL preload having already populated the cache for module 42.
+    _mark_cache_ready(nb.device_types)
+    nb.device_types.components.record("interface_templates", "module", 42, {"xe-0/0/0": existing_interface})
 
-        logged = " ".join(str(call) for call in handle.log.call_args_list)
-        assert "integrity check skipped" in logged
+    module_types = [
+        {
+            "manufacturer": {"slug": "juniper"},
+            "model": "Linecard 1",
+            "slug": "linecard-1",
+            "interfaces": [{"name": "xe-0/0/0"}],
+            "src": "/tmp/repo/module-types/juniper/linecard-1.yaml",
+        }
+    ]
+
+    with patch("glob.glob", return_value=[]):
+        actionable, _, _ = nb.filter_actionable_module_types(
+            module_types,
+            nb.get_existing_module_types(),
+            only_new=False,
+        )
+
+    assert actionable == []
+
+
+def test_filter_actionable_module_types_includes_module_with_missing_component(
+    mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
+):
+    mock_nb_api = mock_pynetbox.api.return_value
+    mock_nb_api.version = "3.5"
+
+    mock_graphql_requests.side_effect = paginate_dispatch(
+        {
+            "manufacturer_list": [],
+            "device_type_list": [],
+            "module_type_list": [
+                {
+                    "id": "42",
+                    "model": "Linecard 1",
+                    "manufacturer": {"id": "20", "name": "Juniper", "slug": "juniper"},
+                }
+            ],
+            "image_attachment_list": [],
+        }
+    )
+
+    nb = NetBox(mock_settings, mock_handle)
+    # Global preload done; module 42 has no interfaces cached → component is missing.
+    _mark_cache_ready(nb.device_types)
+    nb.device_types.components.record("interface_templates", "module", 42, {})
+
+    module_type = {
+        "manufacturer": {"slug": "juniper"},
+        "model": "Linecard 1",
+        "slug": "linecard-1",
+        "interfaces": [{"name": "xe-0/0/0"}],
+        "src": "/tmp/repo/module-types/juniper/linecard-1.yaml",
+    }
+
+    with patch("glob.glob", return_value=[]):
+        actionable, _, _ = nb.filter_actionable_module_types(
+            [module_type],
+            nb.get_existing_module_types(),
+            only_new=False,
+        )
+
+    assert actionable == [module_type]
+
+
+class TestFilterActionableModuleTypesMissingAttr:
+    """Tests for the _MISSING guard in filter_actionable_module_types."""
+
+    def test_missing_netbox_field_is_not_treated_as_change(
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
+    ):
+        """When existing module lacks an attribute, it's skipped — no false positive change."""
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "3.5"
+
+        mock_graphql_requests.side_effect = paginate_dispatch(
+            {
+                "manufacturer_list": [],
+                "device_type_list": [],
+                "module_type_list": [
+                    {
+                        "id": "10",
+                        "model": "Linecard-A",
+                        "manufacturer": {"id": "5", "name": "Arista", "slug": "arista"},
+                    }
+                ],
+                "image_attachment_list": [],
+            }
+        )
+
+        nb = NetBox(mock_settings, mock_handle)
+        _mark_cache_ready(nb.device_types)
+        existing_module = MagicMock(spec=[])
+        existing_module.id = 10
+        existing_module.manufacturer = MagicMock()
+        existing_module.manufacturer.slug = "arista"
+        existing_module.model = "Linecard-A"
+
+        all_module_types = {"arista": {"Linecard-A": existing_module}}
+
+        module_type = {
+            "manufacturer": {"slug": "arista"},
+            "model": "Linecard-A",
+            "slug": "linecard-a",
+            "part_number": "LC-123",
+            "src": "/repo/module-types/arista/linecard-a.yaml",
+        }
+
+        with patch("glob.glob", return_value=[]):
+            actionable, _, changed_property_log = nb.filter_actionable_module_types(
+                [module_type],
+                all_module_types,
+                only_new=False,
+            )
+
+        # The _MISSING sentinel must prevent the module from being flagged for update.
+        # A MagicMock(spec=[]) has no attributes, so every field access returns _MISSING
+        # and the module should NOT appear in actionable or the change log.
+        assert actionable == []
+        assert changed_property_log == []
+
+
+class TestProcessSingleModuleTypeRemoveComponents:
+    """Tests that remove_components=True calls device_types.remove_components."""
+
+    def test_remove_components_is_called_when_flag_set(
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, make_device_types, mock_handle
+    ):
+        """When remove_components=True and there are component changes, remove_components is called."""
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "3.5"
+
+        nb = NetBox(mock_settings, mock_handle)
+
+        # Build a pre-existing module type so the "else" path (update) is taken.
+        existing_module = MagicMock()
+        existing_module.id = 55
+        existing_module.manufacturer.name = "Cisco"
+        existing_module.model = "CM-Remove"
+
+        all_module_types = {"cisco": {"CM-Remove": existing_module}}
+
+        # Populate cache so _compare_components returns a COMPONENT_REMOVED change.
+        stale_iface = MagicMock()
+        stale_iface.name = "xe-stale"
+        nb.device_types.components.record("interface_templates", "module", 55, {"xe-stale": stale_iface})
+        _mark_cache_ready(nb.device_types)
+
+        curr_mt = {
+            "manufacturer": {"slug": "cisco"},
+            "model": "CM-Remove",
+            "slug": "cm-remove",
+            "interfaces": [],  # empty → xe-stale should be detected as removed
+        }
+
+        nb.device_types.remove_components = MagicMock()
+        nb.device_types.update_components = MagicMock()
+
+        result = nb._process_single_module_type(
+            curr_mt,
+            "test.yaml",
+            all_module_types,
+            {},
+            only_new=False,
+            remove_components=True,
+        )
+
+        assert result is True
+        nb.device_types.remove_components.assert_called_once()
+        # Verify the payload: exactly one COMPONENT_REMOVED change for "xe-stale".
+        from core.change_detector import ChangeType
+
+        removal_changes = nb.device_types.remove_components.call_args.args[1]
+        assert len(removal_changes) == 1
+        assert removal_changes[0].change_type == ChangeType.COMPONENT_REMOVED
+        assert removal_changes[0].component_name == "xe-stale"
+
+    def test_component_reconciliation_continues_when_scalar_patch_fails(
+        self, mock_settings, mock_pynetbox, mock_graphql_requests, make_device_types, mock_handle
+    ):
+        """A failed scalar PATCH must NOT skip subsequent component reconciliation.
+
+        Regression: previously the early ``return False`` on a failed
+        ``module_types.update`` left existing modules with property + component
+        diffs in a partial-sync state because component reconciliation was
+        skipped entirely.
+        """
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "3.5"
+
+        nb = NetBox(mock_settings, mock_handle)
+
+        existing_module = MagicMock()
+        existing_module.id = 77
+        existing_module.manufacturer.name = "Cisco"
+        existing_module.model = "CM-Fail-Patch"
+        # Make the scalar diff non-empty so update() will be invoked and fail.
+        existing_module.part_number = "OLD_PN"
+
+        all_module_types = {"cisco": {"CM-Fail-Patch": existing_module}}
+
+        # Cache a stale interface so _compare_components yields a COMPONENT_REMOVED.
+        stale_iface = MagicMock()
+        stale_iface.name = "xe-stale"
+        nb.device_types.components.record("interface_templates", "module", 77, {"xe-stale": stale_iface})
+        _mark_cache_ready(nb.device_types)
+
+        curr_mt = {
+            "manufacturer": {"slug": "cisco"},
+            "model": "CM-Fail-Patch",
+            "slug": "cm-fail-patch",
+            "part_number": "NEW_PN",  # forces a scalar diff
+            "interfaces": [],  # empty → xe-stale should be detected as removed
+        }
+
+        # Force the scalar PATCH to fail with a pynetbox RequestError.
+        # pynetbox is mocked at module level, so we restore the real exception
+        # class first (otherwise `except pynetbox.RequestError` raises TypeError).
+        import pynetbox as _real_pynb
+
+        mock_pynetbox.RequestError = _real_pynb.RequestError
+        request_error = _real_pynb.RequestError(MagicMock(status_code=400, content=b'{"detail":"boom"}'))
+        mock_nb_api.dcim.module_types.update = MagicMock(side_effect=request_error)
+
+        nb.device_types.update_components = MagicMock()
+        nb.device_types.remove_components = MagicMock()
+
+        result = nb._process_single_module_type(
+            curr_mt,
+            "test.yaml",
+            all_module_types,
+            {},
+            only_new=False,
+            remove_components=True,
+        )
+
+        # The failed PATCH should NOT prevent component reconciliation.
+        # Verify the failing PATCH was actually attempted (regression: scalar
+        # diff detection silently skipping update() would still pass without
+        # this assertion).
+        mock_nb_api.dcim.module_types.update.assert_called_once()
+        assert result is True
+        nb.device_types.remove_components.assert_called_once()
+        assert nb.counter["module_updated"] == 0
+        assert nb.counter["module_update_failed"] == 1
+        failures = nb.outcomes.failures()
+        assert len(failures) == 1
+        assert "CM-Fail-Patch" in failures[0].identity

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -2888,6 +2888,7 @@ class TestCreateModuleTypesEdge:
         mock_pynetbox.api.return_value.version = "3.5"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        _mark_cache_ready(nb.device_types)
 
         # Simulate update_components actually updating a component (increments components_updated)
         def _do_update(*args, **kwargs):
@@ -2951,6 +2952,7 @@ class TestCreateModuleTypesEdge:
         mock_pynetbox.api.return_value.version = "3.5"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        _mark_cache_ready(nb.device_types)
 
         # Simulate update_components actually updating a component
         def _do_update(*args, **kwargs):
@@ -3018,6 +3020,7 @@ class TestCreateModuleTypesEdge:
         mock_pynetbox.api.return_value.version = "3.5"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        _mark_cache_ready(nb.device_types)
         # update_components is a no-op for removals (no counter change)
         nb.device_types.update_components = MagicMock()
 
@@ -6004,10 +6007,14 @@ class TestAdditionalModuleTypeCoverage:
         nb = NetBox(mock_settings, mock_handle)
         module_type_res = MagicMock(id=7, model="LC")
         module_type_res.manufacturer.name = "Cisco"
+        nb.device_types.ensure_components_ready = MagicMock()
         nb.change_detector._compare_components = MagicMock(return_value=[])
 
-        nb._apply_module_type_component_updates({}, module_type_res, False, False, patch_ok=False)
+        nb._apply_module_type_component_updates(
+            {"manufacturer": {"slug": "cisco"}}, module_type_res, False, False, patch_ok=False
+        )
 
+        nb.device_types.ensure_components_ready.assert_called_once_with(manufacturer_slug="cisco")
         assert nb.counter["module_update_failed"] == 1
         assert nb.outcomes.failures()[0].reason == "Scalar PATCH failed; no component changes detected."
 
@@ -6033,7 +6040,9 @@ class TestAdditionalModuleTypeCoverage:
             ]
         )
 
-        nb._apply_module_type_component_updates({}, module_type_res, False, False, patch_ok=True)
+        nb._apply_module_type_component_updates(
+            {"manufacturer": {"slug": "cisco"}}, module_type_res, False, False, patch_ok=True
+        )
 
         assert nb.counter["module_partial_update"] == 1
 
@@ -6052,7 +6061,9 @@ class TestAdditionalModuleTypeCoverage:
             return_value=[ComponentChange("interfaces", "xe-0", ChangeType.COMPONENT_CHANGED)]
         )
 
-        nb._apply_module_type_component_updates({}, module_type_res, True, False, patch_ok=True)
+        nb._apply_module_type_component_updates(
+            {"manufacturer": {"slug": "cisco"}}, module_type_res, True, False, patch_ok=True
+        )
 
         assert nb.counter["module_partial_update"] == 1
 
@@ -6070,7 +6081,9 @@ class TestAdditionalModuleTypeCoverage:
             return_value=[ComponentChange("interfaces", "xe-0", ChangeType.COMPONENT_REMOVED)]
         )
 
-        nb._apply_module_type_component_updates({}, module_type_res, False, False, patch_ok=False)
+        nb._apply_module_type_component_updates(
+            {"manufacturer": {"slug": "cisco"}}, module_type_res, False, False, patch_ok=False
+        )
 
         assert nb.counter["module_update_failed"] == 1
         assert nb.outcomes.failures()[0].reason == "Scalar PATCH failed; no component changes were actionable."


### PR DESCRIPTION
Architecture candidate 2, following #111.

## The problem

Prefetching component templates was spread across three modules with no owner:

- The vendor loop in `nb-dt-import.py` built a nine-key job dict (`futures`, `progress_updates`, `endpoint_totals`, `task_ids`, `finished_endpoints`, `executor`, `owns_tasks`, ...), pumped its progress queue at five points, handed it back into `_process_device_types` to be consumed, and stopped it in two places.
- Two call sites in `netbox_api` read a `_global_preload_done` flag and re-ran the preload themselves when it was false.
- `ChangeDetector` reached into `cached_components` and indexed it by hand.

The interface could not express its own ordering rule, so a comment did:

```python
# Non-only_new path: always consume the preload job if one was started.
# This is required even when device_types is empty (e.g. module-type-only vendor)
# so that _global_preload_done is set before _process_module_types runs.
```

## The change

`core/component_cache.py` owns it: `begin_prefetch`, `pump`, `ensure_ready`, `get`, `entries`, `record`, `invalidate`. Futures, the executor, the progress queue, per-endpoint task state and the readiness flag are internal. 775 lines leave `netbox_api.py` (3897 → 3077 before the rewiring).

`ensure_ready()` is idempotent and starts the prefetch itself when none is in flight. That is what removes the rule above: whoever needs cached components asks for them, so there is no longer a stage that must consume a job on another stage's behalf. Both self-healing `if not _global_preload_done` guards collapse into one call.

Progress leaves through an injected display, so the cache no longer imports Rich. `RichTaskDisplay` absorbs the `owns_tasks` flag that four functions threaded through: a display with a shared registry leaves its tasks for the caller to close, one without removes its own. `NullTaskDisplay` removes every `if progress is not None` branch from the fetch path.

## Removed

Two members reachable only from tests:

- `preload_module_type_components` — no production caller since it was added in #64. `git log -S` confirms it was never called; the vendor prefetch already covers module types.
- `_get_filter_kwargs` — its only caller was the cached-or-fetch lookup, which now builds the filter itself.

## Tests

`tests/test_component_cache.py` drives a real `ComponentCache` throughout; the fakes stand in for NetBox and Rich, not for the code under test. 100% statement coverage on the new module.

Tests that poked `cached_components` as a dict now go through the real object, which matters concretely: `test_change_detector` built its `device_types` as a bare `MagicMock` and assigned a dict onto it, so the lookup under test was never the real one. They now populate a real cache and read it back through `entries()`.

- 965 passing, coverage 96.96% (gate 96%)
- 59 tests of the removed private helpers deleted; 12 that exercised real `netbox_api` behavior and only touched the old names incidentally were recovered and adapted

## Note

One partial branch in `close()` is uncovered: the loop that discards displays for endpoints still in flight, when every endpoint has already finished. Statement coverage on the module is 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized component caching for faster, more consistent lookups.
  * Added concurrent prefetching with progress reporting.
  * Added REST fallback support for broader endpoint compatibility.

* **Bug Fixes**
  * Improved detection of added, removed, and modified components.
  * Added cache invalidation to keep device and module data synchronized.
  * Improved handling of vendor-specific data and incomplete results.

* **Tests**
  * Expanded coverage for caching, prefetching, fallback behavior, validation, and change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->