### PR TITLE
refactor: describe each component type once, in one registry

### DIFF
--- a/core/change_detector.py
+++ b/core/change_detector.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 from typing import Any, List, Optional
 from enum import Enum
 
+from core.component_registry import COMPONENT_TYPES
 from core.normalization import normalize_values
 from core.formatting import log_property_diffs
 from core.schema_reader import load_properties_for_type
@@ -126,28 +127,6 @@ _MISSING = object()
 # Image properties: YAML uses boolean flags, NetBox stores URL strings.
 # Only existence is compared (YAML=true vs NetBox=empty).
 IMAGE_PROPERTIES = ["front_image", "rear_image"]
-
-# Component type mapping: YAML key -> (cache_key, comparable_properties)
-COMPONENT_TYPES = {
-    "interfaces": (
-        "interface_templates",
-        ["name", "type", "mgmt_only", "label", "enabled", "poe_mode", "poe_type", "description", "rf_role"],
-    ),
-    "power-ports": (
-        "power_port_templates",
-        ["name", "type", "maximum_draw", "allocated_draw", "label", "description"],
-    ),
-    "console-ports": ("console_port_templates", ["name", "type", "label", "description"]),
-    "power-outlets": ("power_outlet_templates", ["name", "type", "feed_leg", "label", "description"]),
-    "console-server-ports": (
-        "console_server_port_templates",
-        ["name", "type", "label", "description"],
-    ),
-    "rear-ports": ("rear_port_templates", ["name", "type", "positions", "label", "description", "color"]),
-    "front-ports": ("front_port_templates", ["name", "type", "_mappings", "label", "description", "color"]),
-    "device-bays": ("device_bay_templates", ["name", "label", "description"]),
-    "module-bays": ("module_bay_templates", ["name", "position", "label", "description"]),
-}
 
 
 class ChangeDetector:
@@ -312,11 +291,12 @@ class ChangeDetector:
         """
         changes = []
 
-        for yaml_key, (cache_name, properties) in COMPONENT_TYPES.items():
+        for component in COMPONENT_TYPES:
+            yaml_key = component.yaml_key
             yaml_components = list(yaml_data.get(yaml_key) or [])
 
             # entries(), not get(): detection must read the cache, never trigger a fetch.
-            existing_components = self.device_types.components.entries(cache_name, parent_type, device_type_id)
+            existing_components = self.device_types.components.entries(component.endpoint, parent_type, device_type_id)
 
             # Build set of YAML component names for this type
             yaml_component_names = {comp.get("name") for comp in yaml_components if comp.get("name")}
@@ -357,7 +337,7 @@ class ChangeDetector:
                     # Check for property changes on existing component
                     existing = existing_components[comp_name]
                     prop_changes = self._compare_component_properties(
-                        yaml_comp, existing, properties, comp_type=yaml_key
+                        yaml_comp, existing, component.compare_properties, comp_type=yaml_key
                     )
                     if prop_changes:
                         changes.append(

--- a/core/component_cache.py
+++ b/core/component_cache.py
@@ -18,40 +18,8 @@ from core.compat import (
     module_type_filter_key,
     module_type_filter_kwargs,
 )
-from core.graphql_client import (
-    GraphQLCountMismatchError,
-    GraphQLSchemaError,
-    _NO_MODULE_TYPE as NO_MODULE_TYPE_ENDPOINTS,
-)
-
-# Component endpoints fetched up front, with the label shown in the progress display.
-PRELOAD_TARGETS = (
-    ("interface_templates", "Interfaces"),
-    ("power_port_templates", "Power Ports"),
-    ("console_port_templates", "Console Ports"),
-    ("console_server_port_templates", "Console Server Ports"),
-    ("power_outlet_templates", "Power Outlets"),
-    ("rear_port_templates", "Rear Ports"),
-    ("front_port_templates", "Front Ports"),
-    ("device_bay_templates", "Device Bays"),
-    ("module_bay_templates", "Module Bays"),
-)
-
-# YAML component key -> (pynetbox endpoint attribute, cache name).
-ENDPOINT_CACHE_MAP = {
-    "interfaces": ("interface_templates", "interface_templates"),
-    "power-ports": ("power_port_templates", "power_port_templates"),
-    "console-ports": ("console_port_templates", "console_port_templates"),
-    "power-outlets": ("power_outlet_templates", "power_outlet_templates"),
-    "console-server-ports": (
-        "console_server_port_templates",
-        "console_server_port_templates",
-    ),
-    "rear-ports": ("rear_port_templates", "rear_port_templates"),
-    "front-ports": ("front_port_templates", "front_port_templates"),
-    "device-bays": ("device_bay_templates", "device_bay_templates"),
-    "module-bays": ("module_bay_templates", "module_bay_templates"),
-}
+from core.component_registry import COMPONENT_TYPES
+from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError
 
 # Endpoints whose GraphQL schema is missing fields required for accurate change
 # detection, and where REST provides them.  Add an endpoint here if a NetBox
@@ -202,11 +170,11 @@ class ComponentCache:
             return
 
         display = display or NullTaskDisplay()
-        for endpoint_name, label in PRELOAD_TARGETS:
-            display.add(endpoint_name, label)
+        for component in COMPONENT_TYPES:
+            display.add(component.endpoint, component.plural_label)
 
         updates = queue.Queue()
-        max_workers = max(1, min(len(PRELOAD_TARGETS), self.max_threads))
+        max_workers = max(1, min(len(COMPONENT_TYPES), self.max_threads))
         executor = concurrent.futures.ThreadPoolExecutor(max_workers=max_workers)
         try:
             futures = {
@@ -216,12 +184,12 @@ class ComponentCache:
                     lambda name, advance: updates.put((name, advance)),
                     manufacturer_slug,
                 )
-                for endpoint_name, _label in PRELOAD_TARGETS
+                for endpoint_name in (component.endpoint for component in COMPONENT_TYPES)
             }
         except Exception:
             executor.shutdown(wait=False, cancel_futures=True)
-            for endpoint_name, _label in PRELOAD_TARGETS:
-                display.discard(endpoint_name)
+            for component in COMPONENT_TYPES:
+                display.discard(component.endpoint)
             raise
 
         self._job = {
@@ -277,9 +245,9 @@ class ComponentCache:
             )
 
         records = self._collect()
-        for endpoint_name, label in PRELOAD_TARGETS:
-            count = self.populate(endpoint_name, records.get(endpoint_name, []))
-            self.handle.verbose_log(f"Cached {count} {label}.")
+        for component in COMPONENT_TYPES:
+            count = self.populate(component.endpoint, records.get(component.endpoint, []))
+            self.handle.verbose_log(f"Cached {count} {component.plural_label}.")
 
         if manufacturer_slug is not None:
             self._verify_vendor_scope(manufacturer_slug, device_type_ids or set())
@@ -504,7 +472,8 @@ class ComponentCache:
         dt_ids = list(device_type_ids)
         mt_ids = list(module_type_ids)
 
-        for endpoint_name, _label in PRELOAD_TARGETS:
+        for component in COMPONENT_TYPES:
+            endpoint_name = component.endpoint
             if endpoint_name in REST_ONLY_ENDPOINTS:
                 # Already fetched over REST, so comparing REST to REST proves nothing.
                 continue
@@ -519,7 +488,7 @@ class ComponentCache:
             rest_count = 0
             if dt_ids:
                 rest_count += self._rest_count(rest_endpoint, dt_filter_key, dt_ids)
-            if mt_ids and endpoint_name not in NO_MODULE_TYPE_ENDPOINTS:
+            if mt_ids and component.module_types:
                 rest_count += self._rest_count(rest_endpoint, mt_filter_key, mt_ids)
 
             if cached_count != rest_count:

--- a/core/component_registry.py
+++ b/core/component_registry.py
@@ -1,0 +1,130 @@
+"""One row per component template type; every other table is derived from it.
+
+NetBox device types and module types carry nine kinds of component template.  Each kind
+used to be described in eleven places (YAML key, cache name, endpoint attribute, GraphQL
+list key, GraphQL field list, comparable properties, serializer fields, display label,
+module-type support, create method), so adding a field to one copy and not the others
+changed nothing visible and broke the import quietly.
+
+This module holds the row.  Consumers read it; they do not restate it.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+# What a create call must resolve from a name to a NetBox id before it can POST.
+LINK_BRIDGE = "bridge"
+LINK_POWER_PORT = "power_port"
+LINK_REAR_PORTS = "rear_ports"
+
+
+@dataclass(frozen=True)
+class ComponentType:
+    """One kind of component template, described once."""
+
+    yaml_key: str
+    endpoint: str
+    label: str
+    fields: tuple
+    module_types: bool = True
+    graphql_extra: tuple = field(default_factory=tuple)
+    compare_extra: tuple = field(default_factory=tuple)
+    link: Optional[str] = None
+
+    @property
+    def graphql_fields(self):
+        """Fields to select in a GraphQL query, including the id every consumer needs."""
+        return ["id", *self.fields, *self.graphql_extra]
+
+    @property
+    def compare_properties(self):
+        """Properties change detection compares between YAML and NetBox."""
+        return [*self.fields, *self.compare_extra]
+
+    @property
+    def list_key(self):
+        """The GraphQL list field for this endpoint, e.g. ``interface_template_list``."""
+        return f"{self.endpoint.removesuffix('s')}_list"
+
+    @property
+    def plural_label(self):
+        """Label for a group of these components, as shown in the progress display."""
+        return f"{self.label}s"
+
+    def create_label(self, parent_type):
+        """Label used in create and error messages, distinguishing module parents."""
+        return self.label if parent_type == "device" else f"Module {self.label}"
+
+
+# Order is canonical: it sets the YAML key order of an export, the progress-bar order,
+# and the create order.  Rear ports precede front ports, and power ports precede power
+# outlets, because the later type resolves names against the earlier one.
+COMPONENT_TYPES = (
+    ComponentType(
+        yaml_key="interfaces",
+        endpoint="interface_templates",
+        label="Interface",
+        fields=("name", "type", "label", "description", "mgmt_only", "enabled", "poe_mode", "poe_type", "rf_role"),
+        link=LINK_BRIDGE,
+    ),
+    ComponentType(
+        yaml_key="power-ports",
+        endpoint="power_port_templates",
+        label="Power Port",
+        fields=("name", "type", "label", "description", "maximum_draw", "allocated_draw"),
+    ),
+    ComponentType(
+        yaml_key="console-ports",
+        endpoint="console_port_templates",
+        label="Console Port",
+        fields=("name", "type", "label", "description"),
+    ),
+    ComponentType(
+        yaml_key="power-outlets",
+        endpoint="power_outlet_templates",
+        label="Power Outlet",
+        fields=("name", "type", "label", "description", "feed_leg"),
+        link=LINK_POWER_PORT,
+    ),
+    ComponentType(
+        yaml_key="console-server-ports",
+        endpoint="console_server_port_templates",
+        label="Console Server Port",
+        fields=("name", "type", "label", "description"),
+    ),
+    ComponentType(
+        yaml_key="rear-ports",
+        endpoint="rear_port_templates",
+        label="Rear Port",
+        fields=("name", "type", "label", "description", "positions", "color"),
+    ),
+    ComponentType(
+        yaml_key="front-ports",
+        endpoint="front_port_templates",
+        label="Front Port",
+        fields=("name", "type", "label", "description", "color"),
+        graphql_extra=("mappings { id front_port_position rear_port_position rear_port { id name } }",),
+        compare_extra=("_mappings",),
+        link=LINK_REAR_PORTS,
+    ),
+    ComponentType(
+        yaml_key="device-bays",
+        endpoint="device_bay_templates",
+        label="Device Bay",
+        fields=("name", "label", "description"),
+        # NetBox exposes no module_type on device_bay_templates, and a module type cannot
+        # hold a device bay.
+        module_types=False,
+    ),
+    ComponentType(
+        yaml_key="module-bays",
+        endpoint="module_bay_templates",
+        label="Module Bay",
+        fields=("name", "position", "label", "description"),
+    ),
+)
+
+BY_YAML_KEY = {component.yaml_key: component for component in COMPONENT_TYPES}
+BY_ENDPOINT = {component.endpoint: component for component in COMPONENT_TYPES}
+
+MODULE_TYPE_COMPONENTS = tuple(component for component in COMPONENT_TYPES if component.module_types)

--- a/core/export.py
+++ b/core/export.py
@@ -22,7 +22,7 @@ from core.export_manifest import (
 )
 from core.graphql_client import NetBoxGraphQLClient
 from core.nb_serializer import (
-    COMPONENT_ENDPOINTS,
+    COMPONENT_ENDPOINT_NAMES,
     serialize_device_type,
     serialize_module_type,
     serialize_rack_type,
@@ -247,7 +247,7 @@ class Exporter:
             f"Fetched type metadata: {total_dt} device-types, "
             f"{total_mt} module-types, {total_rt} rack-types. "
             f"Component templates fetched per vendor below "
-            f"({len(COMPONENT_ENDPOINTS)} endpoints/vendor)."
+            f"({len(COMPONENT_ENDPOINT_NAMES)} endpoints/vendor)."
         )
 
         # ── Load repo YAML dicts ─────────────────────────────────────────────
@@ -353,7 +353,7 @@ class Exporter:
             self.handle.verbose_log(
                 f"  {mfr_slug}: {len(stale_dts)} device-type(s), "
                 f"{len(stale_mts)} module-type(s) to compare; "
-                f"fetching {len(COMPONENT_ENDPOINTS)} component-template endpoints…"
+                f"fetching {len(COMPONENT_ENDPOINT_NAMES)} component-template endpoints…"
             )
             dt_components, mt_components = self._fetch_vendor_components(mfr_slug)
 
@@ -633,8 +633,8 @@ class Exporter:
             )
 
         try:
-            with ThreadPoolExecutor(max_workers=len(COMPONENT_ENDPOINTS)) as pool:
-                results = list(pool.map(_fetch_one, [ep_name for _, ep_name in COMPONENT_ENDPOINTS]))
+            with ThreadPoolExecutor(max_workers=len(COMPONENT_ENDPOINT_NAMES)) as pool:
+                results = list(pool.map(_fetch_one, COMPONENT_ENDPOINT_NAMES))
         finally:
             for client in _clients:
                 try:

--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -10,6 +10,8 @@ import time
 
 import requests
 
+from core.component_registry import BY_ENDPOINT
+
 # Module-level dedup: tracks (url, requested_page_size) pairs that have already
 # emitted the page-size clamping warning so the message appears at most once
 # even when multiple client instances share the same server.
@@ -90,68 +92,6 @@ def _to_dotdict(obj):
         return [_to_dotdict(item) for item in obj]
     return obj
 
-
-# Deterministic mapping from endpoint name to its GraphQL list key.
-# Using rstrip("s") would strip multiple trailing 's' chars from hypothetical
-# future names; this mapping is explicit and safe.
-ENDPOINT_TO_LIST_KEY = {
-    "interface_templates": "interface_template_list",
-    "power_port_templates": "power_port_template_list",
-    "console_port_templates": "console_port_template_list",
-    "console_server_port_templates": "console_server_port_template_list",
-    "power_outlet_templates": "power_outlet_template_list",
-    "rear_port_templates": "rear_port_template_list",
-    "front_port_templates": "front_port_template_list",
-    "device_bay_templates": "device_bay_template_list",
-    "module_bay_templates": "module_bay_template_list",
-}
-
-# Mapping of endpoint names (as used in DeviceTypes) to their GraphQL fields.
-# Every entry also includes ``device_type { id }`` and ``module_type { id }`` automatically.
-COMPONENT_TEMPLATE_FIELDS = {
-    "interface_templates": [
-        "id",
-        "name",
-        "type",
-        "mgmt_only",
-        "label",
-        "enabled",
-        "poe_mode",
-        "poe_type",
-        "description",
-        "rf_role",
-    ],
-    "power_port_templates": [
-        "id",
-        "name",
-        "type",
-        "maximum_draw",
-        "allocated_draw",
-        "label",
-        "description",
-    ],
-    "console_port_templates": ["id", "name", "type", "label", "description"],
-    "console_server_port_templates": ["id", "name", "type", "label", "description"],
-    "power_outlet_templates": ["id", "name", "type", "feed_leg", "label", "description"],
-    "rear_port_templates": ["id", "name", "type", "positions", "label", "description", "color"],
-    "front_port_templates": [
-        "id",
-        "name",
-        "type",
-        "label",
-        "description",
-        "color",
-        "mappings { id front_port_position rear_port_position rear_port { id name } }",
-    ],
-    "device_bay_templates": ["id", "name", "label", "description"],
-    "module_bay_templates": ["id", "name", "position", "label", "description"],
-}
-
-# Endpoints whose GraphQL schema has no ``module_type`` parent field.
-# Note: module_bay_templates is intentionally excluded from this set — NetBox's
-# module_bay_template_list DOES support module_type { id }, so we must include it
-# in the query to correctly cache module bays owned by module types.
-_NO_MODULE_TYPE = {"device_bay_templates"}
 
 # NetBox returns the real cause (a database error, a plugin traceback) in the response body,
 # so it is worth reporting. Django error pages can be large, hence the cap.
@@ -829,17 +769,18 @@ class NetBoxGraphQLClient:
             ValueError: If *endpoint_name* is not a recognized component template endpoint.
             ValueError: If *manufacturer_slug* is an empty string.
         """
-        if endpoint_name not in COMPONENT_TEMPLATE_FIELDS or endpoint_name not in ENDPOINT_TO_LIST_KEY:
+        component = BY_ENDPOINT.get(endpoint_name)
+        if component is None:
             raise ValueError(f"Unknown component endpoint: {endpoint_name}")
 
         if manufacturer_slug is not None and len(manufacturer_slug) == 0:
             raise ValueError("manufacturer_slug must be None or a non-empty string")
 
-        fields = COMPONENT_TEMPLATE_FIELDS[endpoint_name]
-        list_key = ENDPOINT_TO_LIST_KEY[endpoint_name]
+        fields = component.graphql_fields
+        list_key = component.list_key
 
         parent_fields = "device_type { id }"
-        if endpoint_name not in _NO_MODULE_TYPE:
+        if component.module_types:
             parent_fields += "\n            module_type { id }"
 
         if manufacturer_slug is None:
@@ -869,7 +810,7 @@ class NetBoxGraphQLClient:
             )
 
             # If endpoint supports module_type, also query module-type-filtered templates
-            if endpoint_name not in _NO_MODULE_TYPE:
+            if component.module_types:
                 module_filter = "filters: {module_type: {manufacturer: {slug: {exact: $manufacturer_slug}}}}, "
                 module_items = self._query_component_endpoint(
                     list_key=list_key,

--- a/core/nb_serializer.py
+++ b/core/nb_serializer.py
@@ -7,45 +7,10 @@ comparison against existing repo YAML files.
 import warnings
 from typing import Any
 
-# Maps YAML component key → NetBox endpoint name.
-# Order defines the output key order in the serialized YAML.
-COMPONENT_ENDPOINTS = [
-    ("interfaces", "interface_templates"),
-    ("power-ports", "power_port_templates"),
-    ("console-ports", "console_port_templates"),
-    ("power-outlets", "power_outlet_templates"),
-    ("console-server-ports", "console_server_port_templates"),
-    ("rear-ports", "rear_port_templates"),
-    ("front-ports", "front_port_templates"),
-    ("device-bays", "device_bay_templates"),
-    ("module-bays", "module_bay_templates"),
-]
+from core.component_registry import BY_ENDPOINT, COMPONENT_TYPES
 
-# The DTL endpoint names (for use with get_component_templates())
-COMPONENT_ENDPOINT_NAMES = [ep_name for _, ep_name in COMPONENT_ENDPOINTS]
-
-# Field lists per component type (same fields as graphql_client.COMPONENT_TEMPLATE_FIELDS,
-# minus "id" and parent fields).
-_IFACE_FIELDS = ["name", "type", "label", "description", "mgmt_only", "enabled", "poe_mode", "poe_type", "rf_role"]
-_POWER_PORT_FIELDS = ["name", "type", "label", "description", "maximum_draw", "allocated_draw"]
-_CONSOLE_FIELDS = ["name", "type", "label", "description"]
-_POWER_OUTLET_FIELDS = ["name", "type", "label", "description", "feed_leg"]
-_REAR_PORT_FIELDS = ["name", "type", "label", "description", "positions", "color"]
-_FRONT_PORT_FIELDS = ["name", "type", "label", "description", "color"]  # rear_port handled separately
-_DEVICE_BAY_FIELDS = ["name", "label", "description"]
-_MODULE_BAY_FIELDS = ["name", "position", "label", "description"]
-
-_COMPONENT_FIELDS = {
-    "interface_templates": _IFACE_FIELDS,
-    "power_port_templates": _POWER_PORT_FIELDS,
-    "console_port_templates": _CONSOLE_FIELDS,
-    "console_server_port_templates": _CONSOLE_FIELDS,
-    "power_outlet_templates": _POWER_OUTLET_FIELDS,
-    "rear_port_templates": _REAR_PORT_FIELDS,
-    "front_port_templates": _FRONT_PORT_FIELDS,
-    "device_bay_templates": _DEVICE_BAY_FIELDS,
-    "module_bay_templates": _MODULE_BAY_FIELDS,
-}
+# Row order sets the component key order of the serialized YAML.
+COMPONENT_ENDPOINT_NAMES = [component.endpoint for component in COMPONENT_TYPES]
 
 # Values that are defaults — omit from output to keep YAML clean.
 _OMIT_IF_EQUAL = {
@@ -162,7 +127,7 @@ def _serialize_component(record: Any, fields: list) -> dict:
 
 def _serialize_front_port(record: Any) -> dict:
     """Serialize a front port template, including rear_port mapping."""
-    result = _serialize_component(record, _FRONT_PORT_FIELDS)
+    result = _serialize_component(record, BY_ENDPOINT["front_port_templates"].fields)
     mappings = getattr(record, "mappings", None) or []
     if mappings:
         if len(mappings) > 1:
@@ -201,17 +166,17 @@ def _serialize_component_list(endpoint_name: str, records: list) -> list:
         if endpoint_name == "front_port_templates":
             out.append(_serialize_front_port(record))
         else:
-            out.append(_serialize_component(record, _COMPONENT_FIELDS[endpoint_name]))
+            out.append(_serialize_component(record, BY_ENDPOINT[endpoint_name].fields))
     return out
 
 
 def _add_components(result: dict, type_id: int, components_by_id: dict) -> None:
     """Append serialized component lists to *result* for a given type id."""
     type_components = components_by_id.get(type_id, {})
-    for yaml_key, endpoint_name in COMPONENT_ENDPOINTS:
-        records = type_components.get(endpoint_name, [])
+    for component in COMPONENT_TYPES:
+        records = type_components.get(component.endpoint, [])
         if records:
-            result[yaml_key] = _serialize_component_list(endpoint_name, records)
+            result[component.yaml_key] = _serialize_component_list(component.endpoint, records)
 
 
 def serialize_device_type(nb_record: Any, components_by_dt_id: dict) -> dict:

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -15,7 +15,15 @@ import glob
 from pathlib import Path
 
 from core.change_detector import ChangeDetector, ChangeType
-from core.component_cache import ENDPOINT_CACHE_MAP, ComponentCache
+from core.component_cache import ComponentCache
+from core.component_registry import (
+    BY_YAML_KEY,
+    COMPONENT_TYPES,
+    LINK_BRIDGE,
+    LINK_POWER_PORT,
+    LINK_REAR_PORTS,
+    MODULE_TYPE_COMPONENTS,
+)
 from core.formatting import log_property_diffs
 from core.graphql_client import GraphQLError, NetBoxGraphQLClient
 from core.normalization import values_equal
@@ -1049,24 +1057,13 @@ class NetBox:
             src_file (str): Filesystem path to the YAML source file (for front-port context).
             saved_images (dict): Mapping of image kind to local file path for upload.
         """
-        if "interfaces" in device_type:
-            self.device_types.create_interfaces(device_type["interfaces"], dt_id)
-        if "power-ports" in device_type:
-            self.device_types.create_power_ports(device_type["power-ports"], dt_id)
-        if "console-ports" in device_type:
-            self.device_types.create_console_ports(device_type["console-ports"], dt_id)
-        if "power-outlets" in device_type:
-            self.device_types.create_power_outlets(device_type["power-outlets"], dt_id)
-        if "console-server-ports" in device_type:
-            self.device_types.create_console_server_ports(device_type["console-server-ports"], dt_id)
-        if "rear-ports" in device_type:
-            self.device_types.create_rear_ports(device_type["rear-ports"], dt_id)
-        if "front-ports" in device_type:
-            self.device_types.create_front_ports(device_type["front-ports"], dt_id, context=src_file)
-        if "device-bays" in device_type:
-            self.device_types.create_device_bays(device_type["device-bays"], dt_id)
-        if self.modules and "module-bays" in device_type:
-            self.device_types.create_module_bays(device_type["module-bays"], dt_id)
+        for component in COMPONENT_TYPES:
+            yaml_key = component.yaml_key
+            if yaml_key not in device_type:
+                continue
+            if yaml_key == "module-bays" and not self.modules:
+                continue
+            self.device_types.create_components(yaml_key, device_type[yaml_key], dt_id, context=src_file)
         if saved_images:
             self.device_types.upload_images(self.url, self.token, saved_images, dt_id)
             _store_image_hashes(self._image_hash_cache, saved_images)
@@ -1329,9 +1326,11 @@ class NetBox:
             components = module_type.get(component_key)
             if not components:
                 continue
-            endpoint_attr, cache_name = ENDPOINT_CACHE_MAP[component_key]
-            endpoint = getattr(self.netbox.dcim, endpoint_attr)
-            existing_components = self.device_types.components.get(cache_name, "module", existing_module.id, endpoint)
+            endpoint_name = BY_YAML_KEY[component_key].endpoint
+            endpoint = getattr(self.netbox.dcim, endpoint_name)
+            existing_components = self.device_types.components.get(
+                endpoint_name, "module", existing_module.id, endpoint
+            )
             requested_names = {c.get("name") for c in components if c.get("name")}
             if any(name not in existing_components for name in requested_names):
                 return True
@@ -1509,18 +1508,12 @@ class NetBox:
             module_type_id (int): ID of the newly created module type in NetBox.
             src_file (str): Source file path for error context.
         """
-        component_map = {
-            "interfaces": self.device_types.create_module_interfaces,
-            "power-ports": self.device_types.create_module_power_ports,
-            "console-ports": self.device_types.create_module_console_ports,
-            "power-outlets": self.device_types.create_module_power_outlets,
-            "console-server-ports": self.device_types.create_module_console_server_ports,
-            "rear-ports": self.device_types.create_module_rear_ports,
-            "front-ports": self.device_types.create_module_front_ports,
-        }
-        for key, create_fn in component_map.items():
-            if key in curr_mt:
-                create_fn(curr_mt[key], module_type_id, context=src_file)
+        for component in MODULE_TYPE_COMPONENTS:
+            yaml_key = component.yaml_key
+            if yaml_key in curr_mt:
+                self.device_types.create_components(
+                    yaml_key, curr_mt[yaml_key], module_type_id, parent_type="module", context=src_file
+                )
 
     def _apply_module_type_component_updates(
         self, curr_mt, module_type_res, properties_updated, remove_components, patch_ok=True
@@ -2123,14 +2116,12 @@ class DeviceTypes:
 
     def _create_generic(
         self,
+        component,
         items,
         parent_id,
-        endpoint,
-        component_name,
         parent_type="device",
         post_process=None,
         context=None,
-        cache_name=None,
     ):
         """Create component templates in NetBox, skipping those that already exist.
 
@@ -2139,15 +2130,17 @@ class DeviceTypes:
         then calls ``endpoint.create()`` and updates counters. On error, logs each failed item.
 
         Args:
+            component (ComponentType): Registry row naming the endpoint, cache and label.
             items (list[dict]): Component definitions to create; each must have a "name" key.
             parent_id (int): ID of the parent device or module type.
-            endpoint: pynetbox endpoint proxy for create/filter calls.
-            component_name (str): Human-readable component type for log messages.
             parent_type (str): ``"device"`` or ``"module"``; determines parent key and counter key.
             post_process (callable | None): Optional ``(items, parent_id)`` callback run before creation.
             context (str | None): Optional context string appended to error log messages.
-            cache_name (str | None): Cache entry invalidated after creation, or None to skip.
         """
+        endpoint = getattr(self.netbox.dcim, component.endpoint)
+        component_name = component.create_label(parent_type)
+        cache_name = component.endpoint
+
         # Look up existing components via cache or API fallback
         existing = self.components.get(cache_name, parent_type, parent_id, endpoint)
 
@@ -2170,8 +2163,7 @@ class DeviceTypes:
                     count = self.handle.log_module_ports_created(created, component_name)
                     self.counter.update({"components_added": count})
 
-                if cache_name:
-                    self.components.invalidate(cache_name, parent_type, parent_id)
+                self.components.invalidate(cache_name, parent_type, parent_id)
             except pynetbox.RequestError as excep:
                 context_str = f" (Context: {context})" if context else ""
                 if isinstance(excep.error, list):
@@ -2301,15 +2293,12 @@ class DeviceTypes:
             device_type_id: NetBox ID of the parent device or module type.
             parent_type (str): ``"device"`` or ``"module"``.
         """
-        mapping = ENDPOINT_CACHE_MAP.get(comp_type)
-        if not mapping:
+        component = BY_YAML_KEY.get(comp_type)
+        if component is None:
             return
-        endpoint_attr, cache_name = mapping
-        endpoint = getattr(self.netbox.dcim, endpoint_attr, None)
-        if not endpoint:
-            return
+        endpoint = getattr(self.netbox.dcim, component.endpoint)
 
-        existing = self.components.get(cache_name, parent_type, device_type_id, endpoint)
+        existing = self.components.get(component.endpoint, parent_type, device_type_id, endpoint)
 
         updates = []
         for change in changes:
@@ -2352,14 +2341,13 @@ class DeviceTypes:
             self.counter.update({"components_updated": success_count})
             self.handle.verbose_log(f"Updated {success_count} {comp_type}")
 
-            self.components.invalidate(cache_name, parent_type, device_type_id)
+            self.components.invalidate(component.endpoint, parent_type, device_type_id)
 
     def _apply_additions_for_type(self, comp_type, changes, yaml_data, device_type_id, parent_type):
         """Create new component templates of a single type based on detected additions.
 
-        Resolves the YAML key for *comp_type* (including alias fallback), finds the
-        specific components to add from *yaml_data*, and delegates creation to the
-        appropriate endpoint helper.
+        Finds the components to add in *yaml_data* and hands them to
+        :meth:`create_components`, which resolves any name references.
 
         Args:
             comp_type (str): YAML component key (e.g. ``"interfaces"``).
@@ -2368,48 +2356,17 @@ class DeviceTypes:
             device_type_id: NetBox ID of the parent device or module type.
             parent_type (str): ``"device"`` or ``"module"``.
         """
-        yaml_key = None
-        if comp_type in yaml_data:
-            yaml_key = comp_type
-        if yaml_key is None:
+        if comp_type not in yaml_data or comp_type not in BY_YAML_KEY:
             return
 
-        mapping = ENDPOINT_CACHE_MAP.get(comp_type)
-        if not mapping:
-            return
-        endpoint_attr, cache_name = mapping
-        endpoint = getattr(self.netbox.dcim, endpoint_attr, None)
-        if not endpoint:
-            return
-
-        # Find the new components in the YAML data
-        yaml_components = yaml_data.get(yaml_key) or []
+        yaml_components = yaml_data.get(comp_type) or []
         new_component_names = {change.component_name for change in changes}
         components_to_add = [c for c in yaml_components if c.get("name") in new_component_names]
 
         if not components_to_add:
             return
 
-        # Front ports require special link_rear_ports post-processing (including M2M on 4.5+).
-        # Delegate to the dedicated create methods instead of calling _create_generic directly.
-        if comp_type == "front-ports":
-            if parent_type == "device":
-                self.create_front_ports(components_to_add, device_type_id)
-            else:
-                self.create_module_front_ports(components_to_add, device_type_id)
-            return
-
-        # Format component name for logging (e.g. "power_port_templates" -> "Power Port")
-        component_name = endpoint_attr.replace("_templates", "").replace("_", " ").title()
-
-        self._create_generic(
-            components_to_add,
-            device_type_id,
-            endpoint,
-            component_name,
-            parent_type=parent_type,
-            cache_name=cache_name,
-        )
+        self.create_components(comp_type, components_to_add, device_type_id, parent_type=parent_type)
 
     def update_components(self, yaml_data, device_type_id, component_changes, parent_type="device"):
         """Update existing components and add new components based on detected changes.
@@ -2459,15 +2416,12 @@ class DeviceTypes:
 
         # Process removals for each component type
         for comp_type, changes in removals_by_type.items():
-            mapping = ENDPOINT_CACHE_MAP.get(comp_type)
-            if not mapping:
+            component = BY_YAML_KEY.get(comp_type)
+            if component is None:
                 continue
-            endpoint_attr, cache_name = mapping
-            endpoint = getattr(self.netbox.dcim, endpoint_attr, None)
-            if not endpoint:
-                continue
+            endpoint = getattr(self.netbox.dcim, component.endpoint)
 
-            existing = self.components.get(cache_name, parent_type, device_type_id, endpoint)
+            existing = self.components.get(component.endpoint, parent_type, device_type_id, endpoint)
 
             ids_to_delete = []
             for change in changes:
@@ -2493,99 +2447,26 @@ class DeviceTypes:
                 self.counter.update({"components_removed": success_count})
                 self.handle.log(f"Removed {success_count} {comp_type}")
 
-                self.components.invalidate(cache_name, parent_type, device_type_id)
+                self.components.invalidate(component.endpoint, parent_type, device_type_id)
 
-    def create_interfaces(self, interfaces, device_type, context=None):
-        """Create interface templates for a device type, handling bridge references.
+    def _build_link_power_port(self, parent_type, label, context=None):
+        """Return a ``post_process`` callable that resolves power-port name references.
 
-        Strips ``bridge`` entries before creation and re-applies them after by resolving
-        bridge interface names to their NetBox IDs.
-
-        Args:
-            interfaces (list[dict]): Interface template definitions; may include a "bridge" key.
-            device_type (int): ID of the parent device type.
-            context (str | None): Optional context string for log messages.
-        """
-        bridged_interfaces = {}
-        # Pre-process to separate bridge config
-        for x in interfaces:
-            if "bridge" in x:
-                bridged_interfaces[x["name"]] = x["bridge"]
-                del x["bridge"]
-
-        self._create_generic(
-            interfaces,
-            device_type,
-            self.netbox.dcim.interface_templates,
-            "Interface",
-            context=context,
-            cache_name="interface_templates",
-        )
-
-        if bridged_interfaces:
-            all_interfaces = self.components.get(
-                "interface_templates",
-                "device",
-                device_type,
-                self.netbox.dcim.interface_templates,
-            )
-
-            to_update = []
-            for name, bridge_name in bridged_interfaces.items():
-                if name in all_interfaces and bridge_name in all_interfaces:
-                    iface = all_interfaces[name]
-                    bridge = all_interfaces[bridge_name]
-                    to_update.append({"id": iface.id, "bridge": bridge.id})
-                else:
-                    self.handle.log(f"Error bridging {name} to {bridge_name}: Interface not found (Context: {context})")
-
-            if to_update:
-                try:
-                    _retry_on_connection_error(self.netbox.dcim.interface_templates.update, to_update)
-                    self.handle.verbose_log(f"Bridged {len(to_update)} interfaces.")
-                except pynetbox.RequestError as e:
-                    self.handle.log(f"Error bridging interfaces: {e} (Context: {context})")
-                except _RETRYABLE_EXCEPTIONS as e:
-                    self.handle.log(
-                        f"Connection error bridging interfaces after {_MAX_RETRIES} retries: {e} (Context: {context})"
-                    )
-
-    def create_power_ports(self, power_ports, device_type, context=None):
-        """Create power port templates for a device type."""
-        self._create_generic(
-            power_ports,
-            device_type,
-            self.netbox.dcim.power_port_templates,
-            "Power Port",
-            context=context,
-            cache_name="power_port_templates",
-        )
-
-    def create_console_ports(self, console_ports, device_type, context=None):
-        """Create console port templates for a device type."""
-        self._create_generic(
-            console_ports,
-            device_type,
-            self.netbox.dcim.console_port_templates,
-            "Console Port",
-            context=context,
-            cache_name="console_port_templates",
-        )
-
-    def create_power_outlets(self, power_outlets, device_type, context=None):
-        """Create power outlet templates for a device type, resolving power-port name references.
+        Power outlets name their feeding power port; NetBox wants its id.  Outlets whose
+        power port cannot be resolved are dropped from the batch with a log entry, so one
+        bad reference does not fail the whole create call.
 
         Args:
-            power_outlets (list[dict]): Power-outlet template definitions; may include a "power_port" name key.
-            device_type (int): ID of the parent device type.
-            context (str | None): Optional context string for log messages.
+            parent_type (str): ``"device"`` or ``"module"``, passed to the component cache.
+            label (str): Human-readable label for log messages (e.g. ``"Power Outlet"``).
+            context (str | None): Optional context string appended to log messages.
         """
 
-        def link_ports(items, pid):
-            """Resolve power-port name references in *items* and persist the outlet templates for device type *pid*."""
+        def link_power_ports(items, pid):
+            """Resolve power-port name references in *items* for parent *pid*."""
             existing_pp = self.components.get(
                 "power_port_templates",
-                "device",
+                parent_type,
                 pid,
                 self.netbox.dcim.power_port_templates,
             )
@@ -2602,7 +2483,7 @@ class DeviceTypes:
                     ctx = f" (Context: {context})" if context else ""
                     self.handle.log(
                         f'Could not find Power Port "{outlet["power_port"]}" for '
-                        f'Power Outlet "{outlet.get("name", "Unknown")}". '
+                        f'{label} "{outlet.get("name", "Unknown")}". '
                         f"Available: {available}{ctx}"
                     )
                     outlets_to_remove.append(outlet)
@@ -2615,41 +2496,11 @@ class DeviceTypes:
                 skipped_names = [o["name"] for o in outlets_to_remove]
                 ctx = f" (Context: {context})" if context else ""
                 self.handle.log(
-                    f"Skipped {len(outlets_to_remove)} power outlet(s) with invalid power port refs: "
+                    f"Skipped {len(outlets_to_remove)} {label.lower()}(s) with invalid power port refs: "
                     f"{skipped_names}{ctx}"
                 )
 
-        self._create_generic(
-            power_outlets,
-            device_type,
-            self.netbox.dcim.power_outlet_templates,
-            "Power Outlet",
-            post_process=link_ports,
-            context=context,
-            cache_name="power_outlet_templates",
-        )
-
-    def create_console_server_ports(self, console_server_ports, device_type, context=None):
-        """Create console server port templates for a device type."""
-        self._create_generic(
-            console_server_ports,
-            device_type,
-            self.netbox.dcim.console_server_port_templates,
-            "Console Server Port",
-            context=context,
-            cache_name="console_server_port_templates",
-        )
-
-    def create_rear_ports(self, rear_ports, device_type, context=None):
-        """Create rear port templates for a device type."""
-        self._create_generic(
-            rear_ports,
-            device_type,
-            self.netbox.dcim.rear_port_templates,
-            "Rear Port",
-            context=context,
-            cache_name="rear_port_templates",
-        )
+        return link_power_ports
 
     def _build_link_rear_ports(self, parent_type, label, context=None):
         """Return a ``post_process`` callable that resolves rear-port name references.
@@ -2766,173 +2617,84 @@ class DeviceTypes:
 
         return link_rear_ports
 
-    def create_front_ports(self, front_ports, device_type, context=None):
-        """Create front port templates for a device type, resolving rear-port references."""
-        self._create_generic(
-            front_ports,
-            device_type,
-            self.netbox.dcim.front_port_templates,
-            "Front Port",
-            post_process=self._build_link_rear_ports("device", "Front Port", context),
-            context=context,
-            cache_name="front_port_templates",
-        )
+    def _link_bridges(self, bridged, parent_id, parent_type, context=None):
+        """Point each bridged interface at its bridge partner, once both exist in NetBox.
 
-    def create_device_bays(self, device_bays, device_type, context=None):
-        """Create device bay templates for a device type."""
-        self._create_generic(
-            device_bays,
-            device_type,
-            self.netbox.dcim.device_bay_templates,
-            "Device Bay",
-            context=context,
-            cache_name="device_bay_templates",
-        )
+        Runs after creation because NetBox wants the partner's id and the YAML has its name.
 
-    def create_module_bays(self, module_bays, device_type, context=None):
-        """Create module bay templates for a device type."""
-        self._create_generic(
-            module_bays,
-            device_type,
-            self.netbox.dcim.module_bay_templates,
-            "Module Bay",
-            context=context,
-            cache_name="module_bay_templates",
-        )
-
-    # Module methods
-    def create_module_interfaces(self, interfaces, module_type, context=None):
-        """Create interface templates for a module type."""
-        self._create_generic(
-            interfaces,
-            module_type,
+        Args:
+            bridged (dict): ``{interface_name: bridge_interface_name}``.
+            parent_id (int): NetBox ID of the parent device or module type.
+            parent_type (str): ``"device"`` or ``"module"``.
+            context (str | None): Optional context string appended to log messages.
+        """
+        all_interfaces = self.components.get(
+            "interface_templates",
+            parent_type,
+            parent_id,
             self.netbox.dcim.interface_templates,
-            "Module Interface",
-            parent_type="module",
-            context=context,
-            cache_name="interface_templates",
         )
 
-    def create_module_power_ports(self, power_ports, module_type, context=None):
-        """Create power port templates for a module type."""
-        self._create_generic(
-            power_ports,
-            module_type,
-            self.netbox.dcim.power_port_templates,
-            "Module Power Port",
-            parent_type="module",
-            context=context,
-            cache_name="power_port_templates",
-        )
+        to_update = []
+        for name, bridge_name in bridged.items():
+            if name in all_interfaces and bridge_name in all_interfaces:
+                to_update.append({"id": all_interfaces[name].id, "bridge": all_interfaces[bridge_name].id})
+            else:
+                self.handle.log(f"Error bridging {name} to {bridge_name}: Interface not found (Context: {context})")
 
-    def create_module_console_ports(self, console_ports, module_type, context=None):
-        """Create console port templates for a module type."""
-        self._create_generic(
-            console_ports,
-            module_type,
-            self.netbox.dcim.console_port_templates,
-            "Module Console Port",
-            parent_type="module",
-            context=context,
-            cache_name="console_port_templates",
-        )
-
-    def create_module_power_outlets(self, power_outlets, module_type, context=None):
-        """Create power outlet templates for a module type, resolving power-port name references."""
-
-        def link_ports(items, pid):
-            """Resolve power-port name references in *items* and persist the outlet templates for module type *pid*."""
-            existing_pp = self.components.get(
-                "power_port_templates",
-                "module",
-                pid,
-                self.netbox.dcim.power_port_templates,
+        if not to_update:
+            return
+        try:
+            _retry_on_connection_error(self.netbox.dcim.interface_templates.update, to_update)
+            self.handle.verbose_log(f"Bridged {len(to_update)} interfaces.")
+        except pynetbox.RequestError as e:
+            self.handle.log(f"Error bridging interfaces: {e} (Context: {context})")
+        except _RETRYABLE_EXCEPTIONS as e:
+            self.handle.log(
+                f"Connection error bridging interfaces after {_MAX_RETRIES} retries: {e} (Context: {context})"
             )
 
-            outlets_to_remove = []
-            for outlet in items:
-                if "power_port" not in outlet:
-                    continue
-                try:
-                    power_port = existing_pp[outlet["power_port"]]
-                    outlet["power_port"] = power_port.id
-                except KeyError:
-                    available = list(existing_pp.keys()) if existing_pp else []
-                    ctx = f" (Context: {context})" if context else ""
-                    self.handle.log(
-                        f'Could not find Power Port "{outlet["power_port"]}" for '
-                        f'Module Power Outlet "{outlet.get("name", "Unknown")}". '
-                        f"Available: {available}{ctx}"
-                    )
-                    outlets_to_remove.append(outlet)
+    def create_components(self, yaml_key, items, parent_id, parent_type="device", context=None):
+        """Create component templates of one kind for one parent, skipping those that exist.
 
-            for outlet in outlets_to_remove:
-                items.remove(outlet)
+        The registry row for *yaml_key* supplies the endpoint, the cache name, the log label
+        and which name references have to become NetBox ids, so every component type takes
+        the same path.
 
-            if outlets_to_remove:
-                skipped_names = [o["name"] for o in outlets_to_remove]
-                ctx = f" (Context: {context})" if context else ""
-                self.handle.log(
-                    f"Skipped {len(outlets_to_remove)} module power outlet(s) with invalid power port refs: "
-                    f"{skipped_names}{ctx}"
-                )
-
-        self._create_generic(
-            power_outlets,
-            module_type,
-            self.netbox.dcim.power_outlet_templates,
-            "Module Power Outlet",
-            parent_type="module",
-            post_process=link_ports,
-            context=context,
-            cache_name="power_outlet_templates",
-        )
-
-    def create_module_console_server_ports(self, console_server_ports, module_type, context=None):
-        """Create console server port templates for a module type."""
-        self._create_generic(
-            console_server_ports,
-            module_type,
-            self.netbox.dcim.console_server_port_templates,
-            "Module Console Server Port",
-            parent_type="module",
-            context=context,
-            cache_name="console_server_port_templates",
-        )
-
-    def create_module_rear_ports(self, rear_ports, module_type, context=None):
-        """Create rear-port templates for a module type in NetBox.
-
-        Adds any rear port templates from `rear_ports` that do not already exist for the specified `module_type`.
         Args:
-            rear_ports (list[dict]): List of rear-port template definitions to create; each item
-                must include a `name` and any other template fields required by NetBox.
-            module_type (int|object): The module type identifier or object used to associate
-                created templates with the parent module type.
-            context (str, optional): Optional context string used for logging to identify the source of these templates.
+            yaml_key (str): YAML component key, e.g. ``"interfaces"``.
+            items (list[dict]): Component definitions from the YAML file.
+            parent_id (int): NetBox ID of the parent device or module type.
+            parent_type (str): ``"device"`` or ``"module"``.
+            context (str | None): Optional context string appended to log messages.
         """
+        component = BY_YAML_KEY[yaml_key]
+        label = component.create_label(parent_type)
+
+        post_process = None
+        if component.link == LINK_POWER_PORT:
+            post_process = self._build_link_power_port(parent_type, label, context)
+        elif component.link == LINK_REAR_PORTS:
+            post_process = self._build_link_rear_ports(parent_type, label, context)
+
+        bridged = {}
+        if component.link == LINK_BRIDGE:
+            # NetBox wants the bridge partner's id, so hold the names back until it exists.
+            for item in items:
+                if "bridge" in item:
+                    bridged[item["name"]] = item.pop("bridge")
+
         self._create_generic(
-            rear_ports,
-            module_type,
-            self.netbox.dcim.rear_port_templates,
-            "Module Rear Port",
-            parent_type="module",
+            component,
+            items,
+            parent_id,
+            parent_type=parent_type,
+            post_process=post_process,
             context=context,
-            cache_name="rear_port_templates",
         )
 
-    def create_module_front_ports(self, front_ports, module_type, context=None):
-        """Create front-port templates for a module type, resolving rear-port references."""
-        self._create_generic(
-            front_ports,
-            module_type,
-            self.netbox.dcim.front_port_templates,
-            "Module Front Port",
-            parent_type="module",
-            post_process=self._build_link_rear_ports("module", "Module Front Port", context),
-            context=context,
-            cache_name="front_port_templates",
-        )
+        if bridged:
+            self._link_bridges(bridged, parent_id, parent_type, context)
 
     def upload_images(self, baseurl, token, images, device_type):
         """Upload front and/or rear image files to the specified NetBox device type.

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -31,7 +31,7 @@ C. Image linkage
        "uploaded" as orphan files) and the URLs return HTTP 200.
 D. GraphQL schema consistency
      – Query every device-type schema field and every
-       COMPONENT_TEMPLATE_FIELDS field directly through the GraphQL client so a
+       registry field directly through the GraphQL client so a
        removed/renamed schema field raises an explicit error rather than a
        silent false-positive.
 E. Front-port multi-position linkage
@@ -68,11 +68,8 @@ import urllib3
 
 from core.change_detector import get_device_type_properties
 from core.config import resolve_run_config
-from core.graphql_client import (
-    COMPONENT_TEMPLATE_FIELDS,
-    NetBoxGraphQLClient,
-    _NO_MODULE_TYPE,
-)
+from core.component_registry import COMPONENT_TYPES
+from core.graphql_client import NetBoxGraphQLClient
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
@@ -408,9 +405,11 @@ def test_graphql_schema() -> None:
             )
         ok(f"GraphQL device_type.{prop} = {val!r}")
 
-    # ── Component templates: all COMPONENT_TEMPLATE_FIELDS fields present ──
+    # ── Component templates: every registry field present ──
     device_type_id = fd.id
-    for endpoint_name, expected_fields in COMPONENT_TEMPLATE_FIELDS.items():
+    for component in COMPONENT_TYPES:
+        endpoint_name = component.endpoint
+        expected_fields = component.graphql_fields
         try:
             records = client.get_component_templates(endpoint_name)
         except Exception as exc:
@@ -420,7 +419,7 @@ def test_graphql_schema() -> None:
             )
         test_records = [r for r in records if getattr(getattr(r, "device_type", None), "id", None) == device_type_id]
 
-        if endpoint_name not in _NO_MODULE_TYPE:
+        if component.module_types:
             # Also accept module-type records for endpoints shared by both types
             test_records += [r for r in records if getattr(getattr(r, "module_type", None), "id", None) is not None]
 
@@ -444,8 +443,8 @@ def test_graphql_schema() -> None:
             if val == "__MISSING__":
                 fail(
                     f"GraphQL {endpoint_name} record missing field '{field}' — "
-                    f"schema change detected. Update COMPONENT_TEMPLATE_FIELDS or the "
-                    f"NetBox query in graphql_client.py."
+                    f"schema change detected. Update the row in core/component_registry.py "
+                    f"or the NetBox query in graphql_client.py."
                 )
         ok(f"GraphQL {endpoint_name}: all {len(expected_fields)} fields present")
 

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -11,13 +11,12 @@ import pytest
 
 from core.component_cache import (
     ComponentCache,
-    NO_MODULE_TYPE_ENDPOINTS,
     NullTaskDisplay,
-    PRELOAD_TARGETS,
     RichTaskDisplay,
     _chunked,
 )
-from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError, _NO_MODULE_TYPE
+from core.component_registry import COMPONENT_TYPES
+from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError
 
 
 # ── Fakes ─────────────────────────────────────────────────────────────────────
@@ -197,10 +196,6 @@ def test_chunked_of_nothing_yields_nothing():
     assert list(_chunked([], 3)) == []
 
 
-def test_device_only_endpoints_share_the_graphql_source():
-    assert NO_MODULE_TYPE_ENDPOINTS is _NO_MODULE_TYPE
-
-
 # ── Index ─────────────────────────────────────────────────────────────────────
 
 
@@ -359,7 +354,7 @@ class TestPrefetch:
         cache.begin_prefetch()
         cache.ensure_ready()
 
-        assert len(graphql.slugs_seen) == len(PRELOAD_TARGETS)
+        assert len(graphql.slugs_seen) == len(COMPONENT_TYPES)
 
     def test_a_prefetch_cannot_be_collected_for_another_vendor(self):
         cache = make_cache()
@@ -462,7 +457,7 @@ class TestPrefetchProgress:
         cache.ensure_ready()
 
         # Every task finished, so an owning display removed all tasks.
-        assert len(progress.removed) == len(PRELOAD_TARGETS)
+        assert len(progress.removed) == len(COMPONENT_TYPES)
 
     def test_pump_returns_true_once_an_endpoint_finishes(self):
         with make_cache() as cache:

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -1,0 +1,199 @@
+"""The registry is the single source for nine component types.
+
+These tests pin every table the rest of the codebase derives from it.  A row edited
+without the matching consumer change now fails here instead of silently dropping a
+field from a query, a comparison or an export.
+"""
+
+import pytest
+
+from core.component_registry import (
+    BY_ENDPOINT,
+    BY_YAML_KEY,
+    COMPONENT_TYPES,
+    LINK_BRIDGE,
+    LINK_POWER_PORT,
+    LINK_REAR_PORTS,
+    MODULE_TYPE_COMPONENTS,
+)
+
+_FRONT_PORT_MAPPINGS = "mappings { id front_port_position rear_port_position rear_port { id name } }"
+
+
+class TestTheTableItself:
+    """The rows, their order, and the columns that only a few rows set."""
+
+    def test_nine_component_types_in_a_fixed_order(self):
+        assert [component.yaml_key for component in COMPONENT_TYPES] == [
+            "interfaces",
+            "power-ports",
+            "console-ports",
+            "power-outlets",
+            "console-server-ports",
+            "rear-ports",
+            "front-ports",
+            "device-bays",
+            "module-bays",
+        ]
+
+    def test_every_yaml_key_maps_to_one_endpoint(self):
+        assert {key: component.endpoint for key, component in BY_YAML_KEY.items()} == {
+            "interfaces": "interface_templates",
+            "power-ports": "power_port_templates",
+            "console-ports": "console_port_templates",
+            "power-outlets": "power_outlet_templates",
+            "console-server-ports": "console_server_port_templates",
+            "rear-ports": "rear_port_templates",
+            "front-ports": "front_port_templates",
+            "device-bays": "device_bay_templates",
+            "module-bays": "module_bay_templates",
+        }
+
+    def test_the_endpoint_index_covers_the_same_rows(self):
+        assert set(BY_ENDPOINT) == {component.endpoint for component in COMPONENT_TYPES}
+        assert len(BY_ENDPOINT) == len(COMPONENT_TYPES)
+
+    def test_only_device_bays_are_absent_from_module_types(self):
+        assert [component.yaml_key for component in MODULE_TYPE_COMPONENTS] == [
+            "interfaces",
+            "power-ports",
+            "console-ports",
+            "power-outlets",
+            "console-server-ports",
+            "rear-ports",
+            "front-ports",
+            "module-bays",
+        ]
+
+    def test_only_three_types_resolve_a_name_to_an_id(self):
+        assert {component.yaml_key: component.link for component in COMPONENT_TYPES if component.link} == {
+            "interfaces": LINK_BRIDGE,
+            "power-outlets": LINK_POWER_PORT,
+            "front-ports": LINK_REAR_PORTS,
+        }
+
+    def test_a_type_that_resolves_rear_ports_precedes_none_of_them(self):
+        order = [component.yaml_key for component in COMPONENT_TYPES]
+        assert order.index("rear-ports") < order.index("front-ports")
+        assert order.index("power-ports") < order.index("power-outlets")
+
+
+class TestDerivedGraphQLTables:
+    """What the GraphQL client used to hold as two hand-maintained dicts."""
+
+    def test_the_list_key_is_the_endpoint_singularised(self):
+        assert {component.endpoint: component.list_key for component in COMPONENT_TYPES} == {
+            "interface_templates": "interface_template_list",
+            "power_port_templates": "power_port_template_list",
+            "console_port_templates": "console_port_template_list",
+            "console_server_port_templates": "console_server_port_template_list",
+            "power_outlet_templates": "power_outlet_template_list",
+            "rear_port_templates": "rear_port_template_list",
+            "front_port_templates": "front_port_template_list",
+            "device_bay_templates": "device_bay_template_list",
+            "module_bay_templates": "module_bay_template_list",
+        }
+
+    def test_the_query_selects_exactly_these_fields(self):
+        assert {component.endpoint: component.graphql_fields for component in COMPONENT_TYPES} == {
+            "interface_templates": [
+                "id",
+                "name",
+                "type",
+                "label",
+                "description",
+                "mgmt_only",
+                "enabled",
+                "poe_mode",
+                "poe_type",
+                "rf_role",
+            ],
+            "power_port_templates": [
+                "id",
+                "name",
+                "type",
+                "label",
+                "description",
+                "maximum_draw",
+                "allocated_draw",
+            ],
+            "console_port_templates": ["id", "name", "type", "label", "description"],
+            "console_server_port_templates": ["id", "name", "type", "label", "description"],
+            "power_outlet_templates": ["id", "name", "type", "label", "description", "feed_leg"],
+            "rear_port_templates": ["id", "name", "type", "label", "description", "positions", "color"],
+            "front_port_templates": [
+                "id",
+                "name",
+                "type",
+                "label",
+                "description",
+                "color",
+                _FRONT_PORT_MAPPINGS,
+            ],
+            "device_bay_templates": ["id", "name", "label", "description"],
+            "module_bay_templates": ["id", "name", "position", "label", "description"],
+        }
+
+    def test_only_the_front_port_query_selects_a_nested_block(self):
+        with_extra = {component.yaml_key: component.graphql_extra for component in COMPONENT_TYPES}
+        assert with_extra["front-ports"] == (_FRONT_PORT_MAPPINGS,)
+        assert all(extra == () for key, extra in with_extra.items() if key != "front-ports")
+
+
+class TestDerivedComparisonAndExport:
+    """The invariants that make a dropped field loud instead of silent."""
+
+    @pytest.mark.parametrize("component", COMPONENT_TYPES, ids=lambda c: c.yaml_key)
+    def test_every_compared_property_is_fetched(self, component):
+        """A property compared but never queried reads as missing and is skipped in silence."""
+        queried = set(component.graphql_fields) | {"_mappings"}
+        assert set(component.compare_properties) <= queried
+
+    @pytest.mark.parametrize("component", COMPONENT_TYPES, ids=lambda c: c.yaml_key)
+    def test_the_export_writes_every_scalar_the_query_reads(self, component):
+        """Export fields are the query's scalars: an unexported scalar drops out of a round trip."""
+        scalars = [name for name in component.graphql_fields if name != "id" and name not in component.graphql_extra]
+        assert list(component.fields) == scalars
+
+    def test_front_ports_compare_the_mapping_the_query_selects(self):
+        front_ports = BY_YAML_KEY["front-ports"]
+        assert "_mappings" in front_ports.compare_properties
+        assert "_mappings" not in front_ports.fields
+
+    def test_name_leads_every_field_list(self):
+        assert all(component.fields[0] == "name" for component in COMPONENT_TYPES)
+
+
+class TestLabels:
+    """One label per row, with the plural and the module prefix derived from it."""
+
+    def test_the_singular_label_names_the_component(self):
+        assert [component.label for component in COMPONENT_TYPES] == [
+            "Interface",
+            "Power Port",
+            "Console Port",
+            "Power Outlet",
+            "Console Server Port",
+            "Rear Port",
+            "Front Port",
+            "Device Bay",
+            "Module Bay",
+        ]
+
+    def test_the_progress_display_uses_the_plural(self):
+        assert [component.plural_label for component in COMPONENT_TYPES] == [
+            "Interfaces",
+            "Power Ports",
+            "Console Ports",
+            "Power Outlets",
+            "Console Server Ports",
+            "Rear Ports",
+            "Front Ports",
+            "Device Bays",
+            "Module Bays",
+        ]
+
+    def test_a_module_parent_prefixes_the_label(self):
+        interfaces = BY_YAML_KEY["interfaces"]
+        assert interfaces.create_label("device") == "Interface"
+        assert interfaces.create_label("module") == "Module Interface"

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -1050,29 +1050,20 @@ class TestGetComponentTemplates:
 
         assert records == []
 
-    def test_all_endpoint_names_are_supported(self):
-        """Every component endpoint name used by DeviceTypes should be recognized."""
-        from core.graphql_client import COMPONENT_TEMPLATE_FIELDS
+    def test_every_registry_endpoint_is_queryable(self, mock_post):
+        """Every endpoint in the registry reaches the server instead of being rejected."""
+        from core.component_registry import COMPONENT_TYPES
 
-        expected_endpoints = [
-            "interface_templates",
-            "power_port_templates",
-            "console_port_templates",
-            "console_server_port_templates",
-            "power_outlet_templates",
-            "rear_port_templates",
-            "front_port_templates",
-            "device_bay_templates",
-            "module_bay_templates",
-        ]
-        for endpoint in expected_endpoints:
-            assert endpoint in COMPONENT_TEMPLATE_FIELDS, f"{endpoint} not in COMPONENT_TEMPLATE_FIELDS"
+        mock_post.return_value.json.return_value = {"data": {}}
+        client = self._make_client()
+        for component in COMPONENT_TYPES:
+            assert client.get_component_templates(component.endpoint) == []
 
     def test_front_port_templates_uses_mappings_field(self):
         """front_port_templates fields include the nested mappings subfield (not rear_port_position)."""
-        from core.graphql_client import COMPONENT_TEMPLATE_FIELDS
+        from core.component_registry import BY_ENDPOINT
 
-        fields = COMPONENT_TEMPLATE_FIELDS["front_port_templates"]
+        fields = BY_ENDPOINT["front_port_templates"].graphql_fields
         has_mappings = any("mappings" in f and "{" in f for f in fields)
         has_rear_port_position_direct = "rear_port_position" in fields
         assert has_mappings, "Expected mappings { ... } in front_port_templates fields"
@@ -1519,25 +1510,22 @@ class TestGetComponentTemplatesFrontPortFallback:
     def test_primary_fails_no_mappings_field_reraises(self, mock_post):
         """When primary query fails and schema has no 'mappings' field, re-raise immediately.
 
-        Covers graphql_client.py line 541: 'if not has_mappings: raise'.
-        The guard fires when endpoint_name is front_port_templates but the fields list
-        (COMPONENT_TEMPLATE_FIELDS) has been stripped of the 'mappings' entry — meaning
-        there is no fallback query to attempt.
+        The guard fires when the registry row for front ports carries no 'mappings'
+        selection — meaning there is no older tier left to fall back to.
         """
-        from core.graphql_client import GraphQLError, COMPONENT_TEMPLATE_FIELDS
+        from dataclasses import replace
+
+        from core.component_registry import BY_ENDPOINT
+        from core.graphql_client import GraphQLError
         from unittest.mock import patch
         import core.graphql_client as gc_module
 
-        # Strip 'mappings' from front_port_templates fields so has_mappings is False
-        stripped = {
-            "front_port_templates": [
-                f for f in COMPONENT_TEMPLATE_FIELDS["front_port_templates"] if "mappings" not in f
-            ]
-        }
+        # A NetBox whose schema dropped the mappings block entirely.
+        stripped = {"front_port_templates": replace(BY_ENDPOINT["front_port_templates"], graphql_extra=())}
 
         mock_post.return_value = self._make_error_response("some field error")
 
-        with patch.dict(gc_module.COMPONENT_TEMPLATE_FIELDS, stripped):
+        with patch.dict(gc_module.BY_ENDPOINT, stripped):
             client = self._make_client()
             with pytest.raises(GraphQLError):
                 client.get_component_templates("front_port_templates")

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -4,6 +4,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 from unittest.mock import MagicMock, patch
+from core.component_registry import BY_YAML_KEY, COMPONENT_TYPES
 from core.netbox_api import (
     NetBox,
     DeviceTypes,
@@ -14,17 +15,7 @@ from helpers import paginate_dispatch
 
 
 # All component list keys used by the GraphQL client for empty-response fallback.
-_ALL_COMPONENT_KEYS = [
-    "interface_template_list",
-    "power_port_template_list",
-    "console_port_template_list",
-    "console_server_port_template_list",
-    "power_outlet_template_list",
-    "rear_port_template_list",
-    "front_port_template_list",
-    "device_bay_template_list",
-    "module_bay_template_list",
-]
+_ALL_COMPONENT_KEYS = [component.list_key for component in COMPONENT_TYPES]
 
 
 def _make_graphql_dispatch(payloads_by_list_key):
@@ -180,7 +171,7 @@ def test_device_types_create_interfaces(mock_settings, mock_pynetbox, graphql_cl
     mock_nb_api.dcim.interface_templates.filter.return_value = []
 
     interfaces = [{"name": "GigabitEthernet1", "type": "virtual"}]
-    dt.create_interfaces(interfaces, device_type=1)
+    dt.create_components("interfaces", interfaces, 1)
 
     # Verify create called
     call_args = mock_nb_api.dcim.interface_templates.create.call_args[0][0]
@@ -670,18 +661,15 @@ class TestCreateGenericError:
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("interface_templates", "device", 1, {})
 
-        endpoint = MagicMock()
         err = real_pynb.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
         err.error = ["Name already exists", ""]
-        endpoint.create.side_effect = err
+        mock_nb_api.dcim.interface_templates.create.side_effect = err
 
         dt._create_generic(
+            BY_YAML_KEY["interfaces"],
             [{"name": "eth0"}, {"name": "eth1"}],
             1,
-            endpoint,
-            "Interface",
             parent_type="device",
-            cache_name="interface_templates",
         )
         mock_handle.log.assert_called()
 
@@ -695,18 +683,15 @@ class TestCreateGenericError:
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("interface_templates", "device", 1, {})
 
-        endpoint = MagicMock()
         err = real_pynb.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
         err.error = "Something went wrong"
-        endpoint.create.side_effect = err
+        mock_nb_api.dcim.interface_templates.create.side_effect = err
 
         dt._create_generic(
+            BY_YAML_KEY["interfaces"],
             [{"name": "eth0"}],
             1,
-            endpoint,
-            "Interface",
             parent_type="device",
-            cache_name="interface_templates",
         )
         mock_handle.log.assert_called()
 
@@ -760,7 +745,7 @@ class TestCreatePowerConsolePorts:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("power_port_templates", "device", 1, {})
-        dt.create_power_ports([{"name": "PSU1"}], 1)
+        dt.create_components("power-ports", [{"name": "PSU1"}], 1)
         mock_nb_api.dcim.power_port_templates.create.assert_called_once()
 
     def test_create_console_ports_calls_create_generic(
@@ -769,7 +754,7 @@ class TestCreatePowerConsolePorts:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("console_port_templates", "device", 1, {})
-        dt.create_console_ports([{"name": "Con1"}], 1)
+        dt.create_components("console-ports", [{"name": "Con1"}], 1)
         mock_nb_api.dcim.console_port_templates.create.assert_called_once()
 
     def test_create_rear_ports_calls_create_generic(
@@ -778,7 +763,7 @@ class TestCreatePowerConsolePorts:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("rear_port_templates", "device", 1, {})
-        dt.create_rear_ports([{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
+        dt.create_components("rear-ports", [{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
         mock_nb_api.dcim.rear_port_templates.create.assert_called_once()
 
     def test_create_device_bays_calls_create_generic(
@@ -787,7 +772,7 @@ class TestCreatePowerConsolePorts:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("device_bay_templates", "device", 1, {})
-        dt.create_device_bays([{"name": "Bay1"}], 1)
+        dt.create_components("device-bays", [{"name": "Bay1"}], 1)
         mock_nb_api.dcim.device_bay_templates.create.assert_called_once()
 
 
@@ -1225,35 +1210,35 @@ class TestCreateModuleComponents:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("interface_templates", "module", 1, {})
-        dt.create_module_interfaces([{"name": "xe-0"}], 1)
+        dt.create_components("interfaces", [{"name": "xe-0"}], 1, parent_type="module")
         mock_nb_api.dcim.interface_templates.create.assert_called_once()
 
     def test_create_module_power_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("power_port_templates", "module", 1, {})
-        dt.create_module_power_ports([{"name": "PSU1"}], 1)
+        dt.create_components("power-ports", [{"name": "PSU1"}], 1, parent_type="module")
         mock_nb_api.dcim.power_port_templates.create.assert_called_once()
 
     def test_create_module_console_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("console_port_templates", "module", 1, {})
-        dt.create_module_console_ports([{"name": "Con1"}], 1)
+        dt.create_components("console-ports", [{"name": "Con1"}], 1, parent_type="module")
         mock_nb_api.dcim.console_port_templates.create.assert_called_once()
 
     def test_create_module_console_server_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("console_server_port_templates", "module", 1, {})
-        dt.create_module_console_server_ports([{"name": "CSP1"}], 1)
+        dt.create_components("console-server-ports", [{"name": "CSP1"}], 1, parent_type="module")
         mock_nb_api.dcim.console_server_port_templates.create.assert_called_once()
 
     def test_create_module_rear_ports(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("rear_port_templates", "module", 1, {})
-        dt.create_module_rear_ports([{"name": "RP1", "type": "8p8c", "positions": 1}], 1)
+        dt.create_components("rear-ports", [{"name": "RP1", "type": "8p8c", "positions": 1}], 1, parent_type="module")
         mock_nb_api.dcim.rear_port_templates.create.assert_called_once()
 
 
@@ -1416,7 +1401,7 @@ class TestCreateConsoleServerPorts:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("console_server_port_templates", "device", 1, {})
-        dt.create_console_server_ports([{"name": "CSP1"}], 1)
+        dt.create_components("console-server-ports", [{"name": "CSP1"}], 1)
         mock_nb_api.dcim.console_server_port_templates.create.assert_called_once()
 
 
@@ -1429,7 +1414,7 @@ class TestCreateModuleBays:
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("module_bay_templates", "device", 1, {})
-        dt.create_module_bays([{"name": "MB1"}], 1)
+        dt.create_components("module-bays", [{"name": "MB1"}], 1)
         mock_nb_api.dcim.module_bay_templates.create.assert_called_once()
 
 
@@ -2308,16 +2293,9 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
         dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
-        # Patch all create_* methods on dt
-        dt.create_power_ports = MagicMock()
-        dt.create_console_ports = MagicMock()
-        dt.create_power_outlets = MagicMock()
-        dt.create_console_server_ports = MagicMock()
-        dt.create_rear_ports = MagicMock()
-        dt.create_front_ports = MagicMock()
-        dt.create_device_bays = MagicMock()
-        dt.create_module_bays = MagicMock()
-        dt.create_interfaces = MagicMock()
+        # An empty cache entry per endpoint, so creation does not fall back to a REST read.
+        for component in COMPONENT_TYPES:
+            dt.components.record(component.endpoint, "device", 1, {})
         dt.upload_images = MagicMock()
 
         nb = NetBox(mock_settings, mock_handle)
@@ -2348,14 +2326,18 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
         with patch("glob.glob", return_value=[]):
             nb.create_device_types([device_type])
 
-        dt.create_power_ports.assert_called()
-        dt.create_console_ports.assert_called()
-        dt.create_power_outlets.assert_called()
-        dt.create_console_server_ports.assert_called()
-        dt.create_rear_ports.assert_called()
-        dt.create_front_ports.assert_called()
-        dt.create_device_bays.assert_called()
-        dt.create_module_bays.assert_called()
+        for yaml_key in (
+            "power-ports",
+            "console-ports",
+            "power-outlets",
+            "console-server-ports",
+            "rear-ports",
+            "front-ports",
+            "device-bays",
+            "module-bays",
+        ):
+            endpoint = getattr(mock_nb_api.dcim, BY_YAML_KEY[yaml_key].endpoint)
+            endpoint.create.assert_called_once()
 
     def test_upload_images_called_for_new_dt(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, tmp_path, mock_handle
@@ -2728,7 +2710,7 @@ class TestCreateModuleTypesEdge:
         mock_pynetbox.api.return_value.version = "3.5"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
-        nb.device_types.create_module_interfaces = MagicMock()
+        nb.device_types.components.record("interface_templates", "module", 5, {})
 
         existing_mt = MagicMock()
         existing_mt.id = 5
@@ -2748,7 +2730,7 @@ class TestCreateModuleTypesEdge:
             all_module_types=all_module_types,
             module_type_existing_images={},
         )
-        nb.device_types.create_module_interfaces.assert_not_called()
+        mock_pynetbox.api.return_value.dcim.interface_templates.create.assert_not_called()
 
     def test_creates_module_type_with_power_outlets_console_server_ports_front_ports(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
@@ -2757,9 +2739,10 @@ class TestCreateModuleTypesEdge:
         mock_pynetbox.api.return_value.version = "3.5"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
-        nb.device_types.create_module_power_outlets = MagicMock()
-        nb.device_types.create_module_console_server_ports = MagicMock()
-        nb.device_types.create_module_front_ports = MagicMock()
+        for endpoint_name in ("power_outlet_templates", "console_server_port_templates", "front_port_templates"):
+            nb.device_types.components.record(endpoint_name, "module", 5, {})
+        nb.device_types.components.record("power_port_templates", "module", 5, {})
+        nb.device_types.components.record("rear_port_templates", "module", 5, {})
 
         created_mt = MagicMock()
         created_mt.id = 5
@@ -2776,9 +2759,36 @@ class TestCreateModuleTypesEdge:
             "src": "/repo/module-types/cisco/lc.yaml",
         }
         nb.create_module_types([module_type], all_module_types={}, module_type_existing_images={})
-        nb.device_types.create_module_power_outlets.assert_called_once()
-        nb.device_types.create_module_console_server_ports.assert_called_once()
-        nb.device_types.create_module_front_ports.assert_called_once()
+        dcim = mock_pynetbox.api.return_value.dcim
+        dcim.power_outlet_templates.create.assert_called_once()
+        dcim.console_server_port_templates.create.assert_called_once()
+        dcim.front_port_templates.create.assert_called_once()
+
+    def test_a_new_module_type_gets_its_module_bays(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """The DTL module-type schema allows module-bays, so creation must not skip them."""
+        mock_pynetbox.api.return_value.version = "3.5"
+        nb = NetBox(mock_settings, mock_handle)
+        nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
+        nb.device_types.components.record("module_bay_templates", "module", 5, {})
+
+        created_mt = MagicMock()
+        created_mt.id = 5
+        created_mt.manufacturer.name = "Cisco"
+        created_mt.model = "LC"
+        mock_pynetbox.api.return_value.dcim.module_types.create.return_value = created_mt
+
+        module_type = {
+            "manufacturer": {"slug": "cisco"},
+            "model": "LC",
+            "module-bays": [{"name": "MB1", "position": "1"}],
+            "src": "/repo/module-types/cisco/lc.yaml",
+        }
+        nb.create_module_types([module_type], all_module_types={}, module_type_existing_images={})
+
+        (posted,), _ = mock_pynetbox.api.return_value.dcim.module_bay_templates.create.call_args
+        assert posted == [{"name": "MB1", "position": "1", "module_type": 5}]
 
     def test_existing_module_type_property_update_calls_api(self, mock_settings, mock_pynetbox, mock_handle):
         """Existing module type with changed part_number calls module_types.update and increments counter."""
@@ -3256,13 +3266,11 @@ class TestCreateGenericPostProcess:
             post_calls.append((len(items), pid))
 
         dt._create_generic(
+            BY_YAML_KEY["power-outlets"],
             [{"name": "PO1"}],
             1,
-            mock_nb_api.dcim.power_outlet_templates,
-            "Power Outlet",
             parent_type="device",
             post_process=my_post_process,
-            cache_name="power_outlet_templates",
         )
         assert len(post_calls) == 1
         assert post_calls[0] == (1, 1)
@@ -3278,7 +3286,7 @@ class TestUpdateComponentsMiscBranches:
     """Tests for miscellaneous branches in update_components."""
 
     def test_no_mapping_for_comp_type_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Unknown comp_type (no ENDPOINT_CACHE_MAP entry) is silently skipped."""
+        """Unknown comp_type (no registry row) is silently skipped."""
         from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
         mock_nb_api = mock_pynetbox.api.return_value
@@ -3288,25 +3296,6 @@ class TestUpdateComponentsMiscBranches:
             ComponentChange(
                 component_type="nonexistent-type",
                 component_name="x",
-                change_type=ChangeType.COMPONENT_CHANGED,
-                property_changes=[PropertyChange("label", "a", "b")],
-            )
-        ]
-        # Should not raise
-        dt.update_components({}, 1, changes, parent_type="device")
-
-    def test_no_endpoint_attr_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """If dcim has no attribute for endpoint_attr, the update loop is skipped."""
-        from core.change_detector import ChangeType, ComponentChange, PropertyChange
-
-        mock_nb_api = MagicMock(spec=[])  # no attributes on dcim
-        mock_nb_api.dcim = MagicMock(spec=[])
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        changes = [
-            ComponentChange(
-                component_type="interfaces",
-                component_name="eth0",
                 change_type=ChangeType.COMPONENT_CHANGED,
                 property_changes=[PropertyChange("label", "a", "b")],
             )
@@ -3422,37 +3411,38 @@ class TestUpdateComponentsAdditionsBranches:
         dt.update_components(yaml_data, 1, changes)
         mock_nb_api.dcim.interface_templates.create.assert_not_called()
 
-    def test_front_ports_addition_delegates_to_create_front_ports(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    @pytest.mark.parametrize(
+        ("parent_type", "parent_key"),
+        [("device", "device_type"), ("module", "module_type")],
+    )
+    def test_a_front_port_addition_resolves_its_rear_port(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, parent_type, parent_key
     ):
-        """front-ports COMPONENT_ADDED delegates to create_front_ports."""
+        """An added front port is POSTed with the rear port's id, not its name."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
-        dt.create_front_ports = MagicMock()
-        dt.components.record("front_port_templates", "device", 1, {})
+        dt.m2m_front_ports = True
+        dt.components.record("front_port_templates", parent_type, 1, {})
+        dt.components.record("rear_port_templates", parent_type, 1, {"RP1": MagicMock(id=7)})
 
         changes = [ComponentChange("front-ports", "FP1", ChangeType.COMPONENT_ADDED)]
-        yaml_data = {"front-ports": [{"name": "FP1"}]}
-        dt.update_components(yaml_data, 1, changes, parent_type="device")
-        dt.create_front_ports.assert_called_once()
+        yaml_data = {
+            "front-ports": [
+                {"name": "FP1", "_mappings": [{"rear_port": "RP1", "front_port_position": 1, "rear_port_position": 2}]}
+            ]
+        }
+        dt.update_components(yaml_data, 1, changes, parent_type=parent_type)
 
-    def test_front_ports_addition_module_delegates_to_create_module_front_ports(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
-    ):
-        """front-ports COMPONENT_ADDED for module delegates to create_module_front_ports."""
-        from core.change_detector import ChangeType, ComponentChange
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.create_module_front_ports = MagicMock()
-        dt.components.record("front_port_templates", "module", 1, {})
-
-        changes = [ComponentChange("front-ports", "FP1", ChangeType.COMPONENT_ADDED)]
-        yaml_data = {"front-ports": [{"name": "FP1"}]}
-        dt.update_components(yaml_data, 1, changes, parent_type="module")
-        dt.create_module_front_ports.assert_called_once()
+        (posted,), _ = mock_nb_api.dcim.front_port_templates.create.call_args
+        assert posted == [
+            {
+                "name": "FP1",
+                parent_key: 1,
+                "rear_ports": [{"position": 1, "rear_port": 7, "rear_port_position": 2}],
+            }
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -3464,7 +3454,7 @@ class TestRemoveComponentsBranches:
     """Tests for missing branches in remove_components."""
 
     def test_unknown_comp_type_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """comp_type with no ENDPOINT_CACHE_MAP entry is silently skipped."""
+        """comp_type with no registry row is silently skipped."""
         from core.change_detector import ChangeType, ComponentChange
 
         mock_nb_api = mock_pynetbox.api.return_value
@@ -3473,17 +3463,6 @@ class TestRemoveComponentsBranches:
         changes = [ComponentChange("nonexistent-type", "x", ChangeType.COMPONENT_REMOVED)]
         dt.remove_components(1, changes)
         # No exception; no delete called
-
-    def test_missing_endpoint_attr_skipped(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """If dcim has no attribute for endpoint_attr, deletion is skipped."""
-        from core.change_detector import ChangeType, ComponentChange
-
-        mock_nb_api = MagicMock(spec=[])
-        mock_nb_api.dcim = MagicMock(spec=[])
-        dt = make_device_types(nb_api=mock_nb_api)
-
-        changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_REMOVED)]
-        dt.remove_components(1, changes)
 
     def test_request_error_on_delete_is_logged(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
@@ -3535,7 +3514,7 @@ class TestCreateInterfacesBridge:
         interfaces = [
             {"name": "eth0", "type": "virtual", "bridge": "eth1"},
         ]
-        dt.create_interfaces(interfaces, device_type=1, context="test.yaml")
+        dt.create_components("interfaces", interfaces, 1, context="test.yaml")
         mock_handle.log.assert_called()
         assert any("Error bridging" in str(c) for c in mock_handle.log.call_args_list)
 
@@ -3551,9 +3530,29 @@ class TestCreateInterfacesBridge:
         mock_nb_api.dcim.interface_templates.filter.return_value = []
 
         iface = {"name": "eth0", "type": "virtual", "bridge": "eth1"}
-        dt.create_interfaces([iface], device_type=1)
+        dt.create_components("interfaces", [iface], 1)
         # "bridge" key should have been removed from the dict
         assert "bridge" not in iface
+
+    def test_a_module_interface_bridges_like_a_device_interface(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types
+    ):
+        """A module interface holds its bridge back too: NetBox wants the partner's id."""
+        mock_nb_api = mock_pynetbox.api.return_value
+        dt = make_device_types(nb_api=mock_nb_api)
+        xe0, xe1 = MagicMock(id=10), MagicMock(id=20)
+        dt.components.record("interface_templates", "module", 1, {})
+        mock_nb_api.dcim.interface_templates.create.return_value = []
+
+        dt.create_components("interfaces", [{"name": "xe-0", "bridge": "xe-1"}, {"name": "xe-1"}], 1, "module")
+
+        (posted,), _ = mock_nb_api.dcim.interface_templates.create.call_args
+        assert posted == [{"name": "xe-0", "module_type": 1}, {"name": "xe-1", "module_type": 1}]
+
+        # The link is applied once both interfaces exist in NetBox.
+        dt.components.record("interface_templates", "module", 1, {"xe-0": xe0, "xe-1": xe1})
+        dt.create_components("interfaces", [{"name": "xe-0", "bridge": "xe-1"}], 1, "module")
+        mock_nb_api.dcim.interface_templates.update.assert_called_once_with([{"id": 10, "bridge": 20}])
 
     def test_bridge_update_success(self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle):
         """Successful bridge update calls verbose_log."""
@@ -3573,7 +3572,7 @@ class TestCreateInterfacesBridge:
             {"name": "eth0", "type": "virtual", "bridge": "eth1"},
             {"name": "eth1", "type": "virtual"},
         ]
-        dt.create_interfaces(interfaces, device_type=1)
+        dt.create_components("interfaces", interfaces, 1)
         mock_nb_api.dcim.interface_templates.update.assert_called_once_with([{"id": 10, "bridge": 20}])
         assert any("Bridged" in str(c) for c in mock_handle.verbose_log.call_args_list)
 
@@ -3602,7 +3601,7 @@ class TestCreateInterfacesBridge:
             {"name": "eth0", "type": "virtual", "bridge": "eth1"},
             {"name": "eth1", "type": "virtual"},
         ]
-        dt.create_interfaces(interfaces, device_type=1, context="test.yaml")
+        dt.create_components("interfaces", interfaces, 1, context="test.yaml")
         mock_handle.log.assert_called()
         assert any("Error bridging" in str(c) for c in mock_handle.log.call_args_list)
 
@@ -3627,7 +3626,7 @@ class TestCreatePowerOutletsInvalidPort:
         mock_handle.log.reset_mock()
 
         power_outlets = [{"name": "PO1", "power_port": "PSU1"}]
-        dt.create_power_outlets(power_outlets, 1, context="test.yaml")
+        dt.create_components("power-outlets", power_outlets, 1, context="test.yaml")
         mock_handle.log.assert_called()
         assert any("Could not find Power Port" in str(c) for c in mock_handle.log.call_args_list)
 
@@ -3648,7 +3647,7 @@ class TestCreatePowerOutletsInvalidPort:
             {"name": "PO1", "power_port": "PSU1"},  # valid
             {"name": "PO2", "power_port": "MISSING"},  # invalid
         ]
-        dt.create_power_outlets(power_outlets, 1)
+        dt.create_components("power-outlets", power_outlets, 1)
         # The "Skipped" log should mention PO2
         assert any("PO2" in str(c) or "Skipped" in str(c) for c in mock_handle.log.call_args_list)
 
@@ -3673,7 +3672,7 @@ class TestBuildLinkRearPorts:
         mock_handle.log.reset_mock()
 
         front_ports = [{"name": "FP1", "type": "8p8c", "rear_port": "RP1"}]
-        dt.create_front_ports(front_ports, 1, context="test.yaml")
+        dt.create_components("front-ports", front_ports, 1, context="test.yaml")
         assert any("Could not find Rear Port" in str(c) for c in mock_handle.log.call_args_list)
 
     def test_rear_port_found_non_m2m(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
@@ -3689,7 +3688,7 @@ class TestBuildLinkRearPorts:
         mock_nb_api.dcim.front_port_templates.create.return_value = []
 
         front_ports = [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 1}]
-        dt.create_front_ports(front_ports, 1)
+        dt.create_components("front-ports", front_ports, 1)
         call_args = mock_nb_api.dcim.front_port_templates.create.call_args[0][0]
         assert call_args[0]["rear_port"] == 77
 
@@ -3706,7 +3705,7 @@ class TestBuildLinkRearPorts:
         mock_nb_api.dcim.front_port_templates.create.return_value = []
 
         front_ports = [{"name": "FP1", "type": "8p8c", "rear_port": "RP1", "rear_port_position": 2}]
-        dt.create_front_ports(front_ports, 1)
+        dt.create_components("front-ports", front_ports, 1)
         call_args = mock_nb_api.dcim.front_port_templates.create.call_args[0][0]
         assert call_args[0]["rear_ports"] == [{"position": 1, "rear_port": 77, "rear_port_position": 2}]
         assert "rear_port" not in call_args[0]
@@ -3730,7 +3729,7 @@ class TestBuildLinkRearPorts:
             {"name": "FP1", "type": "8p8c", "rear_port": "RP1"},
             {"name": "FP2", "type": "8p8c", "rear_port": "MISSING"},
         ]
-        dt.create_front_ports(front_ports, 1, context="test.yaml")
+        dt.create_components("front-ports", front_ports, 1, context="test.yaml")
         assert any("Skipped" in str(c) for c in mock_handle.log.call_args_list)
         call_args = mock_nb_api.dcim.front_port_templates.create.call_args[0][0]
         names = [x["name"] for x in call_args]
@@ -3759,7 +3758,7 @@ class TestCreateModuleFrontPorts:
         mock_nb_api.dcim.front_port_templates.create.return_value = []
 
         front_ports = [{"name": "FP1", "type": "8p8c", "rear_port": "RP1"}]
-        dt.create_module_front_ports(front_ports, 5, context="test.yaml")
+        dt.create_components("front-ports", front_ports, 5, context="test.yaml", parent_type="module")
         call_args = mock_nb_api.dcim.front_port_templates.create.call_args[0][0]
         assert call_args[0]["module_type"] == 5
 
@@ -3784,7 +3783,7 @@ class TestCreateModulePowerOutletsInvalidPort:
         mock_handle.log.reset_mock()
 
         power_outlets = [{"name": "PO1", "power_port": "PSU1"}]
-        dt.create_module_power_outlets(power_outlets, 1, context="test.yaml")
+        dt.create_components("power-outlets", power_outlets, 1, context="test.yaml", parent_type="module")
         assert any("Could not find Power Port" in str(c) for c in mock_handle.log.call_args_list)
 
     def test_multiple_outlets_one_invalid(
@@ -3804,7 +3803,7 @@ class TestCreateModulePowerOutletsInvalidPort:
             {"name": "PO1", "power_port": "PSU1"},
             {"name": "PO2", "power_port": "MISSING"},
         ]
-        dt.create_module_power_outlets(power_outlets, 1)
+        dt.create_components("power-outlets", power_outlets, 1, parent_type="module")
         assert any("PO2" in str(c) or "Skipped" in str(c) for c in mock_handle.log.call_args_list)
 
 
@@ -3825,7 +3824,7 @@ class TestCreateModuleRearPorts:
         dt.components.record("rear_port_templates", "module", 3, {})
 
         rear_ports = [{"name": "RP1", "type": "8p8c", "positions": 8}]
-        dt.create_module_rear_ports(rear_ports, 3, context="test.yaml")
+        dt.create_components("rear-ports", rear_ports, 3, context="test.yaml", parent_type="module")
         call_args = mock_nb_api.dcim.rear_port_templates.create.call_args[0][0]
         assert call_args[0]["module_type"] == 3
 
@@ -4004,7 +4003,7 @@ class TestCreateDeviceTypesCornerCases:
         dt = make_device_types(nb_api=mock_nb_api)
         dt.existing_device_types = {}
         dt.existing_device_types_by_slug = {}
-        dt.create_module_bays = MagicMock()
+        dt.components.record("module_bay_templates", "device", 1, {})
 
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = dt
@@ -4024,7 +4023,7 @@ class TestCreateDeviceTypesCornerCases:
             "src": "/tmp/device-types/cisco/testswitch.yaml",
         }
         nb.create_device_types([device_type])
-        dt.create_module_bays.assert_not_called()
+        mock_nb_api.dcim.module_bay_templates.create.assert_not_called()
 
 
 class TestCreateModuleTypesCornerCases:
@@ -4121,24 +4120,6 @@ class TestCreateModuleTypesCornerCases:
 # ---------------------------------------------------------------------------
 
 
-class TestUpdateComponentsAdditionsNoEndpoint:
-    """Tests for additions branch with missing endpoint in update_components."""
-
-    def test_no_endpoint_for_addition_continues(self, mock_settings, mock_pynetbox, graphql_client, make_device_types):
-        """Addition branch: endpoint returns None → continue (line 1550)."""
-        from core.change_detector import ChangeType, ComponentChange
-
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        # Make dcim.interface_templates return None (falsy)
-        dt.netbox.dcim.interface_templates = None
-
-        changes = [ComponentChange("interfaces", "eth0", ChangeType.COMPONENT_ADDED)]
-        yaml_data = {"interfaces": [{"name": "eth0"}]}
-        # Should not raise
-        dt.update_components(yaml_data, 1, changes, parent_type="device")
-
-
 class TestPowerOutletWithoutPowerPortKey:
     """Test that power outlets without 'power_port' key use the continue path."""
 
@@ -4152,7 +4133,7 @@ class TestPowerOutletWithoutPowerPortKey:
         dt.components.record("power_port_templates", "device", 1, {})
         # Outlet without "power_port" key → continue at line 1723
         power_outlets = [{"name": "PO1"}]  # no power_port key
-        dt.create_power_outlets(power_outlets, 1)
+        dt.create_components("power-outlets", power_outlets, 1)
         call_args = mock_nb_api.dcim.power_outlet_templates.create.call_args[0][0]
         assert call_args[0]["name"] == "PO1"
 
@@ -4170,7 +4151,7 @@ class TestFrontPortWithoutRearPortKey:
         dt.components.record("front_port_templates", "device", 1, {})
         # Front port without rear_port key → continue at line 1808
         front_ports = [{"name": "FP1", "type": "8p8c"}]  # no rear_port key
-        dt.create_front_ports(front_ports, 1)
+        dt.create_components("front-ports", front_ports, 1)
         call_args = mock_nb_api.dcim.front_port_templates.create.call_args[0][0]
         assert call_args[0]["name"] == "FP1"
 
@@ -4187,7 +4168,7 @@ class TestModulePowerOutletWithoutPowerPortKey:
         dt.components.record("power_outlet_templates", "module", 1, {})
         dt.components.record("power_port_templates", "module", 1, {})
         power_outlets = [{"name": "PO1"}]  # no power_port key
-        dt.create_module_power_outlets(power_outlets, 1)
+        dt.create_components("power-outlets", power_outlets, 1, parent_type="module")
         call_args = mock_nb_api.dcim.power_outlet_templates.create.call_args[0][0]
         assert call_args[0]["name"] == "PO1"
 
@@ -6107,17 +6088,11 @@ class TestAdditionalDeviceTypesCoverage:
         mock_pynetbox.RequestError = real_pynb.RequestError
         dt = make_device_types(nb_api=mock_pynetbox.api.return_value)
         dt.components.record("interface_templates", "device", 1, {})
-        endpoint = MagicMock()
-        endpoint.create.side_effect = requests.exceptions.ConnectionError("offline")
+        dcim = mock_pynetbox.api.return_value.dcim
+        dcim.interface_templates.create.side_effect = requests.exceptions.ConnectionError("offline")
 
         with patch("core.netbox_api.time.sleep"):
-            dt._create_generic(
-                [{"name": "eth0"}],
-                1,
-                endpoint,
-                "Interface",
-                cache_name="interface_templates",
-            )
+            dt._create_generic(BY_YAML_KEY["interfaces"], [{"name": "eth0"}], 1)
 
         assert any("Connection error creating Interface" in str(c) for c in mock_handle.log.call_args_list)
 
@@ -6182,7 +6157,7 @@ class TestAdditionalDeviceTypesCoverage:
         interfaces = [{"name": "eth0", "type": "virtual", "bridge": "eth1"}, {"name": "eth1", "type": "virtual"}]
 
         with patch("core.netbox_api.time.sleep"):
-            dt.create_interfaces(interfaces, 1, context="ctx.yaml")
+            dt.create_components("interfaces", interfaces, 1, context="ctx.yaml")
 
         assert any("Connection error bridging interfaces" in str(c) for c in mock_handle.log.call_args_list)
 


### PR DESCRIPTION
Stacked on #112.

## Why

The nine component template types were described in **eleven places**:

| encoding | lived in |
|---|---|
| YAML key → endpoint attribute + cache name | `component_cache.ENDPOINT_CACHE_MAP` |
| endpoint → progress label | `component_cache.PRELOAD_TARGETS` |
| endpoints without a module-type parent | `component_cache.NO_MODULE_TYPE_ENDPOINTS` and `graphql_client._NO_MODULE_TYPE` |
| endpoint → GraphQL list key | `graphql_client.ENDPOINT_TO_LIST_KEY` |
| endpoint → GraphQL field list | `graphql_client.COMPONENT_TEMPLATE_FIELDS` |
| YAML key → comparable properties | `change_detector.COMPONENT_TYPES` |
| YAML key → endpoint, in output order | `nb_serializer.COMPONENT_ENDPOINTS` |
| endpoint → serializer field list | `nb_serializer._COMPONENT_FIELDS` |
| one create method per type per parent kind | `netbox_api`, 16 of them |

Two copies already carried a "same as X" comment, so the duplication was known. The failure mode is that drift is **silent**: a property in the comparison list that the query does not select reads as missing at `change_detector.py:_compare_component_properties` and is skipped, so the field simply stops being updated and nothing reports it.

## What changed

`core/component_registry.py` holds one row per type. Everything else is derived:

```python
ComponentType(
    yaml_key="front-ports",
    endpoint="front_port_templates",
    label="Front Port",
    fields=("name", "type", "label", "description", "color"),
    graphql_extra=("mappings { id front_port_position rear_port_position rear_port { id name } }",),
    compare_extra=("_mappings",),
    link=LINK_REAR_PORTS,
)
```

`graphql_fields`, `compare_properties`, `list_key`, `plural_label` and `create_label(parent_type)` come off the row. Row order is canonical: it sets export key order, progress-bar order and create order, with rear ports before front ports and power ports before power outlets because the later type resolves names against the earlier one.

`tests/test_component_registry.py` pins every derived table against its literal values and the invariants between them, so a row edited without its consumers fails there rather than in production.

`_create_generic` now takes a row and derives the endpoint, cache name and label from it. The sixteen per-type wrappers collapse into `create_components(yaml_key, items, parent_id, parent_type, context)`, which reads `link` to decide which name references have to become NetBox ids. The two dispatch sites (`_create_device_type_components`, `_create_module_type_components`) become loops over the table.

## Two behaviour gaps went with the duplication

**A module-type interface declaring `bridge` POSTed a name where NetBox wants an id.** Only the device-type wrapper stripped and re-linked it; the module wrapper passed the dict straight through. Proven against the unfixed code:

```
AssertionError: [{'name': 'xe-0', 'bridge': 'xe-1', 'module_type': 1}, ...]
```

**A new module type declaring `module-bays` created none.** The DTL module-type schema allows the key, NetBox exposes `module_type` on `module_bay_templates`, and the *update* path already created them through `_apply_additions_for_type` — only the create path omitted them, because the hand-written dispatch dict had seven entries instead of eight. 20 module types in the vendored library declare module bays.

Both have tests that were confirmed failing against the pre-change code.

## Also removed

The `endpoint = getattr(self.netbox.dcim, name, None); if not endpoint: return` guard in three methods. pynetbox's `App.__getattr__` returns an `Endpoint` for any name, so the branch was unreachable; the three tests covering it built a `MagicMock(spec=[])` that pynetbox cannot produce.

## Verification

996 tests pass, coverage 96.94% (gate 96%), `core/component_registry.py` at 100%. ruff, ruff-format and interrogate clean. `tests/integration/test_import.py` was updated to read the registry and still parses, though it needs a live NetBox to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified handling of device and module components during imports, including interfaces, ports, bays, and bridges.
  * Improved support for power-port and front/rear-port relationships.
  * Consistent component metadata across GraphQL queries, exports, serialization, and caching.
  * Component creation and updates now follow a standardized workflow.

* **Bug Fixes**
  * Invalid component references are skipped safely while processing continues.
  * Improved validation and cache consistency for component counts and module-specific data.

* **Tests**
  * Expanded coverage for component discovery, linking, imports, exports, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->