### PR TITLE
refactor: give the pipeline an interface and the logger one job

### DIFF
--- a/core/change_detector.py
+++ b/core/change_detector.py
@@ -132,7 +132,7 @@ IMAGE_PROPERTIES = ["front_image", "rear_image"]
 class ChangeDetector:
     """Detects changes between YAML device types and NetBox cached data."""
 
-    def __init__(self, device_types_instance, handle, remove_unmanaged_types: bool = False):
+    def __init__(self, device_types_instance, handle, remove_unmanaged_types: bool = False, *, verbose: bool = False):
         """Initialize the change detector.
 
         Args:
@@ -142,9 +142,11 @@ class ChangeDetector:
                 YAML section is missing (not just those listed in an empty/partial section).
                 Only honoured when callers also pass ``remove_components=True`` to the
                 applier; this flag controls *detection*, not application.
+            verbose: Show the hint about --verbose only when it is off.
         """
         self.device_types = device_types_instance
         self.handle = handle
+        self.verbose = verbose
         self.remove_unmanaged_types = remove_unmanaged_types
 
     def detect_changes(self, device_types: List[dict], progress=None) -> ChangeReport:
@@ -570,7 +572,7 @@ class ChangeDetector:
             self.handle.log("MODIFIED DEVICE TYPES:")
             for dt in report.modified_device_types:
                 self._log_modified_device_details(dt)
-            if not self.handle.args.verbose:
+            if not self.verbose:
                 self.handle.log("  (use --verbose for property diffs and component names)")
         else:
             self.handle.log("Modified device types: 0")

--- a/core/component_cache.py
+++ b/core/component_cache.py
@@ -21,11 +21,6 @@ from core.compat import (
 from core.component_registry import COMPONENT_TYPES
 from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError
 
-# Endpoints whose GraphQL schema is missing fields required for accurate change
-# detection, and where REST provides them.  Add an endpoint here if a NetBox
-# version drops a field from GraphQL but keeps it in REST.
-REST_ONLY_ENDPOINTS: frozenset = frozenset()
-
 
 def _chunked(items, size):
     """Yield successive *size*-length chunks of *items*."""
@@ -339,12 +334,6 @@ class ComponentCache:
 
     def _fetch_endpoint(self, endpoint_name, on_advance, manufacturer_slug):
         """Return every record for *endpoint_name*, reporting each page through *on_advance*."""
-        if endpoint_name in REST_ONLY_ENDPOINTS:
-            records = list(getattr(self.netbox.dcim, endpoint_name).all())
-            if records:
-                on_advance(endpoint_name, len(records))
-            return records
-
         records = self.graphql.get_component_templates(
             endpoint_name,
             manufacturer_slug=manufacturer_slug,
@@ -474,10 +463,6 @@ class ComponentCache:
 
         for component in COMPONENT_TYPES:
             endpoint_name = component.endpoint
-            if endpoint_name in REST_ONLY_ENDPOINTS:
-                # Already fetched over REST, so comparing REST to REST proves nothing.
-                continue
-
             cached_count = sum(
                 len(records)
                 for key, records in self._entries.get(endpoint_name, {}).items()

--- a/core/config.py
+++ b/core/config.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, field
 
 from dotenv import load_dotenv
 
+from core.errors import FatalError
+
 DEFAULT_REPO_URL = "https://github.com/netbox-community/devicetype-library.git"
 DEFAULT_REPO_BRANCH = "master"
 DEFAULT_GRAPHQL_PAGE_SIZE = 5000
@@ -18,8 +20,19 @@ REQUIRED_ENV_VARS = ("NETBOX_URL", "NETBOX_TOKEN")
 _DEFAULT_REPO_PATH = f"{os.path.dirname(os.path.dirname(os.path.realpath(__file__)))}/repo"
 
 
-class ConfigError(Exception):
+class ConfigError(FatalError):
     """A configuration value the run cannot start with, phrased for the person who set it."""
+
+
+class EnvironmentVariableError(ConfigError):
+    """A required environment variable that is not set."""
+
+    def __init__(self, names, stack_trace=None):
+        """Name the required environment variables."""
+        names = (names,) if isinstance(names, str) else tuple(names)
+        message = "\n".join(f'Environment variable "{name}" is not set.' for name in names)
+        message += f"\n\nRequired: {', '.join(REQUIRED_ENV_VARS)}"
+        super().__init__(message, stack_trace)
 
 
 @dataclass(frozen=True)
@@ -242,10 +255,7 @@ def resolve_run_config(argv=None, env=None):
 
     missing = [name for name in REQUIRED_ENV_VARS if _text(env, name) is None]
     if missing:
-        raise ConfigError(
-            "\n".join(f'Environment variable "{name}" is not set.' for name in missing)
-            + f"\n\nRequired: {', '.join(REQUIRED_ENV_VARS)}"
-        )
+        raise EnvironmentVariableError(missing)
 
     slug_values = env.get("SLUGS", "").split() if args.slugs is None else args.slugs
     slugs = _split_slugs(slug_values)

--- a/core/errors.py
+++ b/core/errors.py
@@ -1,0 +1,18 @@
+"""Fatal errors shared by the command-line import workflow."""
+
+
+class FatalError(Exception):
+    """An error that stops the current import run."""
+
+    def __init__(self, message: str, stack_trace=None):
+        """Store the user-facing message and optional diagnostic detail."""
+        super().__init__(message)
+        self.stack_trace = stack_trace
+
+
+class UnknownError(FatalError):
+    """An unexpected error with a stable user-facing category."""
+
+    def __init__(self, context: str, stack_trace=None):
+        """Describe an unexpected error in *context*."""
+        super().__init__(f'An unknown error occurred: "{context}"', stack_trace)

--- a/core/errors.py
+++ b/core/errors.py
@@ -10,6 +10,10 @@ class FatalError(Exception):
         self.stack_trace = stack_trace
 
 
+class VendorSelectionError(FatalError):
+    """A requested vendor selection that matches no source data."""
+
+
 class UnknownError(FatalError):
     """An unexpected error with a stable user-facing category."""
 

--- a/core/export.py
+++ b/core/export.py
@@ -622,7 +622,7 @@ class Exporter:
                     self.graphql.url,
                     self.graphql.token,
                     self.graphql.ignore_ssl,
-                    self.graphql._log_handler,
+                    self.graphql._handle,
                     self.graphql.DEFAULT_PAGE_SIZE,
                 )
                 _thread_local.graphql = client

--- a/core/export.py
+++ b/core/export.py
@@ -208,6 +208,7 @@ class Exporter:
             url=config.netbox_url,
             token=config.netbox_token,
             ignore_ssl=config.ignore_ssl_errors,
+            handle=handle,
             page_size=config.graphql_page_size,
         )
         self._module_image_details: Optional[dict] = None

--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -135,14 +135,14 @@ class NetBoxGraphQLClient:
         or raise the server's ``MAX_PAGE_SIZE`` setting to match.
     """
 
-    def __init__(self, url, token, ignore_ssl=False, log_handler=None, page_size=5000):
+    def __init__(self, url, token, ignore_ssl=False, handle=None, page_size=5000):
         """Store connection parameters for later use in :meth:`query`.
 
         Args:
             url: Base URL of the NetBox instance.
             token: API authentication token.
             ignore_ssl: If True, skip SSL certificate verification.
-            log_handler: Optional :class:`~log_handler.LogHandler` used to emit
+            handle: Optional :class:`~log_handler.LogHandler` used to emit
                 warnings (e.g. server-side page-size clamping).  Falls back to
                 ``print`` when not provided.
             page_size: Default number of items per GraphQL page
@@ -153,7 +153,7 @@ class NetBoxGraphQLClient:
         self.graphql_url = f"{self.url}/graphql/"
         self.token = token
         self.ignore_ssl = ignore_ssl
-        self._log_handler = log_handler
+        self._handle = handle
 
         self._session = requests.Session()
         # v2 tokens start with "nbt_" prefix (format: nbt_<key>.<secret>);
@@ -313,8 +313,8 @@ class NetBoxGraphQLClient:
                             f"will be slower than expected. Consider raising "
                             f"MAX_PAGE_SIZE on your NetBox server."
                         )
-                        if self._log_handler is not None:
-                            self._log_handler.log(msg)
+                        if self._handle is not None:
+                            self._handle.log(msg)
                         else:
                             print(msg)
 

--- a/core/import_run.py
+++ b/core/import_run.py
@@ -9,6 +9,7 @@ import os
 from core.change_detector import ChangeDetector, ChangeType, IMAGE_PROPERTIES
 from core.component_cache import NullTaskDisplay, RichTaskDisplay
 from core.config import RunConfig
+from core.errors import VendorSelectionError
 
 
 _PROGRESS_DESC_WIDTH = 28
@@ -586,21 +587,19 @@ class ImportRun:
             vendor_slug_filter = {vendor.lower() for vendor in self.config.vendors}
             vendors = [vendor for vendor in all_vendors if vendor["slug"] in vendor_slug_filter]
             if not vendors:
-                self.reporter.log(
+                raise VendorSelectionError(
                     f"No vendors matched --vendors: {', '.join(self.config.vendors)}. "
                     f"Available: {', '.join(vendor['slug'] for vendor in all_vendors[:10])}"
                     f"{'...' if len(all_vendors) > 10 else ''}"
                 )
-                raise SystemExit(1)
         else:
             vendors = all_vendors
 
         vendors, slug_resolved = self._narrow_by_slug(vendors)
         if self.config.vendors and not vendors:
-            self.reporter.log(
+            raise VendorSelectionError(
                 f"No vendors matched the combination of --vendors and --slugs: {', '.join(self.config.vendors)}"
             )
-            raise SystemExit(1)
 
         return RunSelection(
             vendors=tuple(vendors),

--- a/core/import_run.py
+++ b/core/import_run.py
@@ -1,0 +1,779 @@
+"""Import pipeline planning and execution."""
+
+from collections import Counter
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import os
+
+from core.change_detector import ChangeDetector, ChangeType, IMAGE_PROPERTIES
+from core.component_cache import NullTaskDisplay, RichTaskDisplay
+from core.config import RunConfig
+
+
+_PROGRESS_DESC_WIDTH = 28
+
+
+@dataclass(frozen=True)
+class RunSelection:
+    """Selected vendors and source paths for one import run."""
+
+    vendors: tuple
+    devices_path: str
+    modules_path: str
+    racks_path: str
+    slug_resolved: dict | None
+
+
+@dataclass(frozen=True)
+class VendorPlan:
+    """Parsed work for one vendor, before any NetBox write occurs."""
+
+    vendor: dict
+    device_types: list
+    module_types: list
+    rack_types: list
+    prefetch_components: bool
+
+    @property
+    def has_types(self):
+        """Return True when the plan contains at least one type."""
+        return bool(self.device_types or self.module_types or self.rack_types)
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    """Snapshot of the result of one completed import run."""
+
+    counter: Counter
+    modules: bool
+    rack_types: bool
+    failure_lines: tuple
+    duplicate_definitions: tuple
+    elapsed: timedelta
+
+    @classmethod
+    def capture(cls, netbox, repo, started_at):
+        """Capture mutable run state as a summary value."""
+        return cls(
+            counter=Counter(netbox.counter),
+            modules=netbox.modules,
+            rack_types=netbox.rack_types,
+            failure_lines=tuple(netbox.outcomes.render_failure_report()),
+            duplicate_definitions=tuple(repo.duplicate_definitions),
+            elapsed=datetime.now() - started_at,
+        )
+
+
+def get_progress_wrapper(progress, iterable, desc=None, total=None, on_step=None, task_registry=None):
+    """Wrap an iterable with a Rich progress task when progress is available."""
+    if progress is None:
+        return iterable
+
+    description = (desc or "").ljust(_PROGRESS_DESC_WIDTH)
+    if total is None:
+        try:
+            total = len(iterable)
+        except TypeError:
+            total = None
+
+    if task_registry is not None:
+        if description not in task_registry:
+            task_registry[description] = progress.add_task(description, total=None)
+        task_id = task_registry[description]
+    else:
+        task_id = progress.add_task(description, total=total)
+
+    def iterator():
+        """Yield items and advance the progress task."""
+        count = 0
+        try:
+            for item in iterable:
+                yield item
+                count += 1
+                progress.advance(task_id)
+                if on_step:
+                    on_step()
+        finally:
+            if task_registry is None:
+                if total is None:
+                    progress.update(task_id, total=max(count, 1), completed=count)
+                progress.stop_task(task_id)
+                progress.remove_task(task_id)
+            if on_step:
+                on_step()
+
+    return iterator()
+
+
+def filter_new_device_types(device_types, existing_by_model, existing_by_slug):
+    """Return device types that do not exist in either lookup."""
+    new_device_types = []
+    for device_type in device_types:
+        manufacturer_slug = device_type["manufacturer"]["slug"]
+        model = device_type["model"]
+        slug = device_type.get("slug", "")
+
+        existing = existing_by_model.get((manufacturer_slug, model))
+        if existing is None and slug:
+            existing = existing_by_slug.get((manufacturer_slug, slug))
+
+        if existing is None:
+            new_device_types.append(device_type)
+
+    return new_device_types
+
+
+def _device_type_change_key(manufacturer_slug, model, slug):
+    """Build a change-detection key."""
+    return manufacturer_slug, model, slug or ""
+
+
+def device_type_key(device_type):
+    """Extract a change-detection key from a parsed device type."""
+    return _device_type_change_key(
+        device_type["manufacturer"]["slug"],
+        device_type["model"],
+        device_type.get("slug", ""),
+    )
+
+
+def change_entry_key(change_entry):
+    """Extract a change-detection key from a change entry."""
+    return _device_type_change_key(
+        change_entry.manufacturer_slug,
+        change_entry.model,
+        change_entry.slug,
+    )
+
+
+def filter_device_types_by_change_keys(device_types, change_keys):
+    """Return device types whose keys occur in the selected change keys."""
+    if not change_keys:
+        return []
+    return [device_type for device_type in device_types if device_type_key(device_type) in change_keys]
+
+
+def _device_types_with_images_keys(device_types):
+    """Return keys for device types that declare images."""
+    return {
+        device_type_key(device_type)
+        for device_type in device_types
+        if device_type.get("front_image") or device_type.get("rear_image")
+    }
+
+
+def select_device_types_for_default_mode(device_types, change_report, verify_images=False):
+    """Select new device types and device types with missing images."""
+    if not change_report:
+        return []
+
+    new_keys = {change_entry_key(change) for change in change_report.new_device_types}
+    image_change_keys = {
+        change_entry_key(change)
+        for change in change_report.modified_device_types
+        if any(property_change.property_name in IMAGE_PROPERTIES for property_change in change.property_changes)
+    }
+    all_keys = new_keys | image_change_keys
+    if verify_images:
+        all_keys |= _device_types_with_images_keys(device_types)
+    return filter_device_types_by_change_keys(device_types, all_keys)
+
+
+def select_device_types_for_update_mode(device_types, change_report, verify_images=False):
+    """Select all new and modified device types."""
+    if not change_report:
+        return []
+
+    actionable_keys = {change_entry_key(change) for change in change_report.new_device_types}
+    actionable_keys.update(change_entry_key(change) for change in change_report.modified_device_types)
+    if verify_images:
+        actionable_keys |= _device_types_with_images_keys(device_types)
+    return filter_device_types_by_change_keys(device_types, actionable_keys)
+
+
+def has_missing_device_images(change_report):
+    """Return True when a device type has an image change."""
+    if not change_report:
+        return False
+    for device_change in change_report.modified_device_types:
+        if any(change.property_name in IMAGE_PROPERTIES for change in device_change.property_changes):
+            return True
+    return False
+
+
+def log_run_mode(handle, config):
+    """Log the active import mode."""
+    if config.only_new:
+        handle.log("Mode: --only-new enabled; existing device types and components will not be modified.")
+    elif config.update:
+        handle.log("Mode: --update enabled; changed properties and components on existing models will be updated.")
+        if config.remove_components:
+            handle.log("Mode: --remove-components enabled; missing components will be removed from existing models.")
+            if config.remove_unmanaged_types:
+                handle.log(
+                    "Mode: --remove-unmanaged-types enabled; components whose entire YAML section is missing "
+                    "will also be removed from existing models."
+                )
+        else:
+            handle.log(
+                "Mode: will not remove components from existing models; use --remove-components with "
+                "--update to change this."
+            )
+        if config.force_resolve_conflicts:
+            handle.log(
+                "Mode: --force-resolve-conflicts enabled; constraint failures will trigger destructive "
+                "remediation when no live device references the affected type."
+            )
+    else:
+        handle.log("Mode: --update not set; changed properties/components will not be applied (use --update).")
+    if config.verify_images:
+        handle.log(
+            "Mode: --verify-images enabled; images already recorded in NetBox will be verified via HTTP "
+            "and re-uploaded if missing or content has changed."
+        )
+
+
+def should_only_create_new_modules(config):
+    """Return True when module processing must skip updates."""
+    return config.only_new or not config.update
+
+
+def _cache_display(progress, task_registry):
+    """Return the cache progress sink."""
+    if progress is None:
+        return NullTaskDisplay()
+    return RichTaskDisplay(progress, registry=task_registry)
+
+
+@contextmanager
+def _image_progress_scope(progress, device_types, total=0):
+    """Set and clear image upload progress state."""
+    image_task = None
+    if progress is not None and total > 0:
+        image_task = progress.add_task("Uploading Images", total=total)
+
+        def advance_images(count=1):
+            """Advance the image upload task."""
+            progress.update(image_task, advance=count)
+
+        device_types._image_progress = advance_images
+    try:
+        yield
+    finally:
+        device_types._image_progress = None
+        if progress is not None and image_task is not None:
+            progress.stop_task(image_task)
+            progress.remove_task(image_task)
+
+
+def _process_device_types(config, netbox, handle, progress, device_types, vendor_slug=None, task_registry=None):
+    """Process device types for one vendor."""
+    if config.only_new:
+        new_device_types = filter_new_device_types(
+            device_types,
+            netbox.device_types.existing_device_types,
+            netbox.device_types.existing_device_types_by_slug,
+        )
+        if new_device_types:
+            image_total = netbox.count_device_type_images(new_device_types)
+            with _image_progress_scope(progress, netbox.device_types, total=image_total):
+                netbox.create_device_types(
+                    new_device_types,
+                    progress=get_progress_wrapper(
+                        progress,
+                        new_device_types,
+                        desc="Creating Device Types",
+                        task_registry=task_registry,
+                    ),
+                    only_new=True,
+                )
+        else:
+            handle.verbose_log("No new device types to create.")
+        return
+
+    if not device_types:
+        handle.verbose_log("No device types matched filters.")
+        return
+
+    handle.verbose_log("Caching NetBox data for comparison (concurrent API requests started after parsing)...")
+    netbox.device_types.ensure_components_ready(manufacturer_slug=vendor_slug)
+
+    detector = ChangeDetector(
+        netbox.device_types,
+        handle,
+        remove_unmanaged_types=config.remove_unmanaged_types,
+        verbose=config.verbose,
+    )
+    change_report = detector.detect_changes(
+        device_types,
+        progress=get_progress_wrapper(progress, device_types, desc="Detecting Changes", task_registry=task_registry),
+    )
+    detector.log_change_report(change_report)
+
+    if config.update:
+        device_types_to_process = select_device_types_for_update_mode(
+            device_types, change_report, verify_images=config.verify_images
+        )
+        if device_types_to_process:
+            image_total = netbox.count_device_type_images(device_types_to_process)
+            with _image_progress_scope(progress, netbox.device_types, total=image_total):
+                netbox.create_device_types(
+                    device_types_to_process,
+                    progress=get_progress_wrapper(
+                        progress,
+                        device_types_to_process,
+                        desc="Processing Device Types",
+                        task_registry=task_registry,
+                    ),
+                    only_new=False,
+                    update=True,
+                    change_report=change_report,
+                    remove_components=config.remove_components,
+                )
+        else:
+            handle.verbose_log("No device type changes to process.")
+    else:
+        device_types_to_process = select_device_types_for_default_mode(
+            device_types, change_report, verify_images=config.verify_images
+        )
+        if device_types_to_process:
+            image_total = netbox.count_device_type_images(device_types_to_process)
+            with _image_progress_scope(progress, netbox.device_types, total=image_total):
+                netbox.create_device_types(
+                    device_types_to_process,
+                    progress=get_progress_wrapper(
+                        progress,
+                        device_types_to_process,
+                        desc="Creating Device Types",
+                        task_registry=task_registry,
+                    ),
+                    only_new=True,
+                )
+        else:
+            handle.verbose_log("No new device types or missing images to process.")
+
+
+def _process_module_types(config, netbox, handle, progress, module_types, task_registry=None):
+    """Process module types for one vendor."""
+    if not module_types:
+        return
+
+    handle.verbose_log(f"{len(module_types)} Module-Types Found")
+
+    module_only_new = should_only_create_new_modules(config)
+    existing_module_types = netbox.get_existing_module_types()
+    module_types_to_process, module_type_existing_images, changed_property_log = netbox.filter_actionable_module_types(
+        module_types,
+        existing_module_types,
+        only_new=config.only_new,
+    )
+
+    new_module_count = len(netbox.filter_new_module_types(module_types, existing_module_types))
+    pending_removal_modules = 0
+    pending_removal_components = 0
+    for _slug, _model, _fields_info, component_changes in changed_property_log:
+        removed_in_group = [
+            change
+            for change in (component_changes or [])
+            if getattr(change, "change_type", None) == ChangeType.COMPONENT_REMOVED
+        ]
+        if removed_in_group:
+            pending_removal_modules += 1
+            pending_removal_components += len(removed_in_group)
+
+    module_changed_count = len(changed_property_log)
+    module_unchanged_count = len(module_types) - len(module_types_to_process) if not config.only_new else 0
+
+    has_module_changes = new_module_count > 0 or module_changed_count > 0 or pending_removal_modules > 0
+    if has_module_changes:
+        handle.log("============================================================")
+        handle.log("MODULE TYPE CHANGE DETECTION")
+        handle.log("============================================================")
+        if config.only_new:
+            handle.log(f"New module types: {new_module_count}")
+        else:
+            image_only_count = max(0, len(module_types_to_process) - new_module_count - module_changed_count)
+            handle.log(f"New module types:       {new_module_count}")
+            handle.log(f"Unchanged module types: {module_unchanged_count}")
+            handle.log(f"Modified module types:  {module_changed_count}")
+            if image_only_count:
+                handle.log(f"Image-only updates:     {image_only_count}")
+            if module_changed_count and not config.update:
+                handle.log("  (Run with --update to apply changes to existing module types)")
+            if pending_removal_modules and not config.remove_components:
+                remove_hint = "--remove-components" if config.update else "--update --remove-components"
+                handle.log(
+                    f"  (Run with {remove_hint} to remove {pending_removal_components} stale "
+                    f"component(s) across {pending_removal_modules} module type(s))"
+                )
+        handle.log("------------------------------------------------------------")
+        netbox.log_module_type_changes(changed_property_log)
+    elif module_unchanged_count:
+        handle.verbose_log(f"No module type changes ({module_unchanged_count} unchanged).")
+
+    if module_types_to_process:
+        module_image_total = netbox.count_module_type_images(
+            module_types_to_process, existing_module_types, module_type_existing_images
+        )
+        with _image_progress_scope(progress, netbox.device_types, total=module_image_total):
+            netbox.create_module_types(
+                module_types_to_process,
+                progress=get_progress_wrapper(
+                    progress,
+                    module_types_to_process,
+                    desc="Processing Module Types",
+                    task_registry=task_registry,
+                ),
+                only_new=module_only_new,
+                all_module_types=existing_module_types,
+                module_type_existing_images=module_type_existing_images,
+                remove_components=config.remove_components,
+            )
+    else:
+        handle.verbose_log("No module type changes to process.")
+
+
+def _process_rack_types(config, netbox, handle, progress, rack_types, task_registry=None):
+    """Process rack types for one vendor."""
+    if not rack_types:
+        return
+
+    if not netbox.rack_types:
+        handle.log("Rack types require NetBox >= 4.1. Skipping rack type import.")
+        return
+
+    handle.verbose_log(f"{len(rack_types)} Rack-Types Found")
+
+    all_rack_types = netbox.get_existing_rack_types()
+    new_count = sum(
+        1
+        for rack_type in rack_types
+        if all_rack_types.get(rack_type.get("manufacturer", {}).get("slug", ""), {}).get(rack_type.get("model")) is None
+    )
+    existing_count = len(rack_types) - new_count
+
+    if new_count == 0:
+        handle.verbose_log(f"No new rack types ({existing_count} unchanged).")
+    else:
+        handle.log("============================================================")
+        handle.log(f"New rack types:       {new_count}")
+        handle.log(f"Existing rack types:  {existing_count}")
+        handle.log("============================================================")
+
+    netbox.create_rack_types(
+        rack_types,
+        progress=get_progress_wrapper(
+            progress,
+            rack_types,
+            desc="Processing Rack Types",
+            task_registry=task_registry,
+        ),
+        only_new=config.only_new,
+        all_rack_types=all_rack_types,
+    )
+
+
+def _log_import_filters(handle, config):
+    """Log active vendor and slug filters."""
+    if config.vendors:
+        handle.log(f"Importing vendors: {', '.join(config.vendors)}")
+    if config.slugs:
+        handle.log(f"Filtering by slugs: {', '.join(config.slugs)}")
+
+
+def _log_run_summary(handle, summary):
+    """Log a completed run summary."""
+    counter = summary.counter
+    handle.log("---")
+    handle.verbose_log(f"Script took {summary.elapsed} to run")
+    handle.log(f"{counter['added']} device types created")
+    handle.log(f"{counter['properties_updated']} device types updated")
+    component_updates = counter.get("device_types_component_updates", 0)
+    if component_updates:
+        handle.log(f"{component_updates} device types had component-only updates")
+    failed = counter.get("device_types_failed", 0)
+    if failed:
+        handle.log(f"{failed} device types FAILED to update (see error log above)")
+    handle.log(f"{counter['components_updated']} components updated")
+    handle.log(f"{counter['components_added']} components added")
+    handle.log(f"{counter['components_removed']} components removed")
+    handle.verbose_log(f"{counter['images']} images uploaded")
+    handle.log(f"{counter['manufacturer']} manufacturers created")
+    if summary.modules:
+        handle.log(f"{counter['module_added']} modules created")
+        handle.log(f"{counter['module_updated']} modules updated")
+        if counter["module_update_failed"]:
+            handle.log(f"{counter['module_update_failed']} modules failed to update")
+        if counter["module_partial_update"]:
+            handle.log(f"{counter['module_partial_update']} modules partially updated")
+    if summary.rack_types:
+        handle.log(f"{counter['rack_type_added']} rack types created")
+        handle.log(f"{counter['rack_type_updated']} rack types updated")
+
+    for line in summary.failure_lines:
+        handle.log(line)
+
+    if summary.duplicate_definitions:
+        handle.log("---")
+        handle.log(
+            f"WARNING: {len(summary.duplicate_definitions)} duplicate "
+            "(manufacturer, model) definition(s) detected in the source repository:"
+        )
+        for duplicate in summary.duplicate_definitions:
+            handle.log(f"  {duplicate['manufacturer']}/{duplicate['model']}")
+            handle.log(f"    kept:    {duplicate['kept']}")
+            for ignored in duplicate["ignored"]:
+                handle.log(f"    ignored: {ignored}")
+        handle.log("These duplicates would otherwise oscillate on every run. Please report/fix them upstream.")
+
+
+def _parse_vendor_racks(repo, racks_path, vendor_name, slugs):
+    """Parse rack types for one vendor when the rack path exists."""
+    if not os.path.isdir(racks_path):
+        return []
+    rack_files, _ = repo.get_devices(racks_path, [vendor_name.casefold()])
+    return repo.parse_files(rack_files, slugs=slugs)
+
+
+def _finalize_task_registry(progress, task_registry):
+    """Resolve unknown totals and stop cumulative progress tasks."""
+    if not progress or not task_registry:
+        return
+    for task_id in task_registry.values():
+        task = next((task for task in progress.tasks if task.id == task_id), None)
+        if task is None:
+            continue
+        if task.total is None:
+            progress.update(task_id, total=max(task.completed, 0))
+        progress.stop_task(task_id)
+
+
+class ImportRun:
+    """Discover, plan, apply, and report one device library import."""
+
+    def __init__(self, config, repo, netbox, reporter, progress_factory, *, started_at=None):
+        """Store the resolved run dependencies.
+
+        Args:
+            config (RunConfig): Resolved run configuration.
+            repo (DTLRepo): Checked out device library repository.
+            netbox (NetBox): Connected NetBox interface.
+            reporter (LogHandler): Run message sink.
+            progress_factory: Context manager factory for the Rich progress display.
+            started_at (datetime | None): Start time used for elapsed-time reporting.
+        """
+        if not isinstance(config, RunConfig):
+            raise TypeError("config must be a RunConfig")
+        self.config = config
+        self.repo = repo
+        self.netbox = netbox
+        self.reporter = reporter
+        self.progress_factory = progress_factory
+        self.started_at = started_at or datetime.now()
+        self.progress = None
+        self.task_registry = None
+        self.vendor_task_id = None
+
+    def discover(self):
+        """Discover source paths and select vendors for this run."""
+        devices_path = self.repo.get_devices_path()
+        modules_path = self.repo.get_modules_path()
+        racks_path = self.repo.get_racks_path()
+        all_vendors = self.repo.discover_vendors(devices_path, modules_path, racks_path)
+
+        if self.config.vendors:
+            vendor_slug_filter = {vendor.lower() for vendor in self.config.vendors}
+            vendors = [vendor for vendor in all_vendors if vendor["slug"] in vendor_slug_filter]
+            if not vendors:
+                self.reporter.log(
+                    f"No vendors matched --vendors: {', '.join(self.config.vendors)}. "
+                    f"Available: {', '.join(vendor['slug'] for vendor in all_vendors[:10])}"
+                    f"{'...' if len(all_vendors) > 10 else ''}"
+                )
+                raise SystemExit(1)
+        else:
+            vendors = all_vendors
+
+        vendors, slug_resolved = self._narrow_by_slug(vendors)
+        if self.config.vendors and not vendors:
+            self.reporter.log(
+                f"No vendors matched the combination of --vendors and --slugs: {', '.join(self.config.vendors)}"
+            )
+            raise SystemExit(1)
+
+        return RunSelection(
+            vendors=tuple(vendors),
+            devices_path=devices_path,
+            modules_path=modules_path,
+            racks_path=racks_path,
+            slug_resolved=slug_resolved,
+        )
+
+    def _narrow_by_slug(self, vendors):
+        """Narrow vendors with the repository slug index when available."""
+        if not self.config.slugs:
+            return vendors, None
+
+        slug_resolved = self.repo.resolve_slug_files(self.config.slugs)
+        if slug_resolved is None:
+            self.reporter.verbose_log("Slug index unavailable; falling back to full file scan.")
+            return vendors, None
+
+        matched_vendor_slugs = (
+            set(slug_resolved["device_files"])
+            | (slug_resolved["module_vendors"] or set())
+            | (slug_resolved["rack_vendors"] or set())
+        )
+        if not matched_vendor_slugs:
+            self.reporter.verbose_log("Slug index returned no matches; falling back to full file scan.")
+            return vendors, None
+        narrowed = [vendor for vendor in vendors if vendor["slug"] in matched_vendor_slugs]
+        self.reporter.verbose_log(
+            f"Slug index resolved {sum(len(files) for files in slug_resolved['device_files'].values())} "
+            f"device file(s) across {len(matched_vendor_slugs)} vendor(s)."
+        )
+        return narrowed, slug_resolved
+
+    def plan_vendor(self, selection, vendor):
+        """Parse source files and return an inspectable vendor plan."""
+        slug_resolved = selection.slug_resolved
+        if slug_resolved is not None:
+            device_files = slug_resolved["device_files"].get(vendor["slug"], [])
+            device_types = self.repo.parse_files(device_files) if device_files else []
+        else:
+            device_files, _ = self.repo.get_devices(selection.devices_path, [vendor["name"].casefold()])
+            device_types = self.repo.parse_files(device_files, slugs=self.config.slugs or [])
+
+        if self.netbox.modules:
+            module_hint = slug_resolved["module_vendors"] if slug_resolved is not None else None
+            if module_hint is not None and vendor["slug"] not in module_hint:
+                module_types = []
+            else:
+                module_files, _ = self.repo.get_devices(selection.modules_path, [vendor["name"].casefold()])
+                module_types = self.repo.parse_files(module_files, slugs=self.config.slugs or [])
+        else:
+            module_types = []
+
+        if self.netbox.rack_types:
+            rack_hint = slug_resolved["rack_vendors"] if slug_resolved is not None else None
+            if rack_hint is not None and vendor["slug"] not in rack_hint:
+                rack_types = []
+            else:
+                rack_types = _parse_vendor_racks(
+                    self.repo,
+                    selection.racks_path,
+                    vendor["name"],
+                    self.config.slugs or [],
+                )
+        else:
+            rack_types = []
+
+        return VendorPlan(
+            vendor=vendor,
+            device_types=device_types,
+            module_types=module_types,
+            rack_types=rack_types,
+            prefetch_components=bool(device_types or module_types) and not self.config.only_new,
+        )
+
+    def apply(self, plan):
+        """Apply one vendor plan to NetBox."""
+        if not plan.has_types:
+            self._advance_vendor()
+            return
+
+        cache = self.netbox.device_types.components
+        self.netbox.load_vendor(plan.vendor["slug"])
+
+        if plan.prefetch_components:
+            cache.begin_prefetch(
+                manufacturer_slug=plan.vendor["slug"],
+                display=_cache_display(self.progress, self.task_registry),
+            )
+
+        self.reporter.verbose_log(f"{len(plan.device_types)} Device-Types Found")
+        cache.pump()
+        self.netbox.create_manufacturers([plan.vendor])
+        cache.pump()
+
+        _process_device_types(
+            self.config,
+            self.netbox,
+            self.reporter,
+            self.progress,
+            plan.device_types,
+            vendor_slug=plan.vendor["slug"],
+            task_registry=self.task_registry,
+        )
+        cache.pump()
+
+        if self.netbox.modules:
+            _process_module_types(
+                self.config,
+                self.netbox,
+                self.reporter,
+                self.progress,
+                plan.module_types,
+                task_registry=self.task_registry,
+            )
+            cache.pump()
+
+        _process_rack_types(
+            self.config,
+            self.netbox,
+            self.reporter,
+            self.progress,
+            plan.rack_types,
+            task_registry=self.task_registry,
+        )
+        cache.pump()
+        cache.close()
+        self._advance_vendor()
+
+    def _advance_vendor(self):
+        """Advance the vendor progress task when it exists."""
+        if self.vendor_task_id is not None:
+            self.progress.advance(self.vendor_task_id)
+
+    def _start_progress(self, vendors):
+        """Initialize progress state for the selected vendors."""
+        self.task_registry = {} if self.progress is not None else None
+        self.vendor_task_id = None
+        if self.progress is not None and vendors:
+            description = "Vendors".ljust(_PROGRESS_DESC_WIDTH)
+            self.vendor_task_id = self.progress.add_task(description, total=len(vendors))
+
+    def _clear_progress(self):
+        """Close preloads and release all progress state."""
+        try:
+            self.netbox.device_types.components.close()
+        finally:
+            try:
+                _finalize_task_registry(self.progress, self.task_registry)
+            finally:
+                self.reporter.set_console(None)
+                self.progress = None
+                self.task_registry = None
+                self.vendor_task_id = None
+
+    def execute(self):
+        """Execute the import sequence and return its summary."""
+        log_run_mode(self.reporter, self.config)
+        _log_import_filters(self.reporter, self.config)
+        selection = self.discover()
+
+        with self.progress_factory(self.config.show_remaining_time) as progress:
+            self.progress = progress
+            if progress is not None:
+                self.reporter.set_console(progress.console)
+            try:
+                self._start_progress(selection.vendors)
+                for vendor in selection.vendors:
+                    self.apply(self.plan_vendor(selection, vendor))
+            finally:
+                self._clear_progress()
+
+        summary = RunSummary.capture(self.netbox, self.repo, self.started_at)
+        _log_run_summary(self.reporter, summary)
+        return summary

--- a/core/log_handler.py
+++ b/core/log_handler.py
@@ -1,64 +1,21 @@
 """Logging utilities for the Device Type Library Import tool."""
 
 from datetime import datetime
-from sys import exit as system_exit
 
 
 class LogHandler:
-    """Handles logging and exception reporting for the device type import process.
+    """Emit normal and verbose log messages for the device type import process."""
 
-    Provides timestamped logging methods, verbose mode support, and formatted
-    error messages that terminate the program on critical failures.
-    """
-
-    def __init__(self, args):
-        """Initialize the LogHandler with parsed arguments or a configuration object.
+    def __init__(self, verbose: bool):
+        """Initialize the sink with its verbose mode.
 
         Args:
-            args: Parsed command-line arguments or a configuration object with at least a `verbose`
-                  attribute (bool); stored on the instance as `self.args`.
+            verbose: Emit verbose messages when True.
         """
-        self.args = args
+        self.verbose = verbose
         self.console = None
         self._defer_depth = 0
         self._deferred_messages = []
-
-    def exception(self, exception_type, exception, stack_trace=None):
-        """Handle an error by formatting a user-facing message and terminating the program.
-
-        Args:
-            exception_type (str): Key identifying the error category (expected keys include
-                "EnvironmentError", "SSLError", "GitCommandError", "GitInvalidRepositoryError",
-                "InvalidGitURL", "InvalidRepoPath", "Exception").
-            exception (str): Value used to populate the chosen error message (e.g., environment
-                variable name, repo name, raw error text, or invalid path for "InvalidRepoPath").
-            stack_trace (str | None): Optional stack trace or additional context. If provided and
-                the instance was constructed with verbose enabled, the stack trace is printed.
-
-        Raises:
-            SystemExit: Exits the process with a formatted message corresponding to `exception_type`.
-        """
-        exception_dict = {
-            "EnvironmentError": f'Environment variable "{exception}" is not set.',
-            "SSLError": (
-                f"SSL verification failed. IGNORE_SSL_ERRORS is {exception}. "
-                f"Set IGNORE_SSL_ERRORS to True if you want to ignore this error. EXITING."
-            ),
-            "GitCommandError": f'Git error for repo "{exception}".',
-            "GitInvalidRepositoryError": f'The repo "{exception}" is not a valid git repo.',
-            "GitBranchNotFound": (
-                f'Branch "{exception}" was not found in the remote repository. Check your REPO_BRANCH setting.'
-            ),
-            "InvalidGitURL": f"Invalid Git URL: {exception}. URL must use HTTPS, SSH, or file protocol.",
-            "InvalidRepoPath": f'Invalid repository path "{exception}".',
-            "Exception": f'An unknown error occurred: "{exception}"',
-        }
-
-        if self.args.verbose and stack_trace:
-            print(stack_trace)
-
-        # Raise SystemExit with the message, which will print to stderr and exit code 1
-        system_exit(exception_dict[exception_type])
 
     def _timestamp(self):
         """Return the current time formatted as HH:MM:SS."""
@@ -96,49 +53,25 @@ class LogHandler:
 
     def verbose_log(self, message):
         """Log *message* only when verbose mode is enabled."""
-        if self.args.verbose:
+        if self.verbose:
             self._emit(f"[{self._timestamp()}] {message}")
 
     def log(self, message):
         """Emit a timestamped log message unconditionally."""
         self._emit(f"[{self._timestamp()}] {message}")
 
-    def log_device_ports_created(self, created_ports=None, port_type: str = "port"):
-        """Log creation of device port templates and return the count created.
+    def log_ports_created(self, created_ports, parent_type: str, port_type: str = "port"):
+        """Log creation of component templates for a device or module type.
 
         Args:
-            created_ports (list | None): Port template records returned by the API.
+            created_ports (list): Port template records returned by the API.
+            parent_type: ``"device"`` or ``"module"``.
             port_type (str): Human-readable port type label used in log messages.
-
-        Returns:
-            int: Number of ports logged.
         """
-        if created_ports is None:
-            created_ports = []
+        parent_attribute = f"{parent_type}_type"
         for port in created_ports:
             self.verbose_log(
                 f"{port_type} Template Created: {port.name} - "
-                + f"{port.type if hasattr(port, 'type') else ''} - {port.device_type.id} - "
+                + f"{port.type if hasattr(port, 'type') else ''} - {getattr(port, parent_attribute).id} - "
                 + f"{port.id}"
             )
-        return len(created_ports)
-
-    def log_module_ports_created(self, created_ports=None, port_type: str = "port"):
-        """Log creation of module port templates and return the count created.
-
-        Args:
-            created_ports (list | None): Port template records returned by the API.
-            port_type (str): Human-readable port type label used in log messages.
-
-        Returns:
-            int: Number of ports logged.
-        """
-        if created_ports is None:
-            created_ports = []
-        for port in created_ports:
-            self.verbose_log(
-                f"{port_type} Template Created: {port.name} - "
-                + f"{port.type if hasattr(port, 'type') else ''} - {port.module_type.id} - "
-                + f"{port.id}"
-            )
-        return len(created_ports)

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -557,14 +557,6 @@ class NetBox:
         except Exception as e:
             raise UnknownError("NetBox API Error", e) from e
 
-    def get_api(self):
-        """Return the underlying pynetbox API instance."""
-        return self.netbox
-
-    def get_counter(self):
-        """Return the shared operation counter."""
-        return self.counter
-
     def verify_compatibility(self):
         """Check the connected NetBox version and configure feature flags accordingly.
 
@@ -1371,22 +1363,6 @@ class NetBox:
                 self.handle.verbose_log(f"      - {len(removed)} component(s) present in NetBox but absent from YAML")
                 for comp in removed:
                     self.handle.verbose_log(f"        - {comp.component_type}: {comp.component_name}")
-
-    def _module_type_has_missing_components(self, module_type, existing_module, component_keys):
-        """Return True if any YAML-defined components are absent from the existing module type in NetBox."""
-        for component_key in component_keys:
-            components = module_type.get(component_key)
-            if not components:
-                continue
-            endpoint_name = BY_YAML_KEY[component_key].endpoint
-            endpoint = getattr(self.netbox.dcim, endpoint_name)
-            existing_components = self.device_types.components.get(
-                endpoint_name, "module", existing_module.id, endpoint
-            )
-            requested_names = {c.get("name") for c in components if c.get("name")}
-            if any(name not in existing_components for name in requested_names):
-                return True
-        return False
 
     def filter_actionable_module_types(self, module_types, all_module_types, only_new=False):
         """Determine which module types need to be created or updated in NetBox.

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -454,9 +454,9 @@ class NetBox:
         self.new_filters = False
         self.m2m_front_ports = False  # True for NetBox >= 4.5 (M2M port mappings)
         self.rack_types = False
-        self.force_resolve_conflicts = False
-        self.remove_unmanaged_types = False
-        self.verify_images = False
+        self.force_resolve_conflicts = config.force_resolve_conflicts
+        self.remove_unmanaged_types = config.remove_unmanaged_types
+        self.verify_images = config.verify_images
         self._module_image_details: dict = {}  # populated by _fetch_module_type_existing_images in verify mode
         # Image hash cache: local file path -> SHA-256 hex-digest at last upload time.
         # Used by --verify-images to detect whether the local file changed since last upload,

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -10,7 +10,6 @@ import time
 import pynetbox
 import requests
 import os
-from sys import exit as system_exit
 import glob
 from pathlib import Path
 
@@ -25,6 +24,7 @@ from core.component_registry import (
     MODULE_TYPE_COMPONENTS,
 )
 from core.formatting import log_property_diffs
+from core.errors import FatalError, UnknownError
 from core.graphql_client import GraphQLError, NetBoxGraphQLClient
 from core.normalization import values_equal
 from core.outcomes import EntityKind, Outcome, OutcomeRegistry
@@ -33,6 +33,22 @@ from core.update_failure_resolver import (
     FailureKind,
     classify_device_type_update_failure,
 )
+
+
+class SSLVerificationError(FatalError):
+    """A TLS certificate verification failure."""
+
+    def __init__(self, ignore_ssl_errors: bool, stack_trace=None):
+        """Report the active TLS verification setting."""
+        super().__init__(
+            f"SSL verification failed. IGNORE_SSL_ERRORS is {ignore_ssl_errors}. "
+            "Set IGNORE_SSL_ERRORS to True if you want to ignore this error. EXITING.",
+            stack_trace,
+        )
+
+
+class NetBoxError(FatalError):
+    """A fatal error reported by the NetBox integration."""
 
 
 def _build_auth_header(token):
@@ -430,6 +446,7 @@ class NetBox:
         self.url = config.netbox_url
         self.token = config.netbox_token
         self.repo_path = config.repo_path
+        self.verbose = config.verbose
         self.handle = handle
         self.netbox = None
         self.ignore_ssl = config.ignore_ssl_errors
@@ -464,13 +481,13 @@ class NetBox:
             self.url,
             self.token,
             self.ignore_ssl,
-            log_handler=self.handle,
+            handle=self.handle,
             page_size=config.graphql_page_size,
         )
         try:
             self.existing_manufacturers = self.get_manufacturers()
         except GraphQLError as e:
-            system_exit(f"GraphQL error: {e}")
+            raise NetBoxError(f"GraphQL error: {e}") from e
         try:
             self.device_types = DeviceTypes(
                 self.netbox,
@@ -484,7 +501,7 @@ class NetBox:
                 max_threads=config.preload_threads,
             )
         except Exception as e:
-            system_exit(f"Error initializing device types: {e}")
+            raise NetBoxError(f"Error initializing device types: {e}") from e
         self._change_detector: ChangeDetector | None = None
 
     @property
@@ -495,6 +512,7 @@ class NetBox:
                 self.device_types,
                 self.handle,
                 remove_unmanaged_types=self.remove_unmanaged_types,
+                verbose=self.verbose,
             )
         return self._change_detector
 
@@ -537,7 +555,7 @@ class NetBox:
                 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
                 self.netbox.http_session.verify = False
         except Exception as e:
-            self.handle.exception("Exception", "NetBox API Error", e)
+            raise UnknownError("NetBox API Error", e) from e
 
     def get_api(self):
         """Return the underlying pynetbox API instance."""
@@ -557,15 +575,17 @@ class NetBox:
         # Strip non-numeric suffixes (e.g. "4.1-beta") before converting to int.
         try:
             nb_version = self.netbox.version
+        except requests.exceptions.SSLError as e:
+            raise SSLVerificationError(self.ignore_ssl, e) from e
         except requests.exceptions.ProxyError as e:
-            system_exit(
+            raise NetBoxError(
                 f"Proxy error while connecting to NetBox at {self.url}: {e}\n"
                 f"Hint: If NetBox is running locally, ensure that the NETBOX_URL host "
                 f"is included in your 'no_proxy' / 'NO_PROXY' environment variable "
                 f"(both with and without brackets for IPv6, e.g. '::1,[::1]')."
-            )
+            ) from e
         except requests.exceptions.ConnectionError as e:
-            system_exit(_fmt_connection_error(self.url, e))
+            raise NetBoxError(_fmt_connection_error(self.url, e)) from e
         except pynetbox.core.query.RequestError as e:
             endpoint = getattr(e, "base", self.url)
             status = getattr(e.req, "status_code", "?") if hasattr(e, "req") else "?"
@@ -576,7 +596,7 @@ class NetBox:
             if body:
                 msg += f"\nResponse body (may be from an intermediate proxy):\n{body}"
             msg += f"\nHint: Verify that {self.url} is reachable and not blocked by a proxy."
-            system_exit(msg)
+            raise NetBoxError(msg) from e
         _raw = [int(re.sub(r"\D.*", "", x.strip()) or "0") for x in nb_version.split(".")]
         version_split = (_raw + [0, 0])[:2]  # pad to (major, minor) to guard against single-component strings
 
@@ -2069,7 +2089,7 @@ class DeviceTypes:
     def __init__(
         self,
         netbox,
-        exception_handler,
+        handle,
         counter,
         ignore_ssl,
         new_filters,
@@ -2086,7 +2106,7 @@ class DeviceTypes:
 
         Args:
             netbox: Connected pynetbox API instance.
-            exception_handler (LogHandler): Handler for logging and error reporting.
+            handle (LogHandler): Sink for creation and error messages.
             counter (Counter): Shared operation counter updated during creation.
             ignore_ssl (bool): Whether SSL certificate verification is disabled.
             new_filters (bool): Whether to use updated filter parameter names (NetBox >= 4.1).
@@ -2096,7 +2116,7 @@ class DeviceTypes:
             max_threads (int): Maximum number of concurrent threads for component preloading.
         """
         self.netbox = netbox
-        self.handle = exception_handler
+        self.handle = handle
         self.counter = counter
         self.ignore_ssl = ignore_ssl
         self.new_filters = new_filters
@@ -2107,7 +2127,7 @@ class DeviceTypes:
         self.components = ComponentCache(
             netbox,
             graphql,
-            exception_handler,
+            handle,
             new_filters,
             max_threads,
             wrap_record=_FrontPortRecordWithMappings,
@@ -2193,12 +2213,8 @@ class DeviceTypes:
         if to_create:
             try:
                 created = _retry_on_connection_error(endpoint.create, to_create)
-                if parent_type == "device":
-                    count = self.handle.log_device_ports_created(created, component_name)
-                    self.counter.update({"components_added": count})
-                else:
-                    count = self.handle.log_module_ports_created(created, component_name)
-                    self.counter.update({"components_added": count})
+                self.handle.log_ports_created(created, parent_type, component_name)
+                self.counter.update({"components_added": len(created)})
 
                 self.components.invalidate(cache_name, parent_type, parent_id)
             except pynetbox.RequestError as excep:

--- a/core/repo.py
+++ b/core/repo.py
@@ -1,5 +1,6 @@
 """Git repository helpers for cloning, updating, and parsing the device-type library."""
 
+import concurrent.futures
 import json
 import os
 import pickle
@@ -9,7 +10,51 @@ from typing import Optional
 from urllib.parse import urlparse
 from git import Repo, exc
 import yaml
-import concurrent.futures
+
+from core.errors import FatalError, UnknownError
+
+
+class GitCommandError(FatalError):
+    """A Git command that failed for a repository."""
+
+    def __init__(self, repository: str, stack_trace=None):
+        """Name the repository whose Git command failed."""
+        super().__init__(f'Git error for repo "{repository}".', stack_trace)
+
+
+class GitInvalidRepositoryError(FatalError):
+    """A path that does not contain a valid Git repository."""
+
+    def __init__(self, repository: str, stack_trace=None):
+        """Name the invalid repository."""
+        super().__init__(f'The repo "{repository}" is not a valid git repo.', stack_trace)
+
+
+class GitBranchNotFoundError(FatalError):
+    """A configured branch that is absent from the remote repository."""
+
+    def __init__(self, branch: str, stack_trace=None):
+        """Name the missing branch."""
+        super().__init__(
+            f'Branch "{branch}" was not found in the remote repository. Check your REPO_BRANCH setting.',
+            stack_trace,
+        )
+
+
+class InvalidGitURLError(FatalError):
+    """A Git URL that does not use an accepted protocol."""
+
+    def __init__(self, url: str, stack_trace=None):
+        """Name the invalid Git URL."""
+        super().__init__(f"Invalid Git URL: {url}. URL must use HTTPS, SSH, or file protocol.", stack_trace)
+
+
+class InvalidRepoPathError(FatalError):
+    """A local repository path that cannot be used."""
+
+    def __init__(self, path: str, stack_trace=None):
+        """Name the invalid local repository path."""
+        super().__init__(f'Invalid repository path "{path}".', stack_trace)
 
 
 class _RestrictedUnpickler(pickle.Unpickler):
@@ -374,7 +419,7 @@ class DTLRepo:
     for locating YAML device and module type files, and exposes a parallel file parser.
     """
 
-    def __init__(self, config, exception_handler):
+    def __init__(self, config, handle):
         """Initialize repository management, updating an existing clone or creating a new one.
 
         If the target path already holds a Git clone, the repository will be updated from
@@ -385,10 +430,9 @@ class DTLRepo:
 
         Args:
             config (RunConfig): Supplies `repo_url`, `repo_branch`, and `repo_path`.
-            exception_handler: An object exposing `exception(name, context, message)` used
-                to report validation and Git errors.
+            handle (LogHandler): Sink for repository progress messages.
         """
-        self.handle = exception_handler
+        self.handle = handle
         self.yaml_extensions = ["yaml", "yml"]
         # Duplicate (manufacturer_slug, model) definitions found while parsing.
         # Populated by parse_files; consumed by the run summary so users can fix upstream.
@@ -402,7 +446,7 @@ class DTLRepo:
 
         is_path_valid, path_error = validate_repo_path(self.repo_path)
         if not is_path_valid:
-            self.handle.exception("InvalidRepoPath", self.repo_path, path_error)
+            raise InvalidRepoPathError(self.repo_path, path_error)
 
         # Test for .git, not the directory itself: a mounted-but-empty volume must still clone.
         # exists(), not isdir(): worktrees and submodules hold .git as a file.
@@ -413,7 +457,7 @@ class DTLRepo:
             # Validate URL only when cloning a new repo
             is_valid, error_msg = validate_git_url(self.url)
             if not is_valid:
-                self.handle.exception("InvalidGitURL", self.url, error_msg)
+                raise InvalidGitURLError(self.url, error_msg)
             self.clone_repo()
 
     def get_relative_path(self):
@@ -454,7 +498,7 @@ class DTLRepo:
 
         Opens the existing clone at ``self.repo_path``, validates the origin URL (updating it
         if REPO_URL has changed), fetches from origin, and checks out ``self.branch``.
-        Reports errors via the configured exception handler.
+        Raises a typed fatal error when validation or a Git operation fails.
         """
         try:
             self.handle.log(
@@ -468,43 +512,46 @@ class DTLRepo:
             if self.url and origin_url != self.url:
                 is_valid, error_msg = validate_git_url(self.url)
                 if not is_valid:
-                    self.handle.exception("InvalidGitURL", self.url, error_msg)
+                    raise InvalidGitURLError(self.url, error_msg)
                 self.handle.verbose_log(f"Remote URL changed ({origin_url} → {self.url}), updating origin")
                 self.repo.remotes.origin.set_url(self.url)
             else:
                 is_valid, error_msg = validate_git_url(origin_url)
                 if not is_valid:
-                    self.handle.exception("InvalidGitURL", origin_url, error_msg)
+                    raise InvalidGitURLError(origin_url, error_msg)
 
             self.repo.remotes.origin.fetch(prune=True)
 
             remote_branch_names = [ref.name for ref in self.repo.remotes.origin.refs]
             if f"origin/{self.branch}" not in remote_branch_names:
-                self.handle.exception("GitBranchNotFound", self.branch)
+                raise GitBranchNotFoundError(self.branch)
 
             # -B creates the branch if absent or resets it to the remote ref if present
             self.repo.git.checkout("-B", self.branch, f"origin/{self.branch}")
             self.handle.verbose_log(f"Updated repo from {self.repo.remotes.origin.url} (branch: {self.branch})")
+        except FatalError:
+            raise
+        except exc.InvalidGitRepositoryError as git_error:
+            raise GitInvalidRepositoryError(self.repo_path, git_error) from git_error
         except exc.GitCommandError as git_error:
-            self.handle.exception("GitCommandError", self.repo.remotes.origin.url, git_error)
+            raise GitCommandError(self.repo.remotes.origin.url, git_error) from git_error
         except Exception as git_error:
-            self.handle.exception("Exception", "Git Repository Error", git_error)
+            raise UnknownError("Git Repository Error", git_error) from git_error
 
     def clone_repo(self):
         """Clone the configured Git repository into the configured local path and record the cloned Repo instance.
 
         Attempts to clone from the repository URL into the absolute repository path and set
         self.repo to the resulting Repo; on success logs the origin URL via the configured
-        handler. If cloning or Git operations fail, the exception is reported to the
-        configured exception handler.
+        handler. Raises a typed fatal error when cloning or another Git operation fails.
         """
         try:
             self.repo = Repo.clone_from(self.url, self.get_absolute_path(), branch=self.branch)
             self.handle.log(f"Package Installed {self.repo.remotes.origin.url}")
         except exc.GitCommandError as git_error:
-            self.handle.exception("GitCommandError", self.url, git_error)
+            raise GitCommandError(self.url, git_error) from git_error
         except Exception as git_error:
-            self.handle.exception("Exception", "Git Repository Error", git_error)
+            raise UnknownError("Git Repository Error", git_error) from git_error
 
     def get_devices(self, base_path, vendors: list = None):
         """Discover device YAML files and vendor directories under a base path.

--- a/docs/adr/0001-no-rest-fallback-for-component-fetch.md
+++ b/docs/adr/0001-no-rest-fallback-for-component-fetch.md
@@ -1,0 +1,27 @@
+# ADR 0001: No REST fallback for component fetch
+
+## Status
+
+Accepted
+
+## Context
+
+The component cache had an empty `REST_ONLY_ENDPOINTS` set. An endpoint in that set would use REST instead of
+GraphQL. The REST count check would then skip the endpoint because comparing REST data with a REST count gives no
+independent check.
+
+The set was always empty, so the trigger condition never fired in production. The REST adapter was a hypothetical
+seam. Tests could exercise the branches only by monkeypatching the module global.
+
+## Decision
+
+Delete `REST_ONLY_ENDPOINTS` and both guarded branches. Bulk component fetching uses GraphQL. The integrity check
+compares each cached component count with REST. Targeted REST reads for a cold cache remain unchanged.
+
+## Consequences
+
+The component cache has one bulk fetch path and no inactive adapter branch. Tests no longer change a module global
+to create a runtime state that production cannot reach.
+
+This decision is reversible. If a NetBox version drops a required field from GraphQL but keeps it in REST, a REST
+path can be restored with a few lines and tests against an actual trigger condition.

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -6,6 +6,7 @@ import os
 from contextlib import contextmanager
 
 from core.config import ConfigError, resolve_run_config
+from core.errors import FatalError
 from core.netbox_api import NetBox, _fmt_connection_error
 from core.log_handler import LogHandler
 from core.repo import DTLRepo
@@ -514,6 +515,7 @@ def _process_device_types(
         netbox.device_types,
         handle,
         remove_unmanaged_types=config.remove_unmanaged_types,
+        verbose=config.verbose,
     )
     change_report = detector.detect_changes(
         device_types,
@@ -983,9 +985,29 @@ def main():
         raise SystemExit(str(exc))
     try:
         return _run(config)
+    except FatalError as exc:
+        if config.verbose and exc.stack_trace:
+            print(exc.stack_trace)
+        raise SystemExit(str(exc))
     except requests.exceptions.ConnectionError as exc:
         print(
             f"[{datetime.now().strftime('%H:%M:%S')}] Error: {_fmt_connection_error(config.netbox_url, exc)}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    except GraphQLError as exc:
+        print(
+            f"[{datetime.now().strftime('%H:%M:%S')}] Error: NetBox GraphQL request failed — {exc}\n"
+            f"[{datetime.now().strftime('%H:%M:%S')}] This may be a temporary connectivity issue. "
+            "Check that NetBox is reachable and try again.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    except NetBoxRequestError as exc:
+        print(
+            f"[{datetime.now().strftime('%H:%M:%S')}] Error: NetBox REST API request failed — {exc}\n"
+            f"[{datetime.now().strftime('%H:%M:%S')}] Check that NetBox is reachable and"
+            " the API token has the required permissions.",
             file=sys.stderr,
         )
         raise SystemExit(1)
@@ -999,7 +1021,7 @@ def _run(config):
     """
     startTime = datetime.now()
 
-    handle = LogHandler(config)
+    handle = LogHandler(config.verbose)
     for notice in config.notices:
         handle.log(notice)
 
@@ -1078,19 +1100,3 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         print(f"[{datetime.now().strftime('%H:%M:%S')}] Interrupted by user (Ctrl-C). Exiting.")
         raise SystemExit(130)
-    except GraphQLError as exc:
-        print(
-            f"[{datetime.now().strftime('%H:%M:%S')}] Error: NetBox GraphQL request failed — {exc}\n"
-            f"[{datetime.now().strftime('%H:%M:%S')}] This may be a temporary connectivity issue. "
-            "Check that NetBox is reachable and try again.",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    except NetBoxRequestError as exc:
-        print(
-            f"[{datetime.now().strftime('%H:%M:%S')}] Error: NetBox REST API request failed — {exc}\n"
-            f"[{datetime.now().strftime('%H:%M:%S')}] Check that NetBox is reachable and"
-            " the API token has the required permissions.",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)

--- a/nb-dt-import.py
+++ b/nb-dt-import.py
@@ -1,23 +1,12 @@
 #!/usr/bin/env python3
-"""Entry-point script for importing NetBox device and module types from the community library."""
+"""Import NetBox device and module types from the community library."""
 
-from datetime import datetime
-import os
 from contextlib import contextmanager
+from datetime import datetime
+import sys
 
-from core.config import ConfigError, resolve_run_config
-from core.errors import FatalError
-from core.netbox_api import NetBox, _fmt_connection_error
-from core.log_handler import LogHandler
-from core.repo import DTLRepo
-from core.change_detector import ChangeDetector, ChangeType, IMAGE_PROPERTIES
-from core.component_cache import NullTaskDisplay, RichTaskDisplay
-from core.graphql_client import GraphQLError
 from pynetbox.core.query import RequestError as NetBoxRequestError
 import requests
-
-
-import sys
 from rich.panel import Panel
 from rich.progress import (
     BarColumn,
@@ -33,28 +22,20 @@ from rich.progress import (
 )
 from rich.text import Text
 
-
-_PROGRESS_DESC_WIDTH = 28  # Longest: "Caching Console Server Ports"
+from core.config import ConfigError, resolve_run_config
+from core.errors import FatalError
+from core.graphql_client import GraphQLError
+from core.import_run import ImportRun
+from core.log_handler import LogHandler
+from core.netbox_api import NetBox, _fmt_connection_error
+from core.repo import DTLRepo
 
 
 class NoPulseBarColumn(BarColumn):
-    """BarColumn that never pulses — shows a static empty bar when total is unknown.
-
-    Rich's default BarColumn sets ``pulse=True`` whenever ``task.total is None``,
-    which produces a scrolling rainbow-gradient animation.  That causes a
-    continuous stream of ANSI color codes on every render frame, creating a
-    distracting "disco" effect on the terminal.  This subclass always passes
-    ``pulse=False`` so the bar stays static when total is unknown.
-    """
+    """Render a static empty bar when the task total is unknown."""
 
     def render(self, task):
-        """Render a static progress bar (no pulsing gradient).
-
-        Rich's ProgressBar triggers pulse when ``total is None`` regardless of
-        the ``pulse`` flag (``should_pulse = self.pulse or self.total is None``).
-        When total is unknown we substitute total=1, completed=0 to get a plain
-        static empty bar instead of the scrolling rainbow gradient.
-        """
+        """Render a progress bar without a pulse animation."""
         if task.total is None:
             total: float = 1.0
             completed: float = 0.0
@@ -75,19 +56,19 @@ class NoPulseBarColumn(BarColumn):
 
 
 class MyProgress(Progress):
-    """Rich Progress subclass that renders each task table inside a bordered Panel."""
+    """Render the progress task table in a bordered panel."""
 
     def get_renderables(self):
-        """Yield a Panel wrapping the tasks table for display inside a bordered box."""
+        """Yield the panel that contains the task table."""
         yield Panel(self.make_tasks_table(self.tasks))
 
 
 class ItemsPerSecondColumn(ProgressColumn):
-    """Custom Rich ProgressColumn that displays processing speed in items per second."""
+    """Display processing speed in items per second."""
 
     @staticmethod
     def _effective_speed(task, primary_attr):
-        """Return the effective speed for *task*, falling back to elapsed/completed if *primary_attr* is unavailable."""
+        """Return the reported speed or an elapsed-time fallback."""
         speed = getattr(task, primary_attr, None)
         if speed is not None:
             return speed
@@ -98,7 +79,7 @@ class ItemsPerSecondColumn(ProgressColumn):
         return None
 
     def render(self, task):
-        """Render the current or finished speed as a ``Text`` object (e.g. ``"12.3 it/s"``)."""
+        """Render the current or finished speed."""
         if task.finished:
             speed = self._effective_speed(task, "finished_speed")
         else:
@@ -110,14 +91,7 @@ class ItemsPerSecondColumn(ProgressColumn):
 
 @contextmanager
 def get_progress_panel(show_remaining_time=False):
-    """Context manager that yields a MyProgress instance when stdout is a TTY, otherwise yields None.
-
-    Args:
-        show_remaining_time (bool): If True, appends a TimeRemainingColumn to the progress bar.
-
-    Yields:
-        MyProgress | None: Progress instance for TTY contexts; None for non-TTY (e.g. piped output).
-    """
+    """Yield a progress display for a TTY, or None for other output."""
     if not sys.stdout.isatty():
         yield None
         return
@@ -134,715 +108,12 @@ def get_progress_panel(show_remaining_time=False):
     if show_remaining_time:
         columns.append(TimeRemainingColumn())
 
-    with MyProgress(
-        *columns,
-        refresh_per_second=4,
-    ) as progress:
+    with MyProgress(*columns, refresh_per_second=4) as progress:
         yield progress
 
 
-def get_progress_wrapper(progress, iterable, desc=None, total=None, on_step=None, task_registry=None):
-    """Wrap *iterable* with a Rich progress task if *progress* is provided, otherwise return *iterable* unchanged.
-
-    Args:
-        progress: A MyProgress instance (or compatible), or None to disable tracking.
-        iterable: The iterable to wrap.
-        desc (str | None): Task description shown in the progress bar.
-        total (int | None): Total number of items; inferred from ``len(iterable)`` if omitted.
-        on_step (callable | None): Optional callback invoked after each item and at the end.
-        task_registry (dict | None): When provided, tasks are created once per description and
-            reused across calls — counts accumulate rather than resetting per vendor. The caller
-            is responsible for stopping/removing tasks at the end of the run.
-
-    Returns:
-        The original iterable if *progress* is None, otherwise a generator that advances
-        the progress task as items are consumed.
-    """
-    if progress is None:
-        return iterable
-
-    description = (desc or "").ljust(_PROGRESS_DESC_WIDTH)
-    if total is None:
-        try:
-            total = len(iterable)
-        except TypeError:
-            total = None
-
-    if task_registry is not None:
-        # Cumulative mode: create the task once, reuse it across vendors.
-        # NOTE: `total` is intentionally ignored here — the final count is
-        # unknown at task-creation time and is resolved during finalization.
-        if description not in task_registry:
-            task_registry[description] = progress.add_task(description, total=None)
-        task_id = task_registry[description]
-    else:
-        task_id = progress.add_task(description, total=total)
-
-    def iterator():
-        """Yield items from *iterable* while advancing the progress task."""
-        count = 0
-        try:
-            for item in iterable:
-                yield item
-                count += 1
-                progress.advance(task_id)
-                if on_step:
-                    on_step()
-        finally:
-            if task_registry is None:
-                # Non-cumulative: finalize and clean up this vendor's task.
-                if total is None:
-                    progress.update(task_id, total=max(count, 1), completed=count)
-                progress.stop_task(task_id)
-                progress.remove_task(task_id)
-            if on_step:
-                on_step()
-
-    return iterator()
-
-
-def filter_new_device_types(device_types, existing_by_model, existing_by_slug):
-    """Return device types that do not already exist in NetBox.
-
-    Looks up each device type by ``(manufacturer_slug, model)`` first, then by
-    ``(manufacturer_slug, slug)`` as a fallback.
-
-    Args:
-        device_types (list[dict]): Parsed YAML device-type dicts to filter.
-        existing_by_model (dict): Mapping of ``(manufacturer_slug, model)`` -> NetBox record.
-        existing_by_slug (dict): Mapping of ``(manufacturer_slug, slug)`` -> NetBox record.
-
-    Returns:
-        list[dict]: Device types not found in either lookup.
-    """
-    new_device_types = []
-    for device_type in device_types:
-        manufacturer_slug = device_type["manufacturer"]["slug"]
-        model = device_type["model"]
-        slug = device_type.get("slug", "")
-
-        existing = existing_by_model.get((manufacturer_slug, model))
-        if existing is None and slug:
-            existing = existing_by_slug.get((manufacturer_slug, slug))
-
-        if existing is None:
-            new_device_types.append(device_type)
-
-    return new_device_types
-
-
-def _device_type_change_key(manufacturer_slug, model, slug):
-    """Build a canonical change-detection key tuple from individual components."""
-    return manufacturer_slug, model, slug or ""
-
-
-def device_type_key(device_type):
-    """Extract the change-detection key from a parsed device-type dict."""
-    return _device_type_change_key(
-        device_type["manufacturer"]["slug"],
-        device_type["model"],
-        device_type.get("slug", ""),
-    )
-
-
-def change_entry_key(change_entry):
-    """Extract the change-detection key from a DeviceTypeChange entry."""
-    return _device_type_change_key(
-        change_entry.manufacturer_slug,
-        change_entry.model,
-        change_entry.slug,
-    )
-
-
-def filter_device_types_by_change_keys(device_types, change_keys):
-    """Return only those *device_types* whose key is present in *change_keys*.
-
-    Args:
-        device_types (list[dict]): Parsed device-type dicts to filter.
-        change_keys (set): Set of change-detection keys to match against.
-
-    Returns:
-        list[dict]: Subset of device_types whose key appears in change_keys.
-    """
-    if not change_keys:
-        return []
-    return [device_type for device_type in device_types if device_type_key(device_type) in change_keys]
-
-
-def _device_types_with_images_keys(device_types):
-    """Return the set of change-detection keys for device types that declare images in their YAML.
-
-    Used by ``--verify-images`` to ensure image-bearing device types are processed even
-    when the change detector reports them as unchanged (e.g. image exists in the DB but the
-    physical file is gone from the server).
-
-    Args:
-        device_types (list[dict]): All parsed device-type dicts.
-
-    Returns:
-        set: Keys of device types that have ``front_image`` or ``rear_image`` set to True.
-    """
-    return {device_type_key(dt) for dt in device_types if dt.get("front_image") or dt.get("rear_image")}
-
-
-def select_device_types_for_default_mode(device_types, change_report, verify_images=False):
-    """Select device types to process in default (non-update) mode.
-
-    Includes newly discovered device types and existing ones with missing images.
-    When *verify_images* is True, also includes all device types that declare images
-    so their physical presence can be verified.
-
-    Args:
-        device_types (list[dict]): All parsed device-type dicts.
-        change_report (ChangeReport | None): Change detection results; if None returns [].
-        verify_images (bool): When True, include image-bearing device types for physical
-            verification even if no DB-level change is detected.
-
-    Returns:
-        list[dict]: Device types that are new or have missing images.
-    """
-    if not change_report:
-        return []
-
-    new_keys = {change_entry_key(change) for change in change_report.new_device_types}
-    image_change_keys = {
-        change_entry_key(change)
-        for change in change_report.modified_device_types
-        if any(property_change.property_name in IMAGE_PROPERTIES for property_change in change.property_changes)
-    }
-    all_keys = new_keys | image_change_keys
-    if verify_images:
-        all_keys |= _device_types_with_images_keys(device_types)
-    return filter_device_types_by_change_keys(device_types, all_keys)
-
-
-def select_device_types_for_update_mode(device_types, change_report, verify_images=False):
-    """Select device types to process in update (``--update``) mode.
-
-    Includes all new and modified device types.  When *verify_images* is True, also
-    includes device types that declare images so their physical presence can be checked.
-
-    Args:
-        device_types (list[dict]): All parsed device-type dicts.
-        change_report (ChangeReport | None): Change detection results; if None returns [].
-        verify_images (bool): When True, include image-bearing device types for physical
-            verification even if no DB-level change is detected.
-
-    Returns:
-        list[dict]: Device types that are either new or have detected changes.
-    """
-    if not change_report:
-        return []
-
-    actionable_keys = {change_entry_key(change) for change in change_report.new_device_types}
-    actionable_keys.update(change_entry_key(change) for change in change_report.modified_device_types)
-    if verify_images:
-        actionable_keys |= _device_types_with_images_keys(device_types)
-    return filter_device_types_by_change_keys(device_types, actionable_keys)
-
-
-def has_missing_device_images(change_report):
-    """Return True if any modified device type has at least one missing image.
-
-    Args:
-        change_report (ChangeReport | None): Change detection results.
-
-    Returns:
-        bool: True if there is at least one image-related property change; False otherwise.
-    """
-    if not change_report:
-        return False
-    for device_change in change_report.modified_device_types:
-        if any(pc.property_name in IMAGE_PROPERTIES for pc in device_change.property_changes):
-            return True
-    return False
-
-
-def log_run_mode(handle, config):
-    """Log a human-readable summary of the active run-mode flags to *handle*.
-
-    Args:
-        handle (LogHandler): Logging handler used to emit messages.
-        config (RunConfig): inspects ``only_new``, ``update``, and ``remove_components``.
-    """
-    if config.only_new:
-        handle.log("Mode: --only-new enabled; existing device types and components will not be modified.")
-    elif config.update:
-        handle.log("Mode: --update enabled; changed properties and components on existing models will be updated.")
-        if config.remove_components:
-            handle.log("Mode: --remove-components enabled; missing components will be removed from existing models.")
-            if config.remove_unmanaged_types:
-                handle.log(
-                    "Mode: --remove-unmanaged-types enabled; components whose entire YAML section is missing "
-                    "will also be removed from existing models."
-                )
-        else:
-            handle.log(
-                "Mode: will not remove components from existing models; use --remove-components with "
-                "--update to change this."
-            )
-        if config.force_resolve_conflicts:
-            handle.log(
-                "Mode: --force-resolve-conflicts enabled; constraint failures will trigger destructive "
-                "remediation when no live device references the affected type."
-            )
-    else:
-        handle.log("Mode: --update not set; changed properties/components will not be applied (use --update).")
-    if config.verify_images:
-        handle.log(
-            "Mode: --verify-images enabled; images already recorded in NetBox will be verified via HTTP "
-            "and re-uploaded if missing or content has changed."
-        )
-
-
-def should_only_create_new_modules(config):
-    """Return True if module processing should only create new entries and skip updates."""
-    return config.only_new or not config.update
-
-
-def _cache_display(progress, task_registry):
-    """Return the progress sink the component cache reports through.
-
-    The registry keeps the "Caching X" tasks cumulative across vendors, so the
-    display leaves them for :func:`_finalize_task_registry` to close.
-    """
-    if progress is None:
-        return NullTaskDisplay()
-    return RichTaskDisplay(progress, registry=task_registry)
-
-
-@contextmanager
-def _image_progress_scope(progress, device_types, total=0):
-    """Context manager that wires up image-upload progress tracking.
-
-    Creates a progress task (if *progress* is not None and *total* > 0),
-    assigns the advance callback to ``device_types._image_progress``, and
-    always resets it to ``None`` on exit — even on exception.  The task is
-    removed from the progress display on exit so completed upload bars do not
-    accumulate when multiple vendors are processed in sequence.
-
-    Args:
-        progress: Rich Progress instance, or None.
-        device_types: ``DeviceTypes`` helper whose ``_image_progress`` callback is set.
-        total (int): Pre-counted number of images to upload. If 0, no progress bar is shown.
-    """
-    _img_task = None
-    if progress is not None and total > 0:
-        _img_task = progress.add_task("Uploading Images", total=total)
-
-        def _adv_img(count=1):
-            """Advance the image-upload progress task by *count* steps."""
-            progress.update(_img_task, advance=count)
-
-        device_types._image_progress = _adv_img
-    try:
-        yield
-    finally:
-        device_types._image_progress = None
-        if progress is not None and _img_task is not None:
-            progress.stop_task(_img_task)
-            progress.remove_task(_img_task)
-
-
-def _log_import_filters(handle, config):
-    """Log active vendor and slug filter choices to *handle*.
-
-    Args:
-        handle (LogHandler): Logging handler used to emit filter messages.
-        config (RunConfig): inspects ``vendors`` and ``slugs``.
-    """
-    if config.vendors:
-        handle.log(f"Importing vendors: {', '.join(config.vendors)}")
-    if config.slugs:
-        handle.log(f"Filtering by slugs: {', '.join(config.slugs)}")
-
-
-def _process_device_types(
-    config,
-    netbox,
-    handle,
-    progress,
-    device_types,
-    vendor_slug=None,
-    task_registry=None,
-):
-    """Process device types according to the active run mode.
-
-    Handles *only_new*, *update*, and default mode device-type processing,
-    including cache preloading, change detection, and NetBox API calls.
-
-    Args:
-        config (RunConfig): inspects ``only_new``, ``update``, and
-            ``remove_components``.
-        netbox (NetBox): NetBox API wrapper instance.
-        handle (LogHandler): Logging handler used to emit progress messages.
-        progress: Rich Progress instance for progress display, or None.
-        device_types (list[dict]): Parsed device-type dicts to process.
-        vendor_slug (str | None): Manufacturer slug for scoped integrity checks.
-        task_registry (dict | None): Shared cumulative progress task registry.
-    """
-    if config.only_new:
-        new_device_types = filter_new_device_types(
-            device_types,
-            netbox.device_types.existing_device_types,
-            netbox.device_types.existing_device_types_by_slug,
-        )
-        if new_device_types:
-            image_total = netbox.count_device_type_images(new_device_types)
-            with _image_progress_scope(progress, netbox.device_types, total=image_total):
-                netbox.create_device_types(
-                    new_device_types,
-                    progress=get_progress_wrapper(
-                        progress,
-                        new_device_types,
-                        desc="Creating Device Types",
-                        task_registry=task_registry,
-                    ),
-                    only_new=True,
-                )
-        else:
-            handle.verbose_log("No new device types to create.")
-        return
-
-    if not device_types:
-        handle.verbose_log("No device types matched filters.")
-        return
-
-    handle.verbose_log("Caching NetBox data for comparison (concurrent API requests started after parsing)...")
-    netbox.device_types.ensure_components_ready(manufacturer_slug=vendor_slug)
-
-    detector = ChangeDetector(
-        netbox.device_types,
-        handle,
-        remove_unmanaged_types=config.remove_unmanaged_types,
-        verbose=config.verbose,
-    )
-    change_report = detector.detect_changes(
-        device_types,
-        progress=get_progress_wrapper(progress, device_types, desc="Detecting Changes", task_registry=task_registry),
-    )
-    detector.log_change_report(change_report)
-
-    if config.update:
-        device_types_to_process = select_device_types_for_update_mode(
-            device_types, change_report, verify_images=config.verify_images
-        )
-        if device_types_to_process:
-            image_total = netbox.count_device_type_images(device_types_to_process)
-            with _image_progress_scope(progress, netbox.device_types, total=image_total):
-                netbox.create_device_types(
-                    device_types_to_process,
-                    progress=get_progress_wrapper(
-                        progress,
-                        device_types_to_process,
-                        desc="Processing Device Types",
-                        task_registry=task_registry,
-                    ),
-                    only_new=False,
-                    update=True,
-                    change_report=change_report,
-                    remove_components=config.remove_components,
-                )
-        else:
-            handle.verbose_log("No device type changes to process.")
-    else:
-        device_types_to_process = select_device_types_for_default_mode(
-            device_types, change_report, verify_images=config.verify_images
-        )
-        if device_types_to_process:
-            image_total = netbox.count_device_type_images(device_types_to_process)
-            with _image_progress_scope(progress, netbox.device_types, total=image_total):
-                netbox.create_device_types(
-                    device_types_to_process,
-                    progress=get_progress_wrapper(
-                        progress,
-                        device_types_to_process,
-                        desc="Creating Device Types",
-                        task_registry=task_registry,
-                    ),
-                    only_new=True,
-                )
-        else:
-            handle.verbose_log("No new device types or missing images to process.")
-
-
-def _process_module_types(config, netbox, handle, progress, module_types, task_registry=None):
-    """Process module types for a single vendor.
-
-    Args:
-        config (RunConfig): inspects ``only_new``, ``update``, and
-            ``remove_components``.
-        netbox (NetBox): NetBox API wrapper instance.
-        handle (LogHandler): Logging handler used to emit progress messages.
-        progress: Rich Progress instance for progress display, or None.
-        module_types (list[dict]): Pre-parsed module-type dicts for this vendor.
-        task_registry (dict | None): Shared cumulative progress task registry.
-    """
-    if not module_types:
-        return
-
-    handle.verbose_log(f"{len(module_types)} Module-Types Found")
-
-    module_only_new = should_only_create_new_modules(config)
-    existing_module_types = netbox.get_existing_module_types()
-    # Always run full change detection (unless --only-new is explicitly set) so that
-    # modified module types are reported even without --update.
-    module_types_to_process, module_type_existing_images, changed_property_log = netbox.filter_actionable_module_types(
-        module_types,
-        existing_module_types,
-        only_new=config.only_new,
-    )
-
-    new_module_count = len(NetBox.filter_new_module_types(module_types, existing_module_types))
-    # Count modules whose only diff is REMOVED components — they will require
-    # --remove-components to converge.  We count groups that have at least one removed
-    # component change; the advisory is informational so over-counting modules that also
-    # have other changes is fine.
-    pending_removal_modules = 0
-    pending_removal_components = 0
-    for _slug, _model, fields_info, comp_changes in changed_property_log:
-        removed_in_group = [
-            c for c in (comp_changes or []) if getattr(c, "change_type", None) == ChangeType.COMPONENT_REMOVED
-        ]
-        if removed_in_group:
-            pending_removal_modules += 1
-            pending_removal_components += len(removed_in_group)
-
-    module_changed_count = len(changed_property_log)
-    module_unchanged_count = len(module_types) - len(module_types_to_process) if not config.only_new else 0
-
-    has_module_changes = new_module_count > 0 or module_changed_count > 0 or pending_removal_modules > 0
-    if has_module_changes:
-        handle.log("============================================================")
-        handle.log("MODULE TYPE CHANGE DETECTION")
-        handle.log("============================================================")
-        if config.only_new:
-            handle.log(f"New module types: {new_module_count}")
-        else:
-            # Modules with only missing image attachments — handled in default mode, so
-            # they are NOT included in the "modified" count and do NOT trigger the
-            # `--update` hint.
-            image_only_count = max(0, len(module_types_to_process) - new_module_count - module_changed_count)
-            handle.log(f"New module types:       {new_module_count}")
-            handle.log(f"Unchanged module types: {module_unchanged_count}")
-            handle.log(f"Modified module types:  {module_changed_count}")
-            if image_only_count:
-                handle.log(f"Image-only updates:     {image_only_count}")
-            if module_changed_count and not config.update:
-                handle.log("  (Run with --update to apply changes to existing module types)")
-            if pending_removal_modules and not config.remove_components:
-                remove_hint = "--remove-components" if config.update else "--update --remove-components"
-                handle.log(
-                    f"  (Run with {remove_hint} to remove {pending_removal_components} stale "
-                    f"component(s) across {pending_removal_modules} module type(s))"
-                )
-        handle.log("------------------------------------------------------------")
-        netbox.log_module_type_changes(changed_property_log)
-    elif module_unchanged_count:
-        handle.verbose_log(f"No module type changes ({module_unchanged_count} unchanged).")
-
-    if module_types_to_process:
-        module_image_total = netbox.count_module_type_images(
-            module_types_to_process, existing_module_types, module_type_existing_images
-        )
-        with _image_progress_scope(progress, netbox.device_types, total=module_image_total):
-            netbox.create_module_types(
-                module_types_to_process,
-                progress=get_progress_wrapper(
-                    progress,
-                    module_types_to_process,
-                    desc="Processing Module Types",
-                    task_registry=task_registry,
-                ),
-                only_new=module_only_new,
-                all_module_types=existing_module_types,
-                module_type_existing_images=module_type_existing_images,
-                remove_components=config.remove_components,
-            )
-    else:
-        handle.verbose_log("No module type changes to process.")
-
-
-def _process_rack_types(config, netbox, handle, progress, rack_types, task_registry=None):
-    """Process rack types for a single vendor.
-
-    Soft-skips with a warning when the connected NetBox instance is older than 4.1.
-
-    Args:
-        config (RunConfig): inspects ``only_new``.
-        netbox (NetBox): NetBox API wrapper instance.
-        handle (LogHandler): Logging handler used to emit progress messages.
-        progress: Rich Progress instance for progress display, or None.
-        rack_types (list[dict]): Pre-parsed rack-type dicts for this vendor.
-        task_registry (dict | None): Shared cumulative progress task registry.
-    """
-    if not rack_types:
-        return
-
-    if not netbox.rack_types:
-        handle.log("Rack types require NetBox >= 4.1. Skipping rack type import.")
-        return
-
-    handle.verbose_log(f"{len(rack_types)} Rack-Types Found")
-
-    all_rack_types = netbox.get_existing_rack_types()
-    new_count = sum(
-        1
-        for rt in rack_types
-        if all_rack_types.get(rt.get("manufacturer", {}).get("slug", ""), {}).get(rt.get("model")) is None
-    )
-    existing_count = len(rack_types) - new_count
-
-    if new_count == 0:
-        handle.verbose_log(f"No new rack types ({existing_count} unchanged).")
-    else:
-        handle.log("============================================================")
-        handle.log(f"New rack types:       {new_count}")
-        handle.log(f"Existing rack types:  {existing_count}")
-        handle.log("============================================================")
-
-    if rack_types:
-        netbox.create_rack_types(
-            rack_types,
-            progress=get_progress_wrapper(
-                progress,
-                rack_types,
-                desc="Processing Rack Types",
-                task_registry=task_registry,
-            ),
-            only_new=config.only_new,
-            all_rack_types=all_rack_types,
-        )
-
-
-def _log_run_summary(handle, netbox, start_time, dtl_repo=None):
-    """Log the final import summary counters to *handle*.
-
-    Args:
-        handle (LogHandler): Logging handler for output.
-        netbox (NetBox): NetBox API wrapper whose ``counter`` is read.
-        start_time (datetime): Timestamp from the start of the run for elapsed-time reporting.
-        dtl_repo (DTLRepo, optional): Repository helper; if provided, any duplicate
-            ``(manufacturer, model)`` definitions detected during YAML parsing are listed
-            so the user can fix them upstream.
-    """
-    handle.log("---")
-    handle.verbose_log(f"Script took {(datetime.now() - start_time)} to run")
-    handle.log(f"{netbox.counter['added']} device types created")
-    handle.log(f"{netbox.counter['properties_updated']} device types updated")
-    component_updates = netbox.counter.get("device_types_component_updates", 0)
-    if component_updates:
-        handle.log(f"{component_updates} device types had component-only updates")
-    failed = netbox.counter.get("device_types_failed", 0)
-    if failed:
-        handle.log(f"{failed} device types FAILED to update (see error log above)")
-    handle.log(f"{netbox.counter['components_updated']} components updated")
-    handle.log(f"{netbox.counter['components_added']} components added")
-    handle.log(f"{netbox.counter['components_removed']} components removed")
-    handle.verbose_log(f"{netbox.counter['images']} images uploaded")
-    handle.log(f"{netbox.counter['manufacturer']} manufacturers created")
-    if netbox.modules:
-        handle.log(f"{netbox.counter['module_added']} modules created")
-        handle.log(f"{netbox.counter['module_updated']} modules updated")
-        if netbox.counter["module_update_failed"]:
-            handle.log(f"{netbox.counter['module_update_failed']} modules failed to update")
-        if netbox.counter["module_partial_update"]:
-            handle.log(f"{netbox.counter['module_partial_update']} modules partially updated")
-    if netbox.rack_types:
-        handle.log(f"{netbox.counter['rack_type_added']} rack types created")
-        handle.log(f"{netbox.counter['rack_type_updated']} rack types updated")
-
-    # Structured failure / partial-update report (replaces the "see error log
-    # above" hand-wave with itemised per-entity context).
-    failure_lines = netbox.outcomes.render_failure_report()
-    for line in failure_lines:
-        handle.log(line)
-
-    if dtl_repo is not None and dtl_repo.duplicate_definitions:
-        handle.log("---")
-        handle.log(
-            f"WARNING: {len(dtl_repo.duplicate_definitions)} duplicate "
-            "(manufacturer, model) definition(s) detected in the source repository:"
-        )
-        for dup in dtl_repo.duplicate_definitions:
-            handle.log(f"  {dup['manufacturer']}/{dup['model']}")
-            handle.log(f"    kept:    {dup['kept']}")
-            for ignored in dup["ignored"]:
-                handle.log(f"    ignored: {ignored}")
-        handle.log("These duplicates would otherwise oscillate on every run. Please report/fix them upstream.")
-
-
-def _parse_vendor_racks(dtl_repo, racks_path, vendor_name, slugs):
-    """Parse rack-type YAML files for *vendor_name*, returning an empty list when *racks_path* is absent.
-
-    Args:
-        dtl_repo (DTLRepo): Repository helper used for file discovery and parsing.
-        racks_path (str): Base path for rack-type YAML files.
-        vendor_name (str): Vendor directory name to filter files by.
-        slugs (list[str]): Optional rack-type slug filter.
-
-    Returns:
-        list[dict]: Parsed rack-type records (may be empty).
-    """
-    if not os.path.isdir(racks_path):
-        return []
-    rack_files, _ = dtl_repo.get_devices(racks_path, [vendor_name.casefold()])
-    return dtl_repo.parse_files(rack_files, slugs=slugs)
-
-
-def _finalize_task_registry(progress, task_registry):
-    """Resolve unknown totals and stop spinners for all cumulative registry tasks.
-
-    Args:
-        progress: Rich Progress instance, or None.
-        task_registry (dict | None): Mapping of description → task ID.
-    """
-    if not progress or not task_registry:
-        return
-    for task_id in task_registry.values():
-        task = next((t for t in progress.tasks if t.id == task_id), None)
-        if task is None:
-            continue
-        if task.total is None:
-            progress.update(task_id, total=max(task.completed, 0))
-        progress.stop_task(task_id)
-
-
-def _apply_slug_fast_path(dtl_repo, config, vendors_to_process, handle):
-    """Use upstream slug indexes to pre-resolve files and narrow the vendor list.
-
-    When ``config.slugs`` is set and the DTL index files (``known-*.json``, or legacy
-    ``known-*.pickle``) are present, resolves exactly which device-type files match the
-    requested slugs and restricts ``vendors_to_process`` to only those vendors.  Returns a
-    ``(vendors, resolved)`` pair where *resolved* is the dict returned by
-    :meth:`DTLRepo.resolve_slug_files` (or ``None`` when the index is absent/unavailable).
-    """
-    if not config.slugs:
-        return vendors_to_process, None
-
-    slug_resolved = dtl_repo.resolve_slug_files(config.slugs)
-    if slug_resolved is None:
-        handle.verbose_log("Slug index unavailable; falling back to full file scan.")
-        return vendors_to_process, None
-
-    matched_vendor_slugs = (
-        set(slug_resolved["device_files"])
-        | (slug_resolved["module_vendors"] or set())
-        | (slug_resolved["rack_vendors"] or set())
-    )
-    if not matched_vendor_slugs:
-        handle.verbose_log("Slug index returned no matches; falling back to full file scan.")
-        return vendors_to_process, None
-    narrowed = [v for v in vendors_to_process if v["slug"] in matched_vendor_slugs]
-    handle.verbose_log(
-        f"Slug index resolved {sum(len(f) for f in slug_resolved['device_files'].values())} "
-        f"device file(s) across {len(matched_vendor_slugs)} vendor(s)."
-    )
-    return narrowed, slug_resolved
-
-
 def _run_export_diff(config, handle):
-    """Run the export-diff pipeline and return."""
+    """Run the export-diff pipeline."""
     from core.export import Exporter
 
     exporter = Exporter(
@@ -855,130 +126,38 @@ def _run_export_diff(config, handle):
     with get_progress_panel(config.show_remaining_time) as progress:
         if progress is not None:
             handle.set_console(progress.console)
-        exporter.run(progress=progress)
+        try:
+            exporter.run(progress=progress)
+        finally:
+            if progress is not None:
+                handle.set_console(None)
 
 
-def _parse_vendor_types(dtl_repo, netbox, config, vendor, devices_path, modules_path, racks_path, slug_resolved):
-    """Parse device-type, module-type, and rack-type YAML files for a single vendor.
+def _run(config):
+    """Build and execute the selected run pipeline."""
+    started_at = datetime.now()
+    handle = LogHandler(config.verbose)
+    for notice in config.notices:
+        handle.log(notice)
 
-    Returns a 3-tuple: (parsed_device_types, parsed_module_types, parsed_rack_types).
-    """
-    if slug_resolved is not None:
-        device_files = slug_resolved["device_files"].get(vendor["slug"], [])
-        parsed_device_types = dtl_repo.parse_files(device_files) if device_files else []
-    else:
-        device_files, _ = dtl_repo.get_devices(devices_path, [vendor["name"].casefold()])
-        parsed_device_types = dtl_repo.parse_files(device_files, slugs=config.slugs or [])
+    if config.export_diff:
+        _run_export_diff(config, handle)
+        return None
 
-    if netbox.modules:
-        module_hint = slug_resolved["module_vendors"] if slug_resolved is not None else None
-        if module_hint is not None and vendor["slug"] not in module_hint:
-            parsed_module_types = []
-        else:
-            module_files, _ = dtl_repo.get_devices(modules_path, [vendor["name"].casefold()])
-            parsed_module_types = dtl_repo.parse_files(module_files, slugs=config.slugs or [])
-    else:
-        parsed_module_types = []
-
-    if netbox.rack_types:
-        rack_hint = slug_resolved["rack_vendors"] if slug_resolved is not None else None
-        if rack_hint is not None and vendor["slug"] not in rack_hint:
-            parsed_rack_types = []
-        else:
-            parsed_rack_types = _parse_vendor_racks(dtl_repo, racks_path, vendor["name"], config.slugs or [])
-    else:
-        parsed_rack_types = []
-
-    return parsed_device_types, parsed_module_types, parsed_rack_types
-
-
-def _run_vendor_loop(
-    dtl_repo,
-    netbox,
-    config,
-    handle,
-    vendors_to_process,
-    devices_path,
-    modules_path,
-    racks_path,
-    slug_resolved,
-    progress,
-    task_registry,
-    vendor_task_id,
-) -> None:
-    """Process all selected vendors and finalize preload/progress teardown."""
-    cache = netbox.device_types.components
-    try:
-        for vendor in vendors_to_process:
-            parsed_device_types, parsed_module_types, parsed_rack_types = _parse_vendor_types(
-                dtl_repo, netbox, config, vendor, devices_path, modules_path, racks_path, slug_resolved
-            )
-
-            if not parsed_device_types and not parsed_module_types and not parsed_rack_types:
-                if vendor_task_id is not None:
-                    progress.advance(vendor_task_id)
-                continue
-
-            netbox.load_vendor(vendor["slug"])
-
-            if (parsed_device_types or parsed_module_types) and not config.only_new:
-                cache.begin_prefetch(
-                    manufacturer_slug=vendor["slug"],
-                    display=_cache_display(progress, task_registry),
-                )
-
-            handle.verbose_log(f"{len(parsed_device_types)} Device-Types Found")
-            cache.pump()
-            netbox.create_manufacturers([vendor])
-            cache.pump()
-
-            _process_device_types(
-                config,
-                netbox,
-                handle,
-                progress,
-                parsed_device_types,
-                vendor_slug=vendor["slug"],
-                task_registry=task_registry,
-            )
-            cache.pump()
-
-            if netbox.modules:
-                _process_module_types(
-                    config,
-                    netbox,
-                    handle,
-                    progress,
-                    parsed_module_types,
-                    task_registry=task_registry,
-                )
-                cache.pump()
-
-            _process_rack_types(
-                config,
-                netbox,
-                handle,
-                progress,
-                parsed_rack_types,
-                task_registry=task_registry,
-            )
-            cache.pump()
-            cache.close()
-
-            if vendor_task_id is not None:
-                progress.advance(vendor_task_id)
-    finally:
-        cache.close()
-        _finalize_task_registry(progress, task_registry)
-        handle.set_console(None)
+    repo = DTLRepo(config, handle)
+    netbox = NetBox(config, handle)
+    return ImportRun(
+        config,
+        repo,
+        netbox,
+        handle,
+        get_progress_panel,
+        started_at=started_at,
+    ).execute()
 
 
 def main():
-    """Resolve the run configuration, then run against it.
-
-    Connection failures are reported here because the resolved NetBox URL is the
-    one that was actually used, rather than a second reading of the environment.
-    """
+    """Resolve the configuration and execute one run."""
     try:
         config = resolve_run_config()
     except ConfigError as exc:
@@ -1011,87 +190,6 @@ def main():
             file=sys.stderr,
         )
         raise SystemExit(1)
-
-
-def _run(config):
-    """Orchestrate importing device- and module-types from a Git repository into NetBox.
-
-    Clones or pulls the DTL repo, parses YAML files, and creates manufacturers, device
-    types, and module types in NetBox. Reports progress and summary counters.
-    """
-    startTime = datetime.now()
-
-    handle = LogHandler(config.verbose)
-    for notice in config.notices:
-        handle.log(notice)
-
-    if config.export_diff:
-        _run_export_diff(config, handle)
-        return
-
-    dtl_repo = DTLRepo(config, handle)
-
-    netbox = NetBox(config, handle)  # handle passed explicitly
-    netbox.force_resolve_conflicts = config.force_resolve_conflicts
-    netbox.remove_unmanaged_types = config.remove_unmanaged_types
-    netbox.verify_images = config.verify_images
-
-    # Confirm effective run behavior right after compatibility checks.
-    log_run_mode(handle, config)
-    _log_import_filters(handle, config)
-
-    devices_path = dtl_repo.get_devices_path()
-    modules_path = dtl_repo.get_modules_path()
-    racks_path = dtl_repo.get_racks_path()
-
-    # Discover all vendors present in the repo across all three type directories.
-    all_vendors = dtl_repo.discover_vendors(devices_path, modules_path, racks_path)
-
-    # Filter to the requested vendors when --vendor config are provided.
-    if config.vendors:
-        vendor_slug_filter = {v.lower() for v in config.vendors}
-        vendors_to_process = [v for v in all_vendors if v["slug"] in vendor_slug_filter]
-        if not vendors_to_process:
-            handle.log(
-                f"No vendors matched --vendors: {', '.join(config.vendors)}. "
-                f"Available: {', '.join(v['slug'] for v in all_vendors[:10])}"
-                f"{'...' if len(all_vendors) > 10 else ''}"
-            )
-            raise SystemExit(1)
-    else:
-        vendors_to_process = all_vendors
-
-    vendors_to_process, slug_resolved = _apply_slug_fast_path(dtl_repo, config, vendors_to_process, handle)
-
-    if config.vendors and not vendors_to_process:
-        handle.log(f"No vendors matched the combination of --vendors and --slugs: {', '.join(config.vendors)}")
-        raise SystemExit(1)
-
-    with get_progress_panel(config.show_remaining_time) as progress:
-        if progress is not None:
-            handle.set_console(progress.console)
-        # Shared task registry for cumulative progress bars across all vendors.
-        task_registry = {} if progress is not None else None
-        vendor_task_id = None
-        if progress is not None and vendors_to_process:
-            _vdesc = "Vendors".ljust(_PROGRESS_DESC_WIDTH)
-            vendor_task_id = progress.add_task(_vdesc, total=len(vendors_to_process))
-        _run_vendor_loop(
-            dtl_repo=dtl_repo,
-            netbox=netbox,
-            config=config,
-            handle=handle,
-            vendors_to_process=vendors_to_process,
-            devices_path=devices_path,
-            modules_path=modules_path,
-            racks_path=racks_path,
-            slug_resolved=slug_resolved,
-            progress=progress,
-            task_registry=task_registry,
-            vendor_task_id=vendor_task_id,
-        )
-
-    _log_run_summary(handle, netbox, startTime, dtl_repo=dtl_repo)
 
 
 if __name__ == "__main__":

--- a/tests/test_change_detector.py
+++ b/tests/test_change_detector.py
@@ -255,8 +255,7 @@ class TestLogChangeReport:
         dt_instance.existing_device_types_by_slug = {}
         dt_instance.components = _cache()
         handle = MagicMock()
-        handle.args = SimpleNamespace(verbose=verbose)
-        return ChangeDetector(dt_instance, handle)
+        return ChangeDetector(dt_instance, handle, verbose=verbose)
 
     def test_empty_report_logs_nothing(self):
         """An all-zero report (no new, no modified, no unchanged) should be silent."""
@@ -602,7 +601,6 @@ class TestLogChangeReportNoModified:
 
     def test_logs_zero_modified_when_only_new_types_exist(self):
         handle = MagicMock()
-        handle.args.verbose = False
         detector = ChangeDetector(MagicMock(), handle)
         report = ChangeReport(new_device_types=[DeviceTypeChange("cisco", "X", "x", is_new=True)])
 
@@ -610,6 +608,26 @@ class TestLogChangeReportNoModified:
 
         logged = [call.args[0] for call in handle.log.call_args_list]
         assert "Modified device types: 0" in logged
+
+    def test_non_verbose_hint_uses_the_explicit_flag(self):
+        from core.log_handler import LogHandler
+
+        messages = []
+
+        class RecordingConsole:
+            """Record messages emitted by a real log handler."""
+
+            def print(self, message, markup=False):
+                messages.append((message, markup))
+
+        handle = LogHandler(False)
+        handle.set_console(RecordingConsole())
+        detector = ChangeDetector(MagicMock(), handle, verbose=False)
+        report = ChangeReport(modified_device_types=[DeviceTypeChange("cisco", "X", "x")])
+
+        detector.log_change_report(report)
+
+        assert any("use --verbose" in message for message, _markup in messages)
 
 
 class TestCompareDeviceTypePropertiesMissingAttribute:

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -633,31 +633,6 @@ class TestFetching:
 
         assert isinstance(cache.entries("front_port_templates", "device", 1)["fp0"], Wrapped)
 
-    def test_a_rest_only_endpoint_is_read_over_rest(self, monkeypatch):
-        import core.component_cache as module
-
-        monkeypatch.setattr(module, "REST_ONLY_ENDPOINTS", frozenset({"interface_templates"}))
-        endpoint = FakeEndpoint([Record("eth0", device_type=1)])
-        netbox = FakeNetBox({"interface_templates": endpoint})
-        graphql = FakeGraphQL()
-        cache = make_cache(netbox=netbox, graphql=graphql)
-
-        cache.ensure_ready()
-
-        assert set(cache.entries("interface_templates", "device", 1)) == {"eth0"}
-        assert "interface_templates" not in graphql.endpoints_seen
-
-    def test_a_rest_only_endpoint_with_no_records_reports_no_progress(self, monkeypatch):
-        import core.component_cache as module
-
-        monkeypatch.setattr(module, "REST_ONLY_ENDPOINTS", frozenset({"interface_templates"}))
-        netbox = FakeNetBox({"interface_templates": FakeEndpoint([])})
-        cache = make_cache(netbox=netbox)
-
-        cache.ensure_ready()
-
-        assert cache.ready is True
-
     def test_records_arrive_unwrapped_when_no_wrapper_is_given(self):
         graphql = FakeGraphQL({"front_port_templates": [Record("fp0", device_type=1)]})
         cache = make_cache(graphql=graphql)
@@ -768,13 +743,3 @@ class TestVendorGuards:
 
         chunks = [call["device_type_id"] for call in cache.netbox.endpoints["interface_templates"].count_calls]
         assert [len(chunk) for chunk in chunks] == [100, 100, 50]
-
-    def test_a_rest_only_endpoint_is_not_compared_with_itself(self, monkeypatch):
-        import core.component_cache as module
-
-        monkeypatch.setattr(module, "REST_ONLY_ENDPOINTS", frozenset({"interface_templates"}))
-        cache = self._cache_for({}, counts={"interface_templates": 99})
-
-        cache.ensure_ready(manufacturer_slug="cisco", device_type_ids={1})
-
-        assert cache.netbox.endpoints["interface_templates"].count_calls == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-from core.config import resolve_run_config
+from core.config import EnvironmentVariableError, resolve_run_config
 
 _ROOT = pathlib.Path(__file__).resolve().parent.parent
 _ENTRY = _ROOT / "nb-dt-import.py"
@@ -60,6 +60,24 @@ class TestOptionalVariablesUseTheirDefault:
         result = _run_cli("--export-diff", REPO_URL="")
 
         assert 'Environment variable "REPO_URL" is not set' not in result.stdout + result.stderr
+
+
+class TestRequiredVariables:
+    """Required environment values fail with a typed configuration error."""
+
+    def test_one_missing_variable_uses_the_catalogue_error(self):
+        with pytest.raises(EnvironmentVariableError, match='Environment variable "NETBOX_TOKEN" is not set.'):
+            resolve_run_config(argv=[], env={"NETBOX_URL": "http://netbox.local"})
+
+    def test_all_missing_variables_use_one_typed_error(self):
+        with pytest.raises(EnvironmentVariableError) as exc_info:
+            resolve_run_config(argv=[], env={})
+
+        assert str(exc_info.value) == (
+            'Environment variable "NETBOX_URL" is not set.\n'
+            'Environment variable "NETBOX_TOKEN" is not set.\n\n'
+            "Required: NETBOX_URL, NETBOX_TOKEN"
+        )
 
 
 class TestRepoPathHasOneResolution:

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,51 @@
+"""Tests for the fatal error catalogue."""
+
+import pytest
+
+from core.config import EnvironmentVariableError
+from core.errors import UnknownError
+from core.netbox_api import SSLVerificationError
+from core.repo import (
+    GitBranchNotFoundError,
+    GitCommandError,
+    GitInvalidRepositoryError,
+    InvalidGitURLError,
+    InvalidRepoPathError,
+)
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        (
+            EnvironmentVariableError("NETBOX_URL"),
+            'Environment variable "NETBOX_URL" is not set.\n\nRequired: NETBOX_URL, NETBOX_TOKEN',
+        ),
+        (
+            SSLVerificationError(False),
+            "SSL verification failed. IGNORE_SSL_ERRORS is False. "
+            "Set IGNORE_SSL_ERRORS to True if you want to ignore this error. EXITING.",
+        ),
+        (GitCommandError("my-repo"), 'Git error for repo "my-repo".'),
+        (GitInvalidRepositoryError("my-repo"), 'The repo "my-repo" is not a valid git repo.'),
+        (
+            GitBranchNotFoundError("release"),
+            'Branch "release" was not found in the remote repository. Check your REPO_BRANCH setting.',
+        ),
+        (
+            InvalidGitURLError("ftp://invalid.example/repo.git"),
+            "Invalid Git URL: ftp://invalid.example/repo.git. URL must use HTTPS, SSH, or file protocol.",
+        ),
+        (InvalidRepoPathError("bad-path"), 'Invalid repository path "bad-path".'),
+        (UnknownError("something bad"), 'An unknown error occurred: "something bad"'),
+    ],
+)
+def test_fatal_error_messages_match_the_old_catalogue(error, message):
+    assert str(error) == message
+
+
+def test_unknown_error_preserves_the_catalogue_message_and_trace():
+    error = UnknownError("Git Repository Error", stack_trace="trace detail")
+
+    assert str(error) == 'An unknown error occurred: "Git Repository Error"'
+    assert error.stack_trace == "trace detail"

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -19,6 +19,7 @@ from core.export import (
     _yaml_equal,
     _SKIP,
 )
+from core.log_handler import LogHandler
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -365,6 +366,13 @@ class TestExporterHonoursTheConfiguredPageSize:
         exporter = Exporter(settings, _make_handle(), str(tmp_path / "extra"), False, None)
 
         assert exporter.graphql.DEFAULT_PAGE_SIZE == 250
+
+    def test_the_graphql_client_uses_the_exporter_reporter(self, tmp_path):
+        handle = LogHandler(False)
+
+        exporter = Exporter(_make_settings(tmp_path), handle, str(tmp_path / "extra"), False, None)
+
+        assert exporter.graphql._handle is handle
 
 
 class TestExporterRequiresTheLibrary:

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -106,6 +106,15 @@ class TestDotDict:
 class TestNetBoxGraphQLClient:
     """Tests for NetBoxGraphQLClient initialization and configuration."""
 
+    def test_logging_dependency_uses_the_common_handle_name(self):
+        from core.graphql_client import NetBoxGraphQLClient
+        from core.log_handler import LogHandler
+
+        handle = LogHandler(False)
+        client = NetBoxGraphQLClient("http://netbox.local", "tok", handle=handle)
+
+        assert client._handle is handle
+
     def test_init_stores_config(self):
         from core.graphql_client import NetBoxGraphQLClient
 
@@ -381,7 +390,7 @@ class TestGraphQLQueryAll:
 
         from core.graphql_client import NetBoxGraphQLClient
 
-        client = NetBoxGraphQLClient("http://netbox.local", "tok", log_handler=FakeLog())
+        client = NetBoxGraphQLClient("http://netbox.local", "tok", handle=FakeLog())
         result = client.query_all(
             "query($p: OffsetPaginationInput) { device_type_list(pagination: $p) { id } }",
             list_key="device_type_list",
@@ -421,7 +430,7 @@ class TestGraphQLQueryAll:
 
         from core.graphql_client import NetBoxGraphQLClient
 
-        client = NetBoxGraphQLClient("http://netbox.local", "tok", log_handler=FakeLog())
+        client = NetBoxGraphQLClient("http://netbox.local", "tok", handle=FakeLog())
         client.query_all(
             "query($p: OffsetPaginationInput) { device_type_list(pagination: $p) { id } }",
             list_key="device_type_list",
@@ -1269,10 +1278,10 @@ class TestQueryAllOnPage:
 
 
 class TestQueryAllClampingPrintFallback:
-    """Tests for the print() fallback in query_all when no log_handler is set."""
+    """Tests for the print() fallback in query_all when no handle is set."""
 
-    def test_clamping_warning_uses_print_when_no_log_handler(self, mock_post, capsys):
-        """When log_handler is None the clamping warning goes to stdout via print()."""
+    def test_clamping_warning_uses_print_when_no_handle(self, mock_post, capsys):
+        """When handle is None the clamping warning goes to stdout via print()."""
         pages = [
             [{"id": "1"}, {"id": "2"}],
             [{"id": "3"}, {"id": "4"}],
@@ -1289,7 +1298,7 @@ class TestQueryAllClampingPrintFallback:
 
         from core.graphql_client import NetBoxGraphQLClient
 
-        client = NetBoxGraphQLClient("http://netbox.local", "tok")  # no log_handler
+        client = NetBoxGraphQLClient("http://netbox.local", "tok")
         result = client.query_all(
             "query($p: OffsetPaginationInput) { device_type_list(pagination: $p) { id } }",
             list_key="device_type_list",

--- a/tests/test_import_run.py
+++ b/tests/test_import_run.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 
 import pytest
 
+from core.errors import VendorSelectionError
 from core.import_run import ImportRun, RunSummary, VendorPlan, _process_device_types
 from core.log_handler import LogHandler
 
@@ -202,6 +203,42 @@ def test_empty_device_types_return_before_cache_readiness(make_config):
         [],
         vendor_slug="vendor-one",
     )
+
+
+def test_discover_raises_a_typed_fatal_error_when_no_vendor_matches(make_config, tmp_path):
+    repo = _RepositoryBoundary(tmp_path)
+    run = ImportRun(
+        make_config(vendors=("missing-vendor",)),
+        repo,
+        _NetBoxBoundary(),
+        LogHandler(False),
+        _ProgressFactory(),
+    )
+
+    with pytest.raises(VendorSelectionError, match="No vendors matched --vendors"):
+        run.discover()
+
+
+def test_discover_raises_a_typed_fatal_error_when_slug_selection_removes_the_vendor(make_config, tmp_path):
+    class SlugResolvedRepository(_RepositoryBoundary):
+        def resolve_slug_files(self, _slugs):
+            return {
+                "device_files": {"other-vendor": []},
+                "module_vendors": set(),
+                "rack_vendors": set(),
+            }
+
+    repo = SlugResolvedRepository(tmp_path)
+    run = ImportRun(
+        make_config(vendors=("vendor-one",), slugs=("missing-slug",)),
+        repo,
+        _NetBoxBoundary(),
+        LogHandler(False),
+        _ProgressFactory(),
+    )
+
+    with pytest.raises(VendorSelectionError, match="combination of --vendors and --slugs"):
+        run.discover()
 
 
 def test_execute_returns_snapshot_and_owns_console_lifecycle(make_config, tmp_path):

--- a/tests/test_import_run.py
+++ b/tests/test_import_run.py
@@ -1,0 +1,242 @@
+"""Tests for the import pipeline interface."""
+
+from collections import Counter
+from contextlib import contextmanager
+
+import pytest
+
+from core.import_run import ImportRun, RunSummary, VendorPlan, _process_device_types
+from core.log_handler import LogHandler
+
+
+class _ComponentCache:
+    """Record cache cleanup without providing import behavior."""
+
+    def __init__(self):
+        self.close_count = 0
+
+    def close(self):
+        """Record one cache close."""
+        self.close_count += 1
+
+
+class _DeviceTypes:
+    """Provide the component cache used by pipeline cleanup."""
+
+    def __init__(self):
+        self.components = _ComponentCache()
+
+
+class _Outcomes:
+    """Provide an empty final failure report."""
+
+    @staticmethod
+    def render_failure_report():
+        """Return no failure lines."""
+        return []
+
+
+class _NetBoxBoundary:
+    """Expose run state and fail if planning starts an import."""
+
+    def __init__(self):
+        self.modules = True
+        self.rack_types = True
+        self.device_types = _DeviceTypes()
+        self.outcomes = _Outcomes()
+        self.counter = Counter(
+            added=2,
+            properties_updated=1,
+            components_updated=3,
+            components_added=4,
+            components_removed=5,
+            images=6,
+            manufacturer=1,
+            module_added=7,
+            module_updated=8,
+            module_update_failed=0,
+            module_partial_update=0,
+            rack_type_added=9,
+            rack_type_updated=10,
+            device_types_failed=0,
+        )
+        self.import_started = False
+
+    def load_vendor(self, _vendor_slug):
+        """Fail when a planning-only test starts the import."""
+        self.import_started = True
+        raise AssertionError("planning started the import")
+
+
+class _RepositoryBoundary:
+    """Return fixed source data for pipeline tests."""
+
+    def __init__(self, root, *, vendors=None):
+        self.devices_path = root / "device-types"
+        self.modules_path = root / "module-types"
+        self.racks_path = root / "rack-types"
+        self.devices_path.mkdir()
+        self.modules_path.mkdir()
+        self.racks_path.mkdir()
+        self.vendors = vendors if vendors is not None else [{"name": "Vendor One", "slug": "vendor-one"}]
+        self.duplicate_definitions = []
+
+    def get_devices_path(self):
+        """Return the device-type source path."""
+        return str(self.devices_path)
+
+    def get_modules_path(self):
+        """Return the module-type source path."""
+        return str(self.modules_path)
+
+    def get_racks_path(self):
+        """Return the rack-type source path."""
+        return str(self.racks_path)
+
+    def discover_vendors(self, _devices_path, _modules_path, _racks_path):
+        """Return the configured vendors."""
+        return self.vendors
+
+    @staticmethod
+    def resolve_slug_files(_slugs):
+        """Force the pipeline to use its full file scan."""
+        return None
+
+    @staticmethod
+    def get_devices(path, vendors):
+        """Return one source file for each type directory."""
+        return ([f"{path}/{vendors[0]}.yaml"], [])
+
+    @staticmethod
+    def parse_files(files, slugs=None):
+        """Return one parsed type identified by its source directory."""
+        path = files[0]
+        if "device-types" in path:
+            return [{"manufacturer": {"slug": "vendor-one"}, "model": "Device One", "slug": "device-one"}]
+        if "module-types" in path:
+            return [{"manufacturer": {"slug": "vendor-one"}, "model": "Module One", "slug": "module-one"}]
+        return [{"manufacturer": {"slug": "vendor-one"}, "model": "Rack One", "slug": "rack-one"}]
+
+
+class _Progress:
+    """Provide the progress shape used by an empty run."""
+
+    def __init__(self):
+        self.console = object()
+        self.tasks = []
+
+
+class _ProgressFactory:
+    """Record entry and exit of the progress context."""
+
+    def __init__(self):
+        self.entered = False
+        self.exited = False
+
+    @contextmanager
+    def __call__(self, _show_remaining_time):
+        """Yield one progress object and record complete cleanup."""
+        self.entered = True
+        try:
+            yield _Progress()
+        finally:
+            self.exited = True
+
+
+class _FailingProgress(_Progress):
+    """Fail while the run creates its vendor task."""
+
+    @staticmethod
+    def add_task(_description, total):
+        """Raise a progress setup error."""
+        raise RuntimeError(f"cannot track {total} vendor")
+
+
+class _FailingProgressFactory(_ProgressFactory):
+    """Yield a progress object that fails during setup."""
+
+    @contextmanager
+    def __call__(self, _show_remaining_time):
+        """Yield failing progress and record context cleanup."""
+        self.entered = True
+        try:
+            yield _FailingProgress()
+        finally:
+            self.exited = True
+
+
+def test_plan_vendor_returns_inspectable_work_without_applying_it(make_config, tmp_path):
+    """Planning returns parsed work and does not call the NetBox import API."""
+    repo = _RepositoryBoundary(tmp_path)
+    netbox = _NetBoxBoundary()
+    run = ImportRun(make_config(), repo, netbox, LogHandler(False), _ProgressFactory())
+
+    selection = run.discover()
+    plan = run.plan_vendor(selection, selection.vendors[0])
+
+    assert isinstance(plan, VendorPlan)
+    assert plan.vendor == {"name": "Vendor One", "slug": "vendor-one"}
+    assert [item["slug"] for item in plan.device_types] == ["device-one"]
+    assert [item["slug"] for item in plan.module_types] == ["module-one"]
+    assert [item["slug"] for item in plan.rack_types] == ["rack-one"]
+    assert plan.prefetch_components is True
+    assert netbox.import_started is False
+
+
+def test_empty_device_types_return_before_cache_readiness(make_config):
+    class DeviceTypes:
+        @staticmethod
+        def ensure_components_ready(manufacturer_slug=None):
+            raise AssertionError(f"empty input populated the cache for {manufacturer_slug}")
+
+    class NetBoxBoundary:
+        device_types = DeviceTypes()
+
+    handle = LogHandler(False)
+
+    _process_device_types(
+        make_config(only_new=False),
+        NetBoxBoundary(),
+        handle,
+        None,
+        [],
+        vendor_slug="vendor-one",
+    )
+
+
+def test_execute_returns_snapshot_and_owns_console_lifecycle(make_config, tmp_path):
+    """Execution returns a summary and releases the console and component cache."""
+    repo = _RepositoryBoundary(tmp_path, vendors=[])
+    netbox = _NetBoxBoundary()
+    handle = LogHandler(False)
+    progress_factory = _ProgressFactory()
+    run = ImportRun(make_config(), repo, netbox, handle, progress_factory)
+
+    summary = run.execute()
+
+    assert isinstance(summary, RunSummary)
+    assert summary.counter["added"] == 2
+    assert summary.modules is True
+    assert summary.rack_types is True
+    assert progress_factory.entered is True
+    assert progress_factory.exited is True
+    assert handle.console is None
+    assert netbox.device_types.components.close_count == 1
+    netbox.counter["added"] = 99
+    assert summary.counter["added"] == 2
+
+
+def test_execute_releases_console_when_progress_setup_fails(make_config, tmp_path):
+    """Progress setup errors do not leave the reporter attached to its console."""
+    repo = _RepositoryBoundary(tmp_path)
+    netbox = _NetBoxBoundary()
+    handle = LogHandler(False)
+    progress_factory = _FailingProgressFactory()
+    run = ImportRun(make_config(), repo, netbox, handle, progress_factory)
+
+    with pytest.raises(RuntimeError, match="cannot track 1 vendor"):
+        run.execute()
+
+    assert progress_factory.exited is True
+    assert handle.console is None
+    assert netbox.device_types.components.close_count == 1

--- a/tests/test_log_handler.py
+++ b/tests/test_log_handler.py
@@ -1,62 +1,35 @@
-import pytest
 from types import SimpleNamespace
+from inspect import signature
 from unittest.mock import MagicMock, patch
 
 from core.log_handler import LogHandler
+from core.graphql_client import NetBoxGraphQLClient
+from core.netbox_api import DeviceTypes, NetBox
+from core.repo import DTLRepo
 
 
-class TestException:
-    """Tests for LogHandler.exception() error handling and SystemExit behaviour."""
+class TestConfiguration:
+    """Tests for the sink's explicit verbose flag."""
 
-    def test_environment_error_exits(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        with pytest.raises(SystemExit) as exc_info:
-            handle.exception("EnvironmentError", "NETBOX_URL")
-        assert "NETBOX_URL" in str(exc_info.value)
+    def test_constructor_takes_a_plain_verbose_flag(self):
+        handle = LogHandler(True)
 
-    def test_ssl_error_exits(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        with pytest.raises(SystemExit):
-            handle.exception("SSLError", "False")
+        assert handle.verbose is True
+        assert not hasattr(handle, "args")
+        assert not hasattr(handle, "exception")
 
-    def test_git_command_error_exits(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        with pytest.raises(SystemExit):
-            handle.exception("GitCommandError", "my-repo")
-
-    def test_git_invalid_repo_exits(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        with pytest.raises(SystemExit):
-            handle.exception("GitInvalidRepositoryError", "my-repo")
-
-    def test_invalid_git_url_exits(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        with pytest.raises(SystemExit):
-            handle.exception("InvalidGitURL", "ftp://bad")
-
-    def test_generic_exception_exits(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        with pytest.raises(SystemExit):
-            handle.exception("Exception", "something bad")
-
-    def test_verbose_prints_stack_trace(self):
-        handle = LogHandler(SimpleNamespace(verbose=True))
-        with patch("builtins.print") as mock_print, pytest.raises(SystemExit):
-            handle.exception("Exception", "err", stack_trace="Traceback...")
-        mock_print.assert_called_once_with("Traceback...")
-
-    def test_verbose_false_does_not_print_stack_trace(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        with patch("builtins.print") as mock_print, pytest.raises(SystemExit):
-            handle.exception("Exception", "err", stack_trace="Traceback...")
-        mock_print.assert_not_called()
+    def test_consumers_use_one_parameter_name_for_the_sink(self):
+        assert list(signature(DTLRepo).parameters)[1] == "handle"
+        assert list(signature(NetBox).parameters)[1] == "handle"
+        assert list(signature(DeviceTypes).parameters)[1] == "handle"
+        assert "handle" in signature(NetBoxGraphQLClient).parameters
 
 
 class TestSetConsole:
     """Tests for TestSetConsole."""
 
     def test_set_console_stores_instance(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
+        handle = LogHandler(False)
         console = MagicMock()
         handle.set_console(console)
         assert handle.console is console
@@ -66,7 +39,7 @@ class TestEmit:
     """Tests for TestEmit."""
 
     def test_emit_uses_console_print_when_set(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
+        handle = LogHandler(False)
         console = MagicMock()
         handle.console = console
         with patch.object(handle, "_timestamp", return_value="00:00:00"):
@@ -74,7 +47,7 @@ class TestEmit:
         console.print.assert_called_once_with("[00:00:00] test message", markup=False)
 
     def test_emit_uses_builtin_print_when_no_console(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
+        handle = LogHandler(False)
         with (
             patch.object(handle, "_timestamp", return_value="00:00:00"),
             patch("builtins.print") as mock_print,
@@ -83,7 +56,7 @@ class TestEmit:
         mock_print.assert_called_once_with("[00:00:00] test message")
 
     def test_emit_defers_when_in_progress_group(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
+        handle = LogHandler(False)
         handle.start_progress_group()
         console = MagicMock()
         handle.console = console
@@ -92,7 +65,7 @@ class TestEmit:
         console.print.assert_not_called()
 
     def test_end_progress_group_uses_console(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
+        handle = LogHandler(False)
         console = MagicMock()
         handle.console = console
         handle.start_progress_group()
@@ -106,7 +79,7 @@ class TestEndProgressGroupEdgeCases:
     """Tests for TestEndProgressGroupEdgeCases."""
 
     def test_end_at_zero_depth_is_noop(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
+        handle = LogHandler(False)
         handle.end_progress_group()
         assert handle._defer_depth == 0
 
@@ -115,7 +88,7 @@ class TestVerboseLog:
     """Tests for TestVerboseLog."""
 
     def test_verbose_logs_when_enabled(self):
-        handle = LogHandler(SimpleNamespace(verbose=True))
+        handle = LogHandler(True)
         with (
             patch.object(handle, "_timestamp", return_value="00:00:00"),
             patch("builtins.print") as mock_print,
@@ -124,61 +97,35 @@ class TestVerboseLog:
         mock_print.assert_called_once_with("[00:00:00] verbose message")
 
     def test_verbose_does_not_log_when_disabled(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
+        handle = LogHandler(False)
         with patch("builtins.print") as mock_print:
             handle.verbose_log("should not appear")
         mock_print.assert_not_called()
 
 
-class TestLogDevicePortsCreated:
-    """Tests for TestLogDevicePortsCreated."""
+class TestLogPortsCreated:
+    """Tests for logging created ports for either parent type."""
 
-    def test_returns_count(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        ports = []
-        for i in range(2):
-            # No `type` attr → exercises the `hasattr(port, 'type')` else-branch.
-            p = SimpleNamespace(name=f"port{i}", device_type=SimpleNamespace(id=1), id=i)
-            ports.append(p)
-        result = handle.log_device_ports_created(ports, "Interface")
-        assert result == 2
-
-    def test_returns_zero_for_none(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        assert handle.log_device_ports_created(None) == 0
-
-    def test_verbose_logs_each_port(self):
-        handle = LogHandler(SimpleNamespace(verbose=True))
+    def test_device_port_logging_does_not_return_a_count(self):
+        handle = LogHandler(True)
         port = SimpleNamespace(name="eth0", type="virtual", device_type=SimpleNamespace(id=5), id=10)
         with patch.object(handle, "_emit") as mock_emit:
-            handle.log_device_ports_created([port], "Interface")
-        assert mock_emit.called
+            result = handle.log_ports_created([port], "device", "Interface")
 
+        assert result is None
+        mock_emit.assert_called_once()
 
-class TestLogModulePortsCreated:
-    """Tests for TestLogModulePortsCreated."""
-
-    def test_returns_count(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        # No `type` attr → exercises the `hasattr(port, 'type')` else-branch.
-        port = SimpleNamespace(name="port", module_type=SimpleNamespace(id=1), id=1)
-        result = handle.log_module_ports_created([port], "Interface")
-        assert result == 1
-
-    def test_returns_zero_for_none(self):
-        handle = LogHandler(SimpleNamespace(verbose=False))
-        assert handle.log_module_ports_created(None) == 0
-
-    def test_verbose_logs_each_port(self):
-        handle = LogHandler(SimpleNamespace(verbose=True))
+    def test_module_port_logging_uses_the_module_parent(self):
+        handle = LogHandler(True)
         port = SimpleNamespace(name="xe-0/0/0", type="10gbase-x-sfpp", module_type=SimpleNamespace(id=3), id=7)
         with patch.object(handle, "_emit") as mock_emit:
-            handle.log_module_ports_created([port], "Interface")
-        assert mock_emit.called
+            handle.log_ports_created([port], "module", "Interface")
+
+        assert " - 3 - 7" in mock_emit.call_args.args[0]
 
 
 def test_progress_group_buffers_logs_until_end():
-    handle = LogHandler(SimpleNamespace(verbose=False))
+    handle = LogHandler(False)
 
     with (
         patch.object(handle, "_timestamp", return_value="12:00:00"),
@@ -194,7 +141,7 @@ def test_progress_group_buffers_logs_until_end():
 
 
 def test_progress_group_supports_nested_blocks():
-    handle = LogHandler(SimpleNamespace(verbose=False))
+    handle = LogHandler(False)
 
     with (
         patch.object(handle, "_timestamp", return_value="12:00:00"),

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core import config as config_module
+from core import import_run as import_run_module
 
 
 def _dt_sort_key(d):
@@ -43,7 +44,7 @@ def test_log_run_mode_reports_default_non_update_behavior(nb_dt_import):
         verify_images=False,
     )
 
-    nb_dt_import.log_run_mode(handle, args)
+    import_run_module.log_run_mode(handle, args)
 
     messages = [call.args[0] for call in handle.log.call_args_list]
     assert any("--update not set" in message for message in messages)
@@ -62,7 +63,7 @@ def test_log_run_mode_reports_update_and_remove_enabled(nb_dt_import):
         verify_images=False,
     )
 
-    nb_dt_import.log_run_mode(handle, args)
+    import_run_module.log_run_mode(handle, args)
 
     messages = [call.args[0] for call in handle.log.call_args_list]
     assert any("--update enabled" in message for message in messages)
@@ -80,7 +81,7 @@ def test_log_run_mode_reports_update_without_remove_components(nb_dt_import):
         verify_images=False,
     )
 
-    nb_dt_import.log_run_mode(handle, args)
+    import_run_module.log_run_mode(handle, args)
 
     messages = [call.args[0] for call in handle.log.call_args_list]
     assert any("--update enabled" in message for message in messages)
@@ -98,7 +99,7 @@ def test_log_run_mode_reports_only_new_enabled(nb_dt_import):
         verify_images=False,
     )
 
-    nb_dt_import.log_run_mode(handle, args)
+    import_run_module.log_run_mode(handle, args)
 
     messages = [call.args[0] for call in handle.log.call_args_list]
     assert any("--only-new enabled" in message for message in messages)
@@ -106,17 +107,17 @@ def test_log_run_mode_reports_only_new_enabled(nb_dt_import):
 
 def test_should_only_create_new_modules_default_mode(nb_dt_import):
     args = SimpleNamespace(only_new=False, update=False)
-    assert nb_dt_import.should_only_create_new_modules(args)
+    assert import_run_module.should_only_create_new_modules(args)
 
 
 def test_should_only_create_new_modules_update_mode(nb_dt_import):
     args = SimpleNamespace(only_new=False, update=True)
-    assert not nb_dt_import.should_only_create_new_modules(args)
+    assert not import_run_module.should_only_create_new_modules(args)
 
 
 def test_should_only_create_new_modules_only_new_flag(nb_dt_import):
     args = SimpleNamespace(only_new=True, update=True)
-    assert nb_dt_import.should_only_create_new_modules(args)
+    assert import_run_module.should_only_create_new_modules(args)
 
 
 def test_filter_new_device_types_by_model_and_slug(nb_dt_import):
@@ -129,7 +130,7 @@ def test_filter_new_device_types_by_model_and_slug(nb_dt_import):
     existing_by_model = {("cisco", "A"): object()}
     existing_by_slug = {("juniper", "c-renamed"): object()}
 
-    filtered = nb_dt_import.filter_new_device_types(device_types, existing_by_model, existing_by_slug)
+    filtered = import_run_module.filter_new_device_types(device_types, existing_by_model, existing_by_slug)
 
     assert filtered == [{"manufacturer": {"slug": "cisco"}, "model": "B", "slug": "b"}]
 
@@ -145,7 +146,7 @@ def test_has_missing_device_images_detects_image_changes(nb_dt_import):
         ]
     )
 
-    assert nb_dt_import.has_missing_device_images(report)
+    assert import_run_module.has_missing_device_images(report)
 
 
 def test_has_missing_device_images_detects_rear_image_changes(nb_dt_import):
@@ -156,11 +157,11 @@ def test_has_missing_device_images_detects_rear_image_changes(nb_dt_import):
         ]
     )
 
-    assert nb_dt_import.has_missing_device_images(report)
+    assert import_run_module.has_missing_device_images(report)
 
 
 def test_has_missing_device_images_returns_false_for_none_report(nb_dt_import):
-    assert not nb_dt_import.has_missing_device_images(None)
+    assert not import_run_module.has_missing_device_images(None)
 
 
 def test_has_missing_device_images_returns_false_when_no_image_changes(nb_dt_import):
@@ -171,7 +172,7 @@ def test_has_missing_device_images_returns_false_when_no_image_changes(nb_dt_imp
         ]
     )
 
-    assert not nb_dt_import.has_missing_device_images(report)
+    assert not import_run_module.has_missing_device_images(report)
 
 
 def test_select_device_types_for_default_mode_scopes_to_new_and_missing_images(
@@ -202,7 +203,7 @@ def test_select_device_types_for_default_mode_scopes_to_new_and_missing_images(
         ],
     )
 
-    selected = nb_dt_import.select_device_types_for_default_mode(device_types, change_report)
+    selected = import_run_module.select_device_types_for_default_mode(device_types, change_report)
 
     expected = [
         {"manufacturer": {"slug": "cisco"}, "model": "A", "slug": "a"},
@@ -232,7 +233,7 @@ def test_select_device_types_for_update_mode_scopes_to_new_and_modified(nb_dt_im
         ],
     )
 
-    selected = nb_dt_import.select_device_types_for_update_mode(device_types, change_report)
+    selected = import_run_module.select_device_types_for_update_mode(device_types, change_report)
 
     expected = [
         {"manufacturer": {"slug": "cisco"}, "model": "A", "slug": "a"},
@@ -415,7 +416,7 @@ class TestGetProgressWrapper:
     def test_none_progress_returns_original_iterable(self, nb_dt_import):
         """Returns the iterable unchanged when progress is None."""
         items = [1, 2, 3]
-        result = nb_dt_import.get_progress_wrapper(None, items)
+        result = import_run_module.get_progress_wrapper(None, items)
         assert result is items
 
     def test_wraps_iterable_and_advances_task(self, nb_dt_import):
@@ -423,7 +424,7 @@ class TestGetProgressWrapper:
         mock_progress = MagicMock()
         mock_progress.add_task.return_value = 7
 
-        result = list(nb_dt_import.get_progress_wrapper(mock_progress, [10, 20, 30], desc="Test"))
+        result = list(import_run_module.get_progress_wrapper(mock_progress, [10, 20, 30], desc="Test"))
 
         assert result == [10, 20, 30]
         mock_progress.add_task.assert_called_once()
@@ -436,7 +437,7 @@ class TestGetProgressWrapper:
         mock_progress.add_task.return_value = 1
         on_step = MagicMock()
 
-        list(nb_dt_import.get_progress_wrapper(mock_progress, [1, 2], on_step=on_step))
+        list(import_run_module.get_progress_wrapper(mock_progress, [1, 2], on_step=on_step))
 
         # 2 items + 1 in finally = 3
         assert on_step.call_count == 3
@@ -450,7 +451,7 @@ class TestGetProgressWrapper:
             yield 1
             yield 2
 
-        result = list(nb_dt_import.get_progress_wrapper(mock_progress, gen(), total=None))
+        result = list(import_run_module.get_progress_wrapper(mock_progress, gen(), total=None))
 
         assert result == [1, 2]
         mock_progress.update.assert_called()
@@ -460,7 +461,7 @@ class TestGetProgressWrapper:
         mock_progress = MagicMock()
         mock_progress.add_task.return_value = 1
 
-        list(nb_dt_import.get_progress_wrapper(mock_progress, [1, 2], total=2))
+        list(import_run_module.get_progress_wrapper(mock_progress, [1, 2], total=2))
 
         mock_progress.update.assert_not_called()
 
@@ -476,7 +477,7 @@ class TestFilterDeviceTypesByChangeKeys:
     def test_empty_change_keys_returns_empty_list(self, nb_dt_import):
         """Returns [] immediately when change_keys is an empty set."""
         device_types = [{"manufacturer": {"slug": "cisco"}, "model": "A", "slug": "a"}]
-        result = nb_dt_import.filter_device_types_by_change_keys(device_types, set())
+        result = import_run_module.filter_device_types_by_change_keys(device_types, set())
         assert result == []
 
 
@@ -490,12 +491,12 @@ class TestSelectDeviceTypesNoneReport:
 
     def test_select_default_mode_none_report_returns_empty(self, nb_dt_import):
         """Returns [] when change_report is None (default mode)."""
-        result = nb_dt_import.select_device_types_for_default_mode([], None)
+        result = import_run_module.select_device_types_for_default_mode([], None)
         assert result == []
 
     def test_select_update_mode_none_report_returns_empty(self, nb_dt_import):
         """Returns [] when change_report is None (update mode)."""
-        result = nb_dt_import.select_device_types_for_update_mode([], None)
+        result = import_run_module.select_device_types_for_update_mode([], None)
         assert result == []
 
 
@@ -510,7 +511,7 @@ class TestImageProgressScope:
     def test_none_progress_resets_attribute_to_none(self, nb_dt_import):
         """Even with progress=None, _image_progress is reset to None on exit."""
         mock_dt = MagicMock()
-        with nb_dt_import._image_progress_scope(None, mock_dt, total=5):
+        with import_run_module._image_progress_scope(None, mock_dt, total=5):
             pass
         assert mock_dt._image_progress is None
 
@@ -519,7 +520,7 @@ class TestImageProgressScope:
         mock_progress = MagicMock()
         mock_dt = MagicMock()
 
-        with nb_dt_import._image_progress_scope(mock_progress, mock_dt, total=0):
+        with import_run_module._image_progress_scope(mock_progress, mock_dt, total=0):
             pass
 
         mock_progress.add_task.assert_not_called()
@@ -531,7 +532,7 @@ class TestImageProgressScope:
         mock_progress.add_task.return_value = 42
         mock_dt = MagicMock()
 
-        with nb_dt_import._image_progress_scope(mock_progress, mock_dt, total=3):
+        with import_run_module._image_progress_scope(mock_progress, mock_dt, total=3):
             assert mock_dt._image_progress is not None
             mock_dt._image_progress(2)  # simulate uploading 2 images
 
@@ -546,7 +547,7 @@ class TestImageProgressScope:
         mock_dt = MagicMock()
 
         with pytest.raises(ValueError):
-            with nb_dt_import._image_progress_scope(mock_progress, mock_dt, total=3):
+            with import_run_module._image_progress_scope(mock_progress, mock_dt, total=3):
                 raise ValueError("boom")
 
         assert mock_dt._image_progress is None
@@ -561,7 +562,7 @@ class TestMain:
     """Tests for the main() orchestration function covering all branches."""
 
     def test_only_new_no_device_types(self, nb_dt_import):
-        """--only-new with no matching files logs 'No new device types'."""
+        """An empty only-new run returns a zero-count summary."""
         with (
             patch.object(sys, "argv", ["nb-dt-import.py", "--only-new"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
@@ -570,7 +571,10 @@ class TestMain:
             MockRepo.return_value = _make_mock_repo()
             MockNetBox.return_value = _make_mock_netbox()
 
-            nb_dt_import.main()
+            summary = nb_dt_import.main()
+
+        assert isinstance(summary, import_run_module.RunSummary)
+        assert summary.counter["added"] == 0
 
     def test_only_new_creates_new_device_types(self, nb_dt_import):
         """--only-new calls create_device_types for genuinely new types."""
@@ -594,18 +598,19 @@ class TestMain:
             assert call.kwargs["only_new"] is True
 
     def test_default_mode_no_device_types(self, nb_dt_import):
-        """Default mode with no discovered vendors completes without error."""
+        """An empty default run returns a zero-count summary."""
         with (
             patch.object(sys, "argv", ["nb-dt-import.py"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
         ):
             MockRepo.return_value = _make_mock_repo()
             MockNetBox.return_value = _make_mock_netbox()
-            MockDetector.return_value.detect_changes.return_value = _empty_change_report()
 
-            nb_dt_import.main()
+            summary = nb_dt_import.main()
+
+        assert isinstance(summary, import_run_module.RunSummary)
+        assert summary.counter["properties_updated"] == 0
 
     def test_default_mode_with_new_device_types(self, nb_dt_import):
         """Default mode creates new device types when change report lists them."""
@@ -617,7 +622,7 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_repo = _make_mock_repo(device_types=dt)
             mock_repo.discover_vendors.return_value = [{"name": "Cisco", "slug": "cisco"}]
@@ -633,19 +638,25 @@ class TestMain:
             assert call.args[0] == dt
             assert call.kwargs["only_new"] is True
 
-    def test_update_mode_no_changes(self, nb_dt_import):
+    def test_update_mode_no_changes(self, nb_dt_import, capsys):
         """--update with no changes logs 'No device type changes to process'."""
+        device_type = {"manufacturer": {"slug": "vendor-one"}, "model": "Device One", "slug": "device-one"}
         with (
-            patch.object(sys, "argv", ["nb-dt-import.py", "--update"]),
+            patch.object(sys, "argv", ["nb-dt-import.py", "--update", "--verbose"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
-            MockRepo.return_value = _make_mock_repo()
+            repo = _make_mock_repo(device_types=[device_type])
+            repo.discover_vendors.return_value = [{"name": "Vendor One", "slug": "vendor-one"}]
+            repo.get_devices.return_value = (["device.yaml"], [])
+            MockRepo.return_value = repo
             MockNetBox.return_value = _make_mock_netbox()
             MockDetector.return_value.detect_changes.return_value = _empty_change_report()
 
             nb_dt_import.main()
+
+        assert "No device type changes to process." in capsys.readouterr().out
 
     def test_update_mode_with_changes(self, nb_dt_import):
         """--update with changed types calls create_device_types with update=True."""
@@ -657,7 +668,7 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py", "--update"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_repo = _make_mock_repo(device_types=dt)
             mock_repo.discover_vendors.return_value = [{"name": "Cisco", "slug": "cisco"}]
@@ -681,7 +692,7 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py", "--update", "--remove-components"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_repo = _make_mock_repo(device_types=dt)
             mock_repo.discover_vendors.return_value = [{"name": "Cisco", "slug": "cisco"}]
@@ -709,8 +720,8 @@ class TestMain:
                 nb_dt_import.main()
         assert exc_info.value.code == 2
 
-    def test_update_with_remove_unmanaged_types_sets_attribute_and_detector_kwarg(self, nb_dt_import):
-        """--update --remove-components --remove-unmanaged-types propagates to NetBox and ChangeDetector."""
+    def test_update_with_remove_unmanaged_types_reaches_constructors(self, nb_dt_import):
+        """The resolved remove-unmanaged flag reaches NetBox and ChangeDetector construction."""
         dt = [{"manufacturer": {"slug": "cisco"}, "model": "A", "slug": "a"}]
         change_entry = SimpleNamespace(manufacturer_slug="cisco", model="A", slug="a")
         report = SimpleNamespace(new_device_types=[change_entry], modified_device_types=[])
@@ -723,7 +734,7 @@ class TestMain:
             ),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_repo = _make_mock_repo(device_types=dt)
             mock_repo.discover_vendors.return_value = [{"name": "Cisco", "slug": "cisco"}]
@@ -735,8 +746,8 @@ class TestMain:
 
             nb_dt_import.main()
 
-            assert mock_nb.remove_unmanaged_types is True
-            # ChangeDetector instantiated with remove_unmanaged_types=True
+            netbox_config = MockNetBox.call_args.args[0]
+            assert netbox_config.remove_unmanaged_types is True
             _, detector_kwargs = MockDetector.call_args
             assert detector_kwargs.get("remove_unmanaged_types") is True
 
@@ -747,8 +758,8 @@ class TestMain:
                 nb_dt_import.main()
         assert exc_info.value.code == 2
 
-    def test_update_with_force_resolve_conflicts(self, nb_dt_import):
-        """--update --force-resolve-conflicts sets netbox.force_resolve_conflicts=True."""
+    def test_update_with_force_resolve_conflicts_reaches_netbox_constructor(self, nb_dt_import):
+        """The resolved conflict policy reaches NetBox construction."""
         dt = [{"manufacturer": {"slug": "cisco"}, "model": "A", "slug": "a"}]
         change_entry = SimpleNamespace(manufacturer_slug="cisco", model="A", slug="a")
         report = SimpleNamespace(new_device_types=[change_entry], modified_device_types=[])
@@ -757,7 +768,7 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py", "--update", "--force-resolve-conflicts"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_repo = _make_mock_repo(device_types=dt)
             mock_repo.discover_vendors.return_value = [{"name": "Cisco", "slug": "cisco"}]
@@ -769,10 +780,10 @@ class TestMain:
 
             nb_dt_import.main()
 
-            assert mock_nb.force_resolve_conflicts is True
+            assert MockNetBox.call_args.args[0].force_resolve_conflicts is True
 
-    def test_verify_images_sets_attribute(self, nb_dt_import):
-        """--verify-images propagates to netbox.verify_images = True."""
+    def test_verify_images_reaches_netbox_constructor(self, nb_dt_import):
+        """The resolved image verification flag reaches NetBox construction."""
         dt = [{"manufacturer": {"slug": "cisco"}, "model": "A", "slug": "a"}]
         change_entry = SimpleNamespace(manufacturer_slug="cisco", model="A", slug="a")
         report = SimpleNamespace(new_device_types=[change_entry], modified_device_types=[])
@@ -781,7 +792,7 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py", "--update", "--verify-images"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_repo = _make_mock_repo(device_types=dt)
             mock_repo.discover_vendors.return_value = [{"name": "Cisco", "slug": "cisco"}]
@@ -793,7 +804,7 @@ class TestMain:
 
             nb_dt_import.main()
 
-            assert mock_nb.verify_images is True
+            assert MockNetBox.call_args.args[0].verify_images is True
 
     def test_missing_env_var_triggers_system_exit(self, nb_dt_import):
         """A missing mandatory environment variable exits from main()."""
@@ -807,7 +818,7 @@ class TestMain:
             with pytest.raises(SystemExit):
                 nb_dt_import.main()
 
-    def test_vendors_and_slugs_flags_log_lines(self, nb_dt_import):
+    def test_vendors_and_slugs_flags_log_lines(self, nb_dt_import, capsys):
         """--vendors and --slugs args cause their respective log lines to execute."""
         with (
             patch.object(
@@ -817,7 +828,7 @@ class TestMain:
             ),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_repo = _make_mock_repo()
             mock_repo.discover_vendors.return_value = [{"name": "Cisco", "slug": "cisco"}]
@@ -825,7 +836,11 @@ class TestMain:
             MockNetBox.return_value = _make_mock_netbox()
             MockDetector.return_value.detect_changes.return_value = _empty_change_report()
 
-            nb_dt_import.main()  # should not raise
+            nb_dt_import.main()
+
+        output = capsys.readouterr().out
+        assert "Importing vendors: cisco" in output
+        assert "Filtering by slugs: ws-c3750" in output
 
     def test_unknown_vendors_exits_nonzero(self, nb_dt_import):
         """--vendors with no matching slug exits with code 1 instead of silently doing nothing."""
@@ -853,7 +868,7 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py", "--update"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_nb = _make_mock_netbox(modules=True)
             mock_nb.filter_actionable_module_types.return_value = ([module_type], {}, [])
@@ -875,20 +890,30 @@ class TestMain:
 
     def test_modules_update_mode_logs_change_detection_section(self, nb_dt_import):
         """--update with modules=True logs the MODULE TYPE CHANGE DETECTION header."""
+        module_type = {"manufacturer": {"slug": "vendor-one"}, "model": "Module One", "slug": "module-one"}
+        change_log = [("module-one", "Module One", {}, [])]
         with (
             patch.object(sys, "argv", ["nb-dt-import.py", "--update"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             mock_nb = _make_mock_netbox(modules=True)
-            mock_nb.filter_actionable_module_types.return_value = ([], {}, [])
+            mock_nb.filter_actionable_module_types.return_value = ([], {}, change_log)
+            mock_nb.filter_new_module_types.return_value = []
             MockNetBox.return_value = mock_nb
-            MockNetBox.filter_new_module_types.return_value = []
-            MockRepo.return_value = _make_mock_repo()
+            repo = _make_mock_repo()
+            repo.discover_vendors.return_value = [{"name": "Vendor One", "slug": "vendor-one"}]
+            repo.get_devices.side_effect = lambda path, vendors=None: (
+                (["module.yaml"], []) if "modules" in path else ([], [])
+            )
+            repo.parse_files.side_effect = lambda files, slugs=None: [module_type] if files == ["module.yaml"] else []
+            MockRepo.return_value = repo
             MockDetector.return_value.detect_changes.return_value = _empty_change_report()
 
-            nb_dt_import.main()  # should not raise
+            nb_dt_import.main()
+
+        mock_nb.log_module_type_changes.assert_called_once_with(change_log)
 
     def test_settings_netbox_features_modules_logs_module_count(self, nb_dt_import):
         """When netbox.modules is True, module_added/updated counters are logged."""
@@ -920,7 +945,7 @@ class TestMain:
             patch.object(sys, "argv", ["nb-dt-import.py"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
             patch("nb_dt_import.LogHandler") as MockLogHandler,
             patch("sys.stdout") as mock_stdout,
             patch("nb_dt_import.MyProgress", MockMyProgress),
@@ -955,7 +980,7 @@ class TestProcessRackTypes:
         netbox.rack_types = False
 
         rack_type = {"manufacturer": {"slug": "apc"}, "model": "AR1300", "slug": "apc-ar1300"}
-        nb_dt_import._process_rack_types(self._make_args(), netbox, handle, None, [rack_type])
+        import_run_module._process_rack_types(self._make_args(), netbox, handle, None, [rack_type])
 
         handle.log.assert_called_once()
         assert "4.1" in handle.log.call_args[0][0]
@@ -967,7 +992,7 @@ class TestProcessRackTypes:
         netbox = MagicMock()
         netbox.rack_types = True
 
-        nb_dt_import._process_rack_types(self._make_args(), netbox, handle, None, [])
+        import_run_module._process_rack_types(self._make_args(), netbox, handle, None, [])
 
         handle.log.assert_not_called()
         handle.verbose_log.assert_not_called()
@@ -987,7 +1012,7 @@ class TestProcessRackTypes:
             "slug": "apc-ar1300",
         }
 
-        nb_dt_import._process_rack_types(self._make_args(), netbox, handle, None, [rack_type])
+        import_run_module._process_rack_types(self._make_args(), netbox, handle, None, [rack_type])
 
         netbox.create_rack_types.assert_called_once()
         assert netbox.create_rack_types.call_args.args[0] == [rack_type]
@@ -1005,7 +1030,7 @@ class TestProcessRackTypes:
             "slug": "apc-ar1300",
         }
 
-        nb_dt_import._process_rack_types(self._make_args(), netbox, handle, None, [rack_type])
+        import_run_module._process_rack_types(self._make_args(), netbox, handle, None, [rack_type])
 
         log_calls = [call.args[0] for call in handle.verbose_log.call_args_list]
         assert any("No new rack types (1 unchanged)" in msg for msg in log_calls)
@@ -1020,7 +1045,7 @@ class TestEntryPoint:
     """Tests for the if __name__ == '__main__' entry point block."""
 
     def test_entry_point_calls_main_normally(self):
-        """Running the script as __main__ with mocked deps completes without error."""
+        """Running the script as __main__ constructs the repository once."""
         with (
             patch("core.repo.DTLRepo") as MockDTLRepo,
             patch("core.netbox_api.NetBox") as MockNetBox,
@@ -1030,6 +1055,8 @@ class TestEntryPoint:
 
             with patch.object(sys, "argv", ["nb-dt-import.py", "--only-new"]):
                 runpy.run_path(_NB_DT_IMPORT_PATH, run_name="__main__")
+
+        MockDTLRepo.assert_called_once()
 
     def test_entry_point_keyboard_interrupt_exits_130(self):
         """KeyboardInterrupt raised inside main() becomes SystemExit(130)."""
@@ -1084,7 +1111,7 @@ class TestPerVendorLoop:
             patch.object(sys, "argv", argv),
             patch("nb_dt_import.DTLRepo") as MockRepo,
             patch("nb_dt_import.NetBox") as MockNetBox,
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             MockRepo.return_value = mock_repo
             MockNetBox.return_value = mock_nb
@@ -1255,27 +1282,6 @@ class TestPerVendorLoop:
                 "ensure_components_ready called without manufacturer_slug (global fetch triggered)"
             )
 
-    def test_empty_device_type_list_returns_before_cache_readiness(self, nb_dt_import):
-        class DeviceTypes:
-            def ensure_components_ready(self, manufacturer_slug=None):
-                raise AssertionError("empty input must not populate the component cache")
-
-        class Handle:
-            def __init__(self):
-                self.messages = []
-
-            def verbose_log(self, message):
-                self.messages.append(message)
-
-        handle = Handle()
-        config = SimpleNamespace(only_new=False)
-        netbox = SimpleNamespace(device_types=DeviceTypes())
-
-        nb_dt_import._process_device_types(config, netbox, handle, None, [], vendor_slug="cisco")
-
-        assert handle.messages == ["No device types matched filters."]
-
-
 # ---------------------------------------------------------------------------
 # _process_module_types hints and counters (lines 554-559, 572, 574-575)
 # ---------------------------------------------------------------------------
@@ -1318,7 +1324,7 @@ class TestProcessModuleTypesHints:
         mock_repo = MagicMock()
         mock_repo.get_devices.return_value = ([], [])
 
-        nb_dt_import._process_module_types(
+        import_run_module._process_module_types(
             self._make_args(only_new=False, update=False, remove_components=False),
             mock_nb,
             handle,
@@ -1367,8 +1373,11 @@ class TestLogRunSummary:
                 "rack_type_updated": 1,
             }
         )
+        mock_nb.outcomes.render_failure_report.return_value = []
+        mock_repo = SimpleNamespace(duplicate_definitions=[])
+        summary = import_run_module.RunSummary.capture(mock_nb, mock_repo, datetime.now())
 
-        nb_dt_import._log_run_summary(handle, mock_nb, datetime.now())
+        import_run_module._log_run_summary(handle, summary)
 
         logged = [call.args[0] for call in handle.log.call_args_list]
         assert any("3 rack types created" in msg for msg in logged)
@@ -1405,8 +1414,10 @@ class TestLogRunSummary:
                 "ignored": ["b.yaml"],
             }
         ]
+        mock_nb.outcomes.render_failure_report.return_value = []
+        summary = import_run_module.RunSummary.capture(mock_nb, mock_repo, datetime.now())
 
-        nb_dt_import._log_run_summary(handle, mock_nb, datetime.now(), dtl_repo=mock_repo)
+        import_run_module._log_run_summary(handle, summary)
 
         logged = [call.args[0] for call in handle.log.call_args_list]
         assert any("cisco" in msg for msg in logged)
@@ -1588,8 +1599,8 @@ class TestDirectHelpers:
         repo.get_devices.return_value = (["rack.yaml"], [])
         repo.parse_files.return_value = [{"model": "Rack"}]
 
-        with patch("nb_dt_import.os.path.isdir", return_value=True):
-            result = nb_dt_import._parse_vendor_racks(repo, "/racks", "nokia", ["rack"])
+        with patch("core.import_run.os.path.isdir", return_value=True):
+            result = import_run_module._parse_vendor_racks(repo, "/racks", "nokia", ["rack"])
 
         assert result == [{"model": "Rack"}]
         repo.get_devices.assert_called_once_with("/racks", ["nokia"])
@@ -1599,7 +1610,7 @@ class TestDirectHelpers:
         progress = MagicMock()
         progress.tasks = [SimpleNamespace(id=1, total=None, completed=3)]
 
-        nb_dt_import._finalize_task_registry(progress, {"seen": 1, "missing": 2})
+        import_run_module._finalize_task_registry(progress, {"seen": 1, "missing": 2})
 
         progress.update.assert_called_once_with(1, total=3)
         progress.stop_task.assert_called_once_with(1)
@@ -1740,7 +1751,10 @@ class TestDirectHelpers:
             "force_overwrite": True,
             "vendor_slugs": ["nokia"],
         }
-        handle.set_console.assert_called_once_with(progress.console)
+        assert handle.set_console.call_args_list == [
+            ((progress.console,),),
+            ((None,),),
+        ]
         MockExporter.return_value.run.assert_called_once_with(progress=progress)
 
     def test_run_export_diff_sends_no_vendor_filter_when_vendors_is_empty(self, nb_dt_import):
@@ -1807,7 +1821,7 @@ class TestMainAdditionalCoverage:
             patch.object(sys, "argv", ["nb-dt-import.py", "--slugs", "x"]),
             patch("nb_dt_import.DTLRepo", return_value=mock_repo),
             patch("nb_dt_import.NetBox", return_value=mock_nb),
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
+            patch("core.import_run.ChangeDetector") as MockDetector,
         ):
             MockDetector.return_value.detect_changes.return_value = _empty_change_report()
             nb_dt_import.main()
@@ -1842,8 +1856,8 @@ class TestMainAdditionalCoverage:
             patch.object(sys, "argv", ["nb-dt-import.py"]),
             patch("nb_dt_import.DTLRepo", return_value=mock_repo),
             patch("nb_dt_import.NetBox", return_value=mock_nb),
-            patch("nb_dt_import.ChangeDetector") as MockDetector,
-            patch("nb_dt_import._process_device_types"),
+            patch("core.import_run.ChangeDetector") as MockDetector,
+            patch("core.import_run._process_device_types"),
             patch("sys.stdout") as mock_stdout,
             patch("nb_dt_import.get_progress_panel", return_value=_Ctx()),
         ):
@@ -1878,7 +1892,7 @@ class TestMainAdditionalCoverage:
             patch.object(sys, "argv", ["nb-dt-import.py"]),
             patch("nb_dt_import.DTLRepo", return_value=mock_repo),
             patch("nb_dt_import.NetBox", return_value=mock_nb),
-            patch("nb_dt_import._process_device_types", side_effect=RuntimeError("boom")),
+            patch("core.import_run._process_device_types", side_effect=RuntimeError("boom")),
             patch("nb_dt_import.get_progress_panel", return_value=_Ctx()),
         ):
             with pytest.raises(RuntimeError, match="boom"):
@@ -1935,10 +1949,12 @@ class TestMainAdditionalCoverage:
         assert parsed.export_diff_dir == "exports/"
         assert parsed.force_export_overwrite is True
 
-    def test_run_vendor_loop_processes_slug_fast_path_and_skips_empty_vendor(self, nb_dt_import):
-        args = SimpleNamespace(only_new=False, slugs=["x"])
+    def test_import_run_processes_slug_fast_path_and_skips_empty_vendor(self, make_config):
+        """Execution applies a resolved plan and advances past an empty plan."""
+        config = make_config(slugs=("x",))
         handle = MagicMock()
         progress = MagicMock()
+        progress.add_task.return_value = 7
         dtl_repo = _make_mock_repo()
         dtl_repo.get_devices.side_effect = lambda path, vendors=None: (
             ([f"{vendors[0]}-{path.split('/')[-1]}.yaml"], [])
@@ -1958,31 +1974,24 @@ class TestMainAdditionalCoverage:
             "module_vendors": {"cisco"},
             "rack_vendors": set(),
         }
+        vendors = [{"slug": "empty", "name": "Empty"}, {"slug": "cisco", "name": "Cisco"}]
+        dtl_repo.discover_vendors.return_value = vendors
+        dtl_repo.resolve_slug_files.return_value = slug_resolved
 
         with (
-            patch(
-                "nb_dt_import._parse_vendor_racks",
-                side_effect=[[], [{"manufacturer": {"slug": "cisco"}, "model": "R", "slug": "r"}]],
-            ),
-            patch("nb_dt_import._process_device_types") as mock_process_device_types,
-            patch("nb_dt_import._process_module_types") as mock_process_module_types,
-            patch("nb_dt_import._process_rack_types") as mock_process_rack_types,
-            patch("nb_dt_import._finalize_task_registry") as mock_finalize,
+            patch("core.import_run._process_device_types") as mock_process_device_types,
+            patch("core.import_run._process_module_types") as mock_process_module_types,
+            patch("core.import_run._process_rack_types") as mock_process_rack_types,
+            patch("core.import_run._finalize_task_registry") as mock_finalize,
         ):
-            nb_dt_import._run_vendor_loop(
-                dtl_repo=dtl_repo,
-                netbox=netbox,
-                config=args,
-                handle=handle,
-                vendors_to_process=[{"slug": "empty", "name": "Empty"}, {"slug": "cisco", "name": "Cisco"}],
-                devices_path="/tmp/devices",
-                modules_path="/tmp/modules",
-                racks_path="/tmp/rack-types",
-                slug_resolved=slug_resolved,
-                progress=progress,
-                task_registry={},
-                vendor_task_id=7,
+            run = import_run_module.ImportRun(
+                config,
+                dtl_repo,
+                netbox,
+                handle,
+                lambda _show_remaining_time: nullcontext(progress),
             )
+            run.execute()
 
         netbox.load_vendor.assert_called_once_with("cisco")
         netbox.device_types.components.begin_prefetch.assert_called_once()
@@ -2006,11 +2015,14 @@ class TestMainAdditionalCoverage:
         mock_finalize.assert_called_once_with(progress, {})
         assert any(call.args[0] == ["resolved.yaml"] for call in dtl_repo.parse_files.call_args_list)
 
-    def test_run_vendor_loop_stops_preload_in_finally_on_error(self, nb_dt_import):
-        args = SimpleNamespace(only_new=False, slugs=[])
+    def test_import_run_stops_preload_in_finally_on_error(self, make_config):
+        """Execution closes the preload and progress registry after an apply error."""
+        config = make_config()
         handle = MagicMock()
         progress = MagicMock()
+        progress.add_task.return_value = 8
         dtl_repo = _make_mock_repo()
+        dtl_repo.discover_vendors.return_value = [{"slug": "cisco", "name": "Cisco"}]
         dtl_repo.get_devices.side_effect = lambda path, vendors=None: (
             (["device.yaml"], []) if path == "/tmp/devices" else ([], [])
         )
@@ -2020,25 +2032,18 @@ class TestMainAdditionalCoverage:
         netbox = _make_mock_netbox()
 
         with (
-            patch("nb_dt_import._parse_vendor_racks", return_value=[]),
-            patch("nb_dt_import._process_device_types", side_effect=RuntimeError("boom")),
-            patch("nb_dt_import._finalize_task_registry") as mock_finalize,
+            patch("core.import_run._process_device_types", side_effect=RuntimeError("boom")),
+            patch("core.import_run._finalize_task_registry") as mock_finalize,
         ):
             with pytest.raises(RuntimeError, match="boom"):
-                nb_dt_import._run_vendor_loop(
-                    dtl_repo=dtl_repo,
-                    netbox=netbox,
-                    config=args,
-                    handle=handle,
-                    vendors_to_process=[{"slug": "cisco", "name": "Cisco"}],
-                    devices_path="/tmp/devices",
-                    modules_path="/tmp/modules",
-                    racks_path="/tmp/rack-types",
-                    slug_resolved=None,
-                    progress=progress,
-                    task_registry={},
-                    vendor_task_id=8,
+                run = import_run_module.ImportRun(
+                    config,
+                    dtl_repo,
+                    netbox,
+                    handle,
+                    lambda _show_remaining_time: nullcontext(progress),
                 )
+                run.execute()
 
         netbox.device_types.components.close.assert_called()
         mock_finalize.assert_called_once_with(progress, {})

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -843,7 +843,7 @@ class TestMain:
         assert "Filtering by slugs: ws-c3750" in output
 
     def test_unknown_vendors_exits_nonzero(self, nb_dt_import):
-        """--vendors with no matching slug exits with code 1 instead of silently doing nothing."""
+        """--vendors with no matching slug exits with the fatal error message."""
         with (
             patch.object(
                 sys,
@@ -858,7 +858,7 @@ class TestMain:
             MockRepo.return_value = mock_repo
             with pytest.raises(SystemExit) as exc_info:
                 nb_dt_import.main()
-            assert exc_info.value.code == 1
+            assert str(exc_info.value) == "No vendors matched --vendors: nonexistent-vendor. Available: nokia"
 
     def test_modules_with_types_to_process(self, nb_dt_import):
         """modules=True + non-empty filter_actionable_module_types calls create_module_types."""
@@ -1281,6 +1281,7 @@ class TestPerVendorLoop:
             assert call.kwargs.get("manufacturer_slug") is not None, (
                 "ensure_components_ready called without manufacturer_slug (global fetch triggered)"
             )
+
 
 # ---------------------------------------------------------------------------
 # _process_module_types hints and counters (lines 554-559, 572, 574-575)

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -796,7 +796,7 @@ class TestMain:
             assert mock_nb.verify_images is True
 
     def test_missing_env_var_triggers_system_exit(self, nb_dt_import):
-        """A missing mandatory env var calls handle.exception which exits."""
+        """A missing mandatory environment variable exits from main()."""
         with (
             patch.object(sys, "argv", ["nb-dt-import.py", "--only-new"]),
             patch("nb_dt_import.DTLRepo"),
@@ -1462,6 +1462,37 @@ class TestEntryPointErrorHandlers:
 
         assert exc_info.value.code == 1
         assert "NetBox REST API request failed" in capsys.readouterr().err
+
+
+class TestFatalErrorPolicy:
+    """Tests for the one fatal-error rendering boundary in main()."""
+
+    def test_main_turns_a_fatal_error_into_system_exit(self, nb_dt_import, make_config, capsys):
+        from core.errors import UnknownError
+
+        error = UnknownError("Git Repository Error", stack_trace="diagnostic detail")
+        with (
+            patch.object(nb_dt_import, "resolve_run_config", return_value=make_config(verbose=False)),
+            patch.object(nb_dt_import, "_run", side_effect=error),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                nb_dt_import.main()
+
+        assert str(exc_info.value) == 'An unknown error occurred: "Git Repository Error"'
+        assert capsys.readouterr().out == ""
+
+    def test_main_prints_fatal_diagnostic_detail_only_in_verbose_mode(self, nb_dt_import, make_config, capsys):
+        from core.errors import UnknownError
+
+        error = UnknownError("NetBox API Error", stack_trace="diagnostic detail")
+        with (
+            patch.object(nb_dt_import, "resolve_run_config", return_value=make_config(verbose=True)),
+            patch.object(nb_dt_import, "_run", side_effect=error),
+        ):
+            with pytest.raises(SystemExit):
+                nb_dt_import.main()
+
+        assert capsys.readouterr().out == "diagnostic detail\n"
 
 
 class TestExportDiffFlags:

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -9,7 +9,9 @@ from unittest.mock import MagicMock, patch
 from core.component_registry import BY_YAML_KEY, COMPONENT_TYPES
 from core.netbox_api import (
     NetBox,
+    NetBoxError,
     DeviceTypes,
+    SSLVerificationError,
     _delete_image_attachment,
     _FrontPortRecordWithMappings,
 )
@@ -180,6 +182,28 @@ def test_device_types_create_interfaces(mock_settings, mock_pynetbox, graphql_cl
     assert len(call_args) == 1
     assert call_args[0]["name"] == "GigabitEthernet1"
     assert call_args[0]["device_type"] == 1
+
+
+def test_create_generic_counts_the_created_list_at_the_caller(mock_pynetbox, make_device_types):
+    """The API caller owns the created count, while the sink only logs records."""
+    from collections import Counter
+    from types import SimpleNamespace
+
+    from core.log_handler import LogHandler
+
+    netbox = mock_pynetbox.api.return_value
+    created = [
+        SimpleNamespace(name="eth0", type="virtual", device_type=SimpleNamespace(id=1), id=10),
+        SimpleNamespace(name="eth1", type="virtual", device_type=SimpleNamespace(id=1), id=11),
+    ]
+    netbox.dcim.interface_templates.create.return_value = created
+    counter = Counter()
+    device_types = make_device_types(nb_api=netbox, handle=LogHandler(False), counter=counter)
+    device_types.components.record("interface_templates", "device", 1, {})
+
+    device_types._create_generic(BY_YAML_KEY["interfaces"], [{"name": "eth0"}, {"name": "eth1"}], 1)
+
+    assert counter["components_added"] == len(created)
 
 
 def test_redundant_image_upload(mock_settings, mock_pynetbox, mock_handle):
@@ -1433,15 +1457,22 @@ class TestCreateModuleBays:
 class TestConnectApiException:
     """Tests for connect_api exception handling."""
 
-    def test_exception_is_caught_and_logged(self, mock_settings, mock_pynetbox, mock_handle):
-        """When pynetbox.api raises, handle.exception should be called."""
-        mock_pynetbox.api.side_effect = Exception("connection failed")
-        # NetBox.__init__ calls connect_api; the exception should be swallowed.
-        try:
-            NetBox(mock_settings, mock_handle)
-        except Exception:
-            pass
-        mock_handle.exception.assert_called()
+    def test_connection_setup_raises_a_typed_unknown_error(self, mock_settings, mock_pynetbox):
+        """A setup failure carries its diagnostic detail to the entry point."""
+        from core.errors import UnknownError
+        from core.log_handler import LogHandler
+
+        mock_pynetbox.api.side_effect = RuntimeError("connection failed")
+        nb = NetBox.__new__(NetBox)
+        nb.url = mock_settings.netbox_url
+        nb.token = mock_settings.netbox_token
+        nb.ignore_ssl = False
+        nb.handle = LogHandler(False)
+
+        with pytest.raises(UnknownError) as exc_info:
+            nb.connect_api()
+
+        assert exc_info.value.stack_trace.args == ("connection failed",)
 
 
 # ---------------------------------------------------------------------------
@@ -5508,7 +5539,7 @@ class TestNetBoxImageHelperFunctions:
             side_effect=_requests.exceptions.ConnectionError("drop")
         )
 
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(NetBoxError) as exc_info:
             NetBox(mock_settings, mock_handle)
 
         exc_msg = str(exc_info.value.args[0]) if exc_info.value.args else ""
@@ -5810,26 +5841,28 @@ class TestAdditionalNetBoxCoverage:
 
         assert _load_image_hash_cache(str(cache_file)) == {}
 
-    def test_init_exits_on_graphql_error_from_get_manufacturers(self, mock_settings, mock_pynetbox, mock_handle):
+    def test_init_raises_typed_graphql_error_from_get_manufacturers(self, mock_settings, mock_pynetbox, mock_handle):
         from core.graphql_client import GraphQLError
 
         mock_pynetbox.api.return_value.version = "3.5"
 
         with patch.object(NetBox, "get_manufacturers", side_effect=GraphQLError("bad query")):
-            with pytest.raises(SystemExit, match="GraphQL error: bad query"):
+            with pytest.raises(NetBoxError, match="GraphQL error: bad query"):
                 NetBox(mock_settings, mock_handle)
 
-    def test_init_exits_when_device_types_initialization_fails(self, mock_settings, mock_pynetbox, mock_handle):
+    def test_init_raises_typed_error_when_device_types_initialization_fails(
+        self, mock_settings, mock_pynetbox, mock_handle
+    ):
         mock_pynetbox.api.return_value.version = "3.5"
 
         with (
             patch.object(NetBox, "get_manufacturers", return_value=[]),
             patch("core.netbox_api.DeviceTypes", side_effect=RuntimeError("boom")),
         ):
-            with pytest.raises(SystemExit, match="Error initializing device types: boom"):
+            with pytest.raises(NetBoxError, match="Error initializing device types: boom"):
                 NetBox(mock_settings, mock_handle)
 
-    def test_verify_compatibility_exits_on_proxy_error(self, mock_settings, mock_handle):
+    def test_verify_compatibility_raises_typed_proxy_error(self, mock_settings, mock_handle):
         import requests
 
         class BadAPI:
@@ -5842,8 +5875,27 @@ class TestAdditionalNetBoxCoverage:
         nb.handle = mock_handle
         nb.netbox = BadAPI()
 
-        with pytest.raises(SystemExit, match="Proxy error while connecting to NetBox"):
+        with pytest.raises(NetBoxError, match="Proxy error while connecting to NetBox"):
             nb.verify_compatibility()
+
+    def test_verify_compatibility_raises_the_ssl_catalogue_error(self, mock_settings, mock_handle):
+        import requests
+
+        class BadAPI:
+            @property
+            def version(self):
+                raise requests.exceptions.SSLError("certificate verify failed")
+
+        nb = NetBox.__new__(NetBox)
+        nb.url = mock_settings.netbox_url
+        nb.ignore_ssl = False
+        nb.handle = mock_handle
+        nb.netbox = BadAPI()
+
+        with pytest.raises(SSLVerificationError) as exc_info:
+            nb.verify_compatibility()
+
+        assert str(exc_info.value).startswith("SSL verification failed. IGNORE_SSL_ERRORS is False.")
 
     def test_verify_compatibility_formats_request_error_details(self, mock_settings, mock_handle):
         import pynetbox as real_pynb
@@ -5864,7 +5916,7 @@ class TestAdditionalNetBoxCoverage:
         nb.handle = mock_handle
         nb.netbox = BadAPI()
 
-        with pytest.raises(SystemExit) as exc_info:
+        with pytest.raises(NetBoxError) as exc_info:
             nb.verify_compatibility()
 
         message = str(exc_info.value)

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -607,16 +607,6 @@ class TestNetBoxConnectApi:
         nb = NetBox(mock_settings, mock_handle)
         assert nb.netbox.http_session.verify is False
 
-    def test_get_api_returns_netbox(self, mock_settings, mock_pynetbox, mock_handle):
-        mock_pynetbox.api.return_value.version = "3.5"
-        nb = NetBox(mock_settings, mock_handle)
-        assert nb.get_api() is nb.netbox
-
-    def test_get_counter_returns_counter(self, mock_settings, mock_pynetbox, mock_handle):
-        mock_pynetbox.api.return_value.version = "3.5"
-        nb = NetBox(mock_settings, mock_handle)
-        assert nb.get_counter() is nb.counter
-
 
 class TestCreateManufacturersError:
     """Tests for TestCreateManufacturersError."""
@@ -4699,68 +4689,6 @@ class TestBuildLinkRearPortsEdgeCases:
         log_calls = [str(c) for c in mock_handle.log.call_args_list]
         assert any("only first mapping applied" in c for c in log_calls)
         assert any("MyDevice" in c for c in log_calls)
-
-
-# ---------------------------------------------------------------------------
-# _module_type_has_missing_components (lines 770-782)
-# ---------------------------------------------------------------------------
-
-
-class TestModuleTypeHasMissingComponents:
-    """Tests for NetBox._module_type_has_missing_components()."""
-
-    def test_returns_false_when_no_components_in_yaml(
-        self, mock_settings, mock_pynetbox, make_device_types, mock_handle
-    ):
-        """Returns False when the module type dict has no components under the key."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
-
-        nb = NetBox(mock_settings, mock_handle)
-        module_type = {}  # no "interfaces" key
-        existing_module = MagicMock()
-        existing_module.id = 99
-
-        result = nb._module_type_has_missing_components(module_type, existing_module, ["interfaces"])
-
-        assert result is False
-
-    def test_returns_true_when_component_missing(self, mock_settings, mock_pynetbox, make_device_types, mock_handle):
-        """Returns True when a YAML-defined component name is absent from the cache."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
-
-        nb = NetBox(mock_settings, mock_handle)
-        # Pre-populate cache with an empty interface set for module 42.
-        nb.device_types.components.record("interface_templates", "module", 42, {})
-
-        module_type = {"interfaces": [{"name": "xe-0/0/0"}]}
-        existing_module = MagicMock()
-        existing_module.id = 42
-
-        result = nb._module_type_has_missing_components(module_type, existing_module, ["interfaces"])
-
-        assert result is True
-
-    def test_returns_false_when_all_components_present(
-        self, mock_settings, mock_pynetbox, make_device_types, mock_handle
-    ):
-        """Returns False when all YAML-defined components exist in the cache."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
-
-        nb = NetBox(mock_settings, mock_handle)
-        existing_iface = MagicMock()
-        existing_iface.name = "xe-0/0/0"
-        nb.device_types.components.record("interface_templates", "module", 42, {"xe-0/0/0": existing_iface})
-
-        module_type = {"interfaces": [{"name": "xe-0/0/0"}]}
-        existing_module = MagicMock()
-        existing_module.id = 42
-
-        result = nb._module_type_has_missing_components(module_type, existing_module, ["interfaces"])
-
-        assert result is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -113,6 +113,22 @@ def test_netbox_init(mock_settings, mock_pynetbox, mock_handle):
     assert nb.modules
 
 
+def test_netbox_init_applies_import_policy_flags(make_config, mock_pynetbox, mock_handle):
+    """NetBox receives all import policy flags through construction."""
+    config = make_config(
+        force_resolve_conflicts=True,
+        remove_unmanaged_types=True,
+        verify_images=True,
+    )
+    mock_pynetbox.api.return_value.version = "3.5"
+
+    netbox = NetBox(config, mock_handle)
+
+    assert netbox.force_resolve_conflicts is True
+    assert netbox.remove_unmanaged_types is True
+    assert netbox.verify_images is True
+
+
 def test_netbox_version_check(mock_settings, mock_pynetbox, mock_handle):
     # Test 5.0
     mock_pynetbox.api.return_value.version = "5.0"

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -5,6 +5,11 @@ from unittest.mock import MagicMock, call, mock_open, patch
 from git import Actor, Repo as GitRepo, exc as git_exc
 from core.repo import (
     DTLRepo,
+    GitBranchNotFoundError,
+    GitCommandError,
+    GitInvalidRepositoryError,
+    InvalidGitURLError,
+    InvalidRepoPathError,
     _resolve_index_path,
     _safe_index_load,
     _safe_json_load,
@@ -12,6 +17,8 @@ from core.repo import (
     validate_git_url,
     normalize_port_mappings,
 )
+from core.errors import UnknownError
+from core.log_handler import LogHandler
 
 
 def _dtl_repo(config, repo_path, handle):
@@ -130,18 +137,21 @@ class TestDTLRepoInit:
             _dtl_repo(mock_args, "/tmp/repo", mock_handle)
         MockRepo.clone_from.assert_called_once()
 
-    def test_invalid_url_calls_exception(self):
+    def test_invalid_url_raises_before_the_clone_path(self):
         mock_args = MagicMock()
         mock_args.repo_url = "ftp://bad.url"
         mock_args.repo_branch = "master"
-        mock_handle = MagicMock()
         with _clone_present(False), patch("core.repo.Repo"):
-            _dtl_repo(mock_args, "/tmp/repo", mock_handle)
-        mock_handle.exception.assert_called_with(
-            "InvalidGitURL",
-            "ftp://bad.url",
-            "URL must use HTTPS, SSH, or file protocol",
-        )
+            with pytest.raises(InvalidGitURLError, match="Invalid Git URL: ftp://bad.url"):
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
+
+    def test_invalid_path_raises_before_repository_access(self, tmp_path):
+        invalid_path = tmp_path / "repo-file"
+        invalid_path.write_text("not a directory")
+        config = MagicMock(repo_url="https://github.com/org/repo.git", repo_branch="master")
+
+        with pytest.raises(InvalidRepoPathError, match="Invalid repository path"):
+            _dtl_repo(config, str(invalid_path), LogHandler(False))
 
 
 class TestDTLRepoRealGit:
@@ -178,13 +188,11 @@ class TestDTLRepoRealGit:
         return source
 
     def _init_dtl(self, source, target):
-        """Run DTLRepo against *source* and *target*; return its exception handler for assertions."""
+        """Run DTLRepo against *source* and *target*."""
         mock_args = MagicMock()
         mock_args.repo_url = f"file://{source}"
         mock_args.repo_branch = "master"
-        mock_handle = MagicMock()
-        _dtl_repo(mock_args, str(target), mock_handle)
-        return mock_handle
+        _dtl_repo(mock_args, str(target), LogHandler(False))
 
     def test_clones_into_existing_empty_directory(self, tmp_path):
         """A mounted-but-empty target (Docker volume on first run) must be cloned into, not pulled."""
@@ -195,9 +203,8 @@ class TestDTLRepoRealGit:
         target = tmp_path / "repo"
         target.mkdir()
 
-        mock_handle = self._init_dtl(source, target)
+        self._init_dtl(source, target)
 
-        mock_handle.exception.assert_not_called()
         assert (target / ".git").is_dir()
         assert (target / "device-types" / "TestVendor" / "device.yaml").is_file()
 
@@ -215,9 +222,8 @@ class TestDTLRepoRealGit:
         new_file.write_text("manufacturer: TestVendor\nmodel: Second\n")
         self._commit(source_repo, "device-types/TestVendor/second.yaml", "second device")
 
-        mock_handle = self._init_dtl(source, target)
+        self._init_dtl(source, target)
 
-        mock_handle.exception.assert_not_called()
         assert (target / "device-types" / "TestVendor" / "second.yaml").is_file()
 
     def test_pulls_when_target_is_a_git_worktree(self, tmp_path):
@@ -237,9 +243,8 @@ class TestDTLRepoRealGit:
         clone_repo.git.worktree("add", str(worktree), "master")
         assert (worktree / ".git").is_file(), "a worktree must have .git as a file for this test to mean anything"
 
-        mock_handle = self._init_dtl(source, worktree)
+        self._init_dtl(source, worktree)
 
-        mock_handle.exception.assert_not_called()
         assert (worktree / "device-types" / "TestVendor" / "device.yaml").is_file()
 
 
@@ -280,12 +285,11 @@ class TestDTLRepoPathMethods:
 class TestPullRepo:
     """Tests for DTLRepo.pull_repo(): origin URL validation, pull success, and error handling."""
 
-    def test_pull_repo_invalid_origin_calls_exception(self):
-        """When origin URL equals configured URL and both are invalid, exception is called."""
+    def test_pull_repo_invalid_origin_raises(self):
+        """An invalid existing origin stops before fetch."""
         mock_args = MagicMock()
         mock_args.repo_url = "ftp://bad"
         mock_args.repo_branch = "master"
-        mock_handle = MagicMock()
         with (
             _clone_present(),
             patch("core.repo.Repo") as MockRepo,
@@ -294,15 +298,15 @@ class TestPullRepo:
             # origin URL matches configured URL → validate origin path
             mock_git_repo.remotes.origin.url = "ftp://bad"
             MockRepo.return_value = mock_git_repo
-            _dtl_repo(mock_args, "/tmp/repo", mock_handle)
-        mock_handle.exception.assert_called()
+            with pytest.raises(InvalidGitURLError):
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
+        mock_git_repo.remotes.origin.fetch.assert_not_called()
 
-    def test_pull_repo_invalid_configured_url_calls_exception(self):
-        """When configured REPO_URL differs from origin and is invalid, exception is called."""
+    def test_pull_repo_invalid_configured_url_raises(self):
+        """An invalid configured URL stops before the origin changes."""
         mock_args = MagicMock()
         mock_args.repo_url = "ftp://bad-config"
         mock_args.repo_branch = "master"
-        mock_handle = MagicMock()
         with (
             _clone_present(),
             patch("core.repo.Repo") as MockRepo,
@@ -310,12 +314,9 @@ class TestPullRepo:
             mock_git_repo = MagicMock()
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             MockRepo.return_value = mock_git_repo
-            _dtl_repo(mock_args, "/tmp/repo", mock_handle)
-        mock_handle.exception.assert_any_call(
-            "InvalidGitURL",
-            "ftp://bad-config",
-            "URL must use HTTPS, SSH, or file protocol",
-        )
+            with pytest.raises(InvalidGitURLError):
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
+        mock_git_repo.remotes.origin.set_url.assert_not_called()
 
     def test_pull_repo_updates_remote_url_when_different(self):
         """When REPO_URL differs from origin URL, the remote is updated before fetching."""
@@ -339,12 +340,11 @@ class TestPullRepo:
             call.fetch(prune=True),
         ]
 
-    def test_pull_repo_branch_not_found_calls_exception(self):
-        """When the configured branch does not exist on the remote, GitBranchNotFound is reported."""
+    def test_pull_repo_branch_not_found_raises(self):
+        """A missing configured branch stops before checkout."""
         mock_args = MagicMock()
         mock_args.repo_url = "https://github.com/org/repo.git"
         mock_args.repo_branch = "missing-branch"
-        mock_handle = MagicMock()
         with (
             _clone_present(),
             patch("core.repo.Repo") as MockRepo,
@@ -355,14 +355,14 @@ class TestPullRepo:
             ref.name = "origin/master"
             mock_git_repo.remotes.origin.refs = [ref]
             MockRepo.return_value = mock_git_repo
-            _dtl_repo(mock_args, "/tmp/repo", mock_handle)
-        mock_handle.exception.assert_called_with("GitBranchNotFound", "missing-branch")
+            with pytest.raises(GitBranchNotFoundError):
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
+        mock_git_repo.git.checkout.assert_not_called()
 
-    def test_pull_repo_git_command_error_calls_exception(self):
+    def test_pull_repo_git_command_error_raises(self):
         mock_args = MagicMock()
         mock_args.repo_url = "https://github.com/org/repo.git"
         mock_args.repo_branch = "master"
-        mock_handle = MagicMock()
         with (
             _clone_present(),
             patch("core.repo.Repo") as MockRepo,
@@ -371,14 +371,14 @@ class TestPullRepo:
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             mock_git_repo.remotes.origin.fetch.side_effect = git_exc.GitCommandError("fetch", 1)
             MockRepo.return_value = mock_git_repo
-            _dtl_repo(mock_args, "/tmp/repo", mock_handle)
-        mock_handle.exception.assert_called()
+            with pytest.raises(GitCommandError) as exc_info:
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
+        assert isinstance(exc_info.value.stack_trace, git_exc.GitCommandError)
 
-    def test_pull_repo_generic_error_calls_exception(self):
+    def test_pull_repo_generic_error_raises(self):
         mock_args = MagicMock()
         mock_args.repo_url = "https://github.com/org/repo.git"
         mock_args.repo_branch = "master"
-        mock_handle = MagicMock()
         with (
             _clone_present(),
             patch("core.repo.Repo") as MockRepo,
@@ -387,38 +387,45 @@ class TestPullRepo:
             mock_git_repo.remotes.origin.url = "https://github.com/org/repo.git"
             mock_git_repo.remotes.origin.fetch.side_effect = RuntimeError("network error")
             MockRepo.return_value = mock_git_repo
-            _dtl_repo(mock_args, "/tmp/repo", mock_handle)
-        mock_handle.exception.assert_called()
+            with pytest.raises(UnknownError) as exc_info:
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
+        assert exc_info.value.stack_trace.args == ("network error",)
+
+    def test_invalid_git_repository_raises_its_catalogue_error(self):
+        mock_args = MagicMock(repo_url="https://github.com/org/repo.git", repo_branch="master")
+        invalid = git_exc.InvalidGitRepositoryError("/tmp/repo")
+
+        with _clone_present(), patch("core.repo.Repo", side_effect=invalid):
+            with pytest.raises(GitInvalidRepositoryError, match='The repo "/tmp/repo" is not a valid git repo.'):
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
 
 
 class TestCloneRepo:
     """Tests for DTLRepo.clone_repo(): successful clone and git error handling."""
 
-    def test_clone_repo_git_error_calls_exception(self):
+    def test_clone_repo_git_error_raises(self):
         mock_args = MagicMock()
         mock_args.repo_url = "https://github.com/org/repo.git"
         mock_args.repo_branch = "master"
-        mock_handle = MagicMock()
         with (
             _clone_present(False),
             patch("core.repo.Repo") as MockRepo,
         ):
             MockRepo.clone_from.side_effect = git_exc.GitCommandError("clone", 128)
-            _dtl_repo(mock_args, "/tmp/repo", mock_handle)
-        mock_handle.exception.assert_called()
+            with pytest.raises(GitCommandError):
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
 
-    def test_clone_repo_generic_error_calls_exception(self):
+    def test_clone_repo_generic_error_raises(self):
         mock_args = MagicMock()
         mock_args.repo_url = "https://github.com/org/repo.git"
         mock_args.repo_branch = "master"
-        mock_handle = MagicMock()
         with (
             _clone_present(False),
             patch("core.repo.Repo") as MockRepo,
         ):
             MockRepo.clone_from.side_effect = RuntimeError("failed")
-            _dtl_repo(mock_args, "/tmp/repo", mock_handle)
-        mock_handle.exception.assert_called()
+            with pytest.raises(UnknownError):
+                _dtl_repo(mock_args, "/tmp/repo", LogHandler(False))
 
 
 class TestGetDevices:
@@ -684,7 +691,7 @@ def test_slug_format():
     # However, creating DTLRepo instance requires args, repo_path, handler.
 
     mock_args = MagicMock()
-    mock_args.repo_url = "http://example.com"
+    mock_args.repo_url = "https://example.invalid/repo.git"
     mock_args.repo_branch = "master"
 
     mock_handle = MagicMock()
@@ -700,7 +707,7 @@ def test_slug_format():
 
 def test_parse_files():
     mock_args = MagicMock()
-    mock_args.repo_url = "http://example.com"
+    mock_args.repo_url = "https://example.invalid/repo.git"
     mock_args.repo_branch = "master"
     mock_handle = MagicMock()
 
@@ -735,7 +742,7 @@ part_number: C9300-24T-A
 
 def test_parse_files_missing_slug_does_not_crash():
     mock_args = MagicMock()
-    mock_args.repo_url = "http://example.com"
+    mock_args.repo_url = "https://example.invalid/repo.git"
     mock_args.repo_branch = "master"
     mock_handle = MagicMock()
 


### PR DESCRIPTION
Stacked on #114. Three commits, one per architecture candidate, implemented sequentially.

| commit | candidate |
|---|---|
| `5071ebf` | split `LogHandler` into a sink and a fatal-error policy |
| `f26bb92` | give the import pipeline an interface |
| `4b2ebd7` | delete the interface members only tests use |

## 5 — the invisible exit

A method named `exception` on an object named `handle` terminated the process, and nothing in its signature said so. Eleven call sites were written as if it returned; some ran code production could never reach. The catalogue was 8 magic strings in a dict literal, where an unknown key raised `KeyError` inside the error handler. Two exit mechanisms coexisted: `netbox_api` reached the catalogue once and called `system_exit` directly five times.

Each category is now a typed exception raised by the module that detects it (git errors in `repo.py`, TLS and NetBox errors in `netbox_api.py`, config errors in `config.py`). `core/errors.py` holds only the shared `FatalError` base and `UnknownError`. `main()` renders and exits once; the GraphQL and REST handlers moved there from `__main__`. Every user-facing message is unchanged.

`LogHandler` takes a `bool` instead of a namespace it read one attribute from. `ChangeDetector` gets that flag directly instead of reaching through the handler. `log_device_ports_created` / `log_module_ports_created` merge into `log_ports_created`; the count moves to `_create_generic`, which already holds the list.

**One behaviour change:** `requests.exceptions.SSLError` subclasses `ConnectionError`, so a certificate failure rendered as a generic connection error. The catalogue already carried an SSL message that no caller could reach; it now has a home in `verify_compatibility`, ahead of the `ConnectionError` branch.

Tests that passed a `MagicMock` handle now use a real `LogHandler` — a mocked `exception` returns where the real one exits, so those tests asserted a call and then ran on down a path production cannot take.

## 6 — 17 stages, none named

`_run` constructed the repo, constructed NetBox, then set three policy flags on it **after** construction, resolved three paths, discovered vendors, filtered, narrowed, acquired the console, and called a vendor loop taking **12 parameters**. The console lifecycle was split across two functions: `_run` acquired it, `_run_vendor_loop` released it in its own `finally`. Nothing separated deciding what to do for a vendor from doing it.

`core/import_run.py` owns the sequence:

```
ImportRun(config, repo, netbox, reporter, progress_factory).execute() -> RunSummary
  discover()            -> RunSelection
  plan_vendor(sel, v)   -> VendorPlan     (parses; never touches the NetBox import API)
  apply(plan)                             (consumes it)
```

`execute()` acquires and releases the console in one method. The 12 parameters became state on the object. `NetBox` reads its three policy flags from the config it is constructed with, so no post-construction assignment remains. The entry point keeps what belongs to the terminal (Rich columns, the progress panel, `--export-diff`, error rendering) and goes from **1095 lines to 200**.

Behaviour is unchanged: the loop body, the skip-and-advance path, the prefetch condition and the teardown order all match what they replaced.

Test effects: **six tests whose only assertion was that nothing raised** now assert on a returned summary, captured output, or the constructor call. Three flag tests asserted a post-construction attribute and now assert the config reaching the constructor, with a `NetBox` test covering the other half. One module-change test never reached the behaviour in its name because its setup had no vendors.

## 7 — members with no caller

`NetBox.get_api` and `NetBox.get_counter` returned public attributes. `NetBox._module_type_has_missing_components` was 15 lines with a three-test class; `git log -S` shows it arrived in `2af54a0` already uncalled and never had a production caller in any commit.

`REST_ONLY_ENDPOINTS` was an empty `frozenset` guarding two branches. The branch could not run in production, and its three tests monkeypatched the module global to reach a state the program cannot enter. Deleted per the owner's decision, with **[ADR 0001](docs/adr/0001-no-rest-fallback-for-component-fetch.md)** recording why and noting that restoring a REST path costs a few lines if a NetBox version ever drops a field from GraphQL but keeps it in REST. Coverage was checked after each deletion, not once at the end.

Nine other test-only members were found and left in place; they are listed in `4b2ebd7`.

## Verification

1015 tests pass, coverage **97.35%** (gate 96%). ruff, ruff-format and interrogate clean; ADR within the 120-char markdownlint limit.

Note: as with #113 and #114, `tests.yml` only triggers on PRs into `master`/`main`/`develop`, so this shows only the title check until the base moves to `develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete import workflow with planning, execution, progress tracking, summaries, and cleanup.
  * Added categorized error reporting for configuration, network, API, Git, and unexpected failures.
  * Added optional verbose diagnostics, including stack traces for fatal errors.

* **Bug Fixes**
  * Standardized component fetching through GraphQL with REST-based validation.
  * Improved cleanup and console restoration when imports or progress setup fail.
  * Improved vendor selection and validation feedback.

* **Documentation**
  * Documented component-fetching behavior and operational considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->