### PR TITLE
chore(ci): rename pull request image build job

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         name: Check the image runs
         run: ./.github/scripts/docker-smoke-test.sh nb-dt-import:smoke
 
-  build-and-push-images:
+  build-images:
     needs: smoke-test
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -18,7 +18,6 @@ def test_pull_request_image_build_has_no_package_write_permission():
     jobs = _jobs()
     job = jobs["build-images"]
 
-    assert "build-and-push-images" not in jobs
     assert job["if"] == "github.event_name == 'pull_request'"
     assert job["permissions"] == {"contents": "read"}
     build = next(step for step in job["steps"] if step.get("uses", "").startswith("docker/build-push-action@"))

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -15,8 +15,10 @@ def _jobs():
 
 def test_pull_request_image_build_has_no_package_write_permission():
     """A pull request can build untrusted code, so its token must be read-only."""
-    job = _jobs()["build-and-push-images"]
+    jobs = _jobs()
+    job = jobs["build-images"]
 
+    assert "build-and-push-images" not in jobs
     assert job["if"] == "github.event_name == 'pull_request'"
     assert job["permissions"] == {"contents": "read"}
     build = next(step for step in job["steps"] if step.get("uses", "").startswith("docker/build-push-action@"))


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the pull-request Docker build job for improved clarity.
  * Existing build behavior remains unchanged.
  * Updated automated checks to reflect the new job name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->