### PR TITLE
feat:  REPO_URL=local sentinel to skip git update entirely

### DIFF
--- a/core/repo.py
+++ b/core/repo.py
@@ -419,11 +419,13 @@ class DTLRepo:
     def __init__(self, config, handle):
         """Initialize repository management, updating an existing clone or creating a new one.
 
-        If the target path already holds a Git clone, the repository will be updated from
-        its configured remote; otherwise the provided URL is validated and a new clone is
-        created. The initializer sets instance attributes used by other methods (handler,
-        supported YAML extensions, URL, repo path, branch, repo reference, and current
-        working directory).
+        If REPO_URL is the sentinel "local", no git operation of any kind is performed —
+        REPO_PATH is used as-is and must already contain the device-type file tree.
+        Otherwise, if the target path already holds a Git clone, the repository will be
+        updated from its configured remote; if not, the provided URL is validated and a new
+        clone is created. The initializer sets instance attributes used by other methods
+        (handler, supported YAML extensions, URL, repo path, branch, repo reference, and
+        current working directory).
 
         Args:
             config (RunConfig): Supplies `repo_url`, `repo_branch`, and `repo_path`.
@@ -440,6 +442,14 @@ class DTLRepo:
         self.branch = config.repo_branch
         self.repo = None
         self.cwd = os.getcwd()
+
+        if str(self.url).strip().casefold() == "local":
+            if not os.path.isdir(self.get_absolute_path()):
+                raise InvalidRepoPathError(
+                    self.repo_path, reason="REPO_URL=local requires REPO_PATH to already contain the library files"
+                )
+            self.handle.log(f"REPO_URL=local: using {self.get_absolute_path()} as-is, no git operations")
+            return
 
         is_path_valid, path_error = validate_repo_path(self.repo_path)
         if not is_path_valid:


### PR DESCRIPTION
### Problem

Import mode always runs a git operation. On a fresh `REPO_PATH` it clones. On an existing checkout it fetches from origin. There's no way to just point the tool at a directory that already has the library files and have it read them, nothing else.

This used to work by accident with `REPO_URL=local`, back before `validate_git_url()` existed. Once that validator landed, `'local'` got rejected as an invalid URL, since it matches none of `https://`, `ssh://`, `git@host:`, or `file://`. Even fixing the URL string wouldn't fully solve it though: `pull_repo()` calls `self.repo.remotes.origin.fetch(prune=True)` unconditionally whenever `.git` exists at `REPO_PATH`, regardless of what `REPO_URL` is set to. Anyone running this in an air-gapped environment, or just working from a local copy they manage themselves, has no way to avoid that fetch.

Export mode already handles this correctly — `--export-diff` never clones or updates, it just reads whatever's at `REPO_PATH`. Import mode has no equivalent.

### Fix

`DTLRepo.__init__` now checks for `REPO_URL=local` (case-insensitive) before touching git at all. When set, it verifies `REPO_PATH` exists and returns immediately without `Repo()`, `clone_from()`, or `fetch()`. `REPO_PATH` is expected to already contain `device-types/`, `module-types/`, `rack-types/`, and ideally `tests/known-*.json` for the slug-index fast path, the same layout the tool produces on a normal clone.

No `.git` directory is required or read in this mode.

### Behavior change

None for existing users. `REPO_URL` defaults to the community library URL as before; this only activates on the literal value `local`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using an existing local directory as the repository source.
  * Local mode now validates the configured directory and skips unnecessary repository operations.

* **Bug Fixes**
  * Preserved repository validation, updates, and cloning for standard remote configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->