### PR TITLE
fix(netbox): name the item NetBox rejected in a bulk create

### DIFF
--- a/core/change_detector.py
+++ b/core/change_detector.py
@@ -545,12 +545,17 @@ class ChangeDetector:
             for comp in removed:
                 self.handle.verbose_log(f"        - {comp.component_type}: {comp.component_name}")
 
-    def log_change_report(self, report: ChangeReport):
+    def log_change_report(self, report: ChangeReport, vendor: str = ""):
         """Log the change report in a clear, readable format.
 
         Suppresses the full banner when there are no new or modified types —
         emits a single verbose-level summary instead to avoid flooding the
         terminal with empty reports during a multi-vendor run.
+
+        Args:
+            report: The change report to render.
+            vendor: Vendor name appended to the banner title, so consecutive
+                reports in a multi-vendor run stay distinguishable.
         """
         has_changes = report.new_device_types or report.modified_device_types
         if not has_changes:
@@ -559,7 +564,7 @@ class ChangeDetector:
             return
 
         self.handle.log("=" * 60)
-        self.handle.log("CHANGE DETECTION REPORT")
+        self.handle.log(f"CHANGE DETECTION REPORT: {vendor}" if vendor else "CHANGE DETECTION REPORT")
         self.handle.log("=" * 60)
 
         self.handle.log(f"New device types: {len(report.new_device_types)}")

--- a/core/import_run.py
+++ b/core/import_run.py
@@ -512,7 +512,7 @@ def _log_run_summary(handle, summary):
         handle.log(f"{component_updates} device types had component-only updates")
     failed = summary.outcome_count(EntityKind.DEVICE_TYPE, Outcome.FAILED)
     if failed:
-        handle.log(f"{failed} device types FAILED to update (see error log above)")
+        handle.log(f"{failed} device types FAILED to create or update (see error log above)")
     device_partial = summary.outcome_count(EntityKind.DEVICE_TYPE, Outcome.PARTIAL)
     if device_partial:
         handle.log(f"{device_partial} device types partially updated")
@@ -526,7 +526,7 @@ def _log_run_summary(handle, summary):
         handle.log(f"{counter['module_updated']} modules updated")
         module_failed = summary.outcome_count(EntityKind.MODULE_TYPE, Outcome.FAILED)
         if module_failed:
-            handle.log(f"{module_failed} modules failed to update")
+            handle.log(f"{module_failed} modules failed to create or update")
         module_partial = summary.outcome_count(EntityKind.MODULE_TYPE, Outcome.PARTIAL)
         if module_partial:
             handle.log(f"{module_partial} modules partially updated")

--- a/core/import_run.py
+++ b/core/import_run.py
@@ -513,6 +513,9 @@ def _log_run_summary(handle, summary):
     failed = summary.outcome_count(EntityKind.DEVICE_TYPE, Outcome.FAILED)
     if failed:
         handle.log(f"{failed} device types FAILED to update (see error log above)")
+    device_partial = summary.outcome_count(EntityKind.DEVICE_TYPE, Outcome.PARTIAL)
+    if device_partial:
+        handle.log(f"{device_partial} device types partially updated")
     handle.log(f"{counter['components_updated']} components updated")
     handle.log(f"{counter['components_added']} components added")
     handle.log(f"{counter['components_removed']} components removed")

--- a/core/import_run.py
+++ b/core/import_run.py
@@ -269,7 +269,9 @@ def _image_progress_scope(progress, device_types, total=0):
             progress.remove_task(image_task)
 
 
-def _process_device_types(config, netbox, handle, progress, device_types, vendor_slug=None, task_registry=None):
+def _process_device_types(
+    config, netbox, handle, progress, device_types, vendor_slug=None, vendor_name="", task_registry=None
+):
     """Process device types for one vendor."""
     if config.only_new:
         new_device_types = filter_new_device_types(
@@ -311,7 +313,7 @@ def _process_device_types(config, netbox, handle, progress, device_types, vendor
         device_types,
         progress=get_progress_wrapper(progress, device_types, desc="Detecting Changes", task_registry=task_registry),
     )
-    detector.log_change_report(change_report)
+    detector.log_change_report(change_report, vendor=vendor_name)
 
     if config.update:
         device_types_to_process = select_device_types_for_update_mode(
@@ -356,7 +358,7 @@ def _process_device_types(config, netbox, handle, progress, device_types, vendor
             handle.verbose_log("No new device types or missing images to process.")
 
 
-def _process_module_types(config, netbox, handle, progress, module_types, task_registry=None):
+def _process_module_types(config, netbox, handle, progress, module_types, vendor_name="", task_registry=None):
     """Process module types for one vendor."""
     if not module_types:
         return
@@ -390,7 +392,7 @@ def _process_module_types(config, netbox, handle, progress, module_types, task_r
     has_module_changes = new_module_count > 0 or module_changed_count > 0 or pending_removal_modules > 0
     if has_module_changes:
         handle.log("============================================================")
-        handle.log("MODULE TYPE CHANGE DETECTION")
+        handle.log(f"MODULE TYPE CHANGE DETECTION: {vendor_name}" if vendor_name else "MODULE TYPE CHANGE DETECTION")
         handle.log("============================================================")
         if config.only_new:
             handle.log(f"New module types: {new_module_count}")
@@ -436,7 +438,7 @@ def _process_module_types(config, netbox, handle, progress, module_types, task_r
         handle.verbose_log("No module type changes to process.")
 
 
-def _process_rack_types(config, netbox, handle, progress, rack_types, task_registry=None):
+def _process_rack_types(config, netbox, handle, progress, rack_types, vendor_name="", task_registry=None):
     """Process rack types for one vendor."""
     if not rack_types:
         return
@@ -458,6 +460,8 @@ def _process_rack_types(config, netbox, handle, progress, rack_types, task_regis
     if new_count == 0:
         handle.verbose_log(f"No new rack types ({existing_count} unchanged).")
     else:
+        handle.log("============================================================")
+        handle.log(f"RACK TYPE CHANGE DETECTION: {vendor_name}" if vendor_name else "RACK TYPE CHANGE DETECTION")
         handle.log("============================================================")
         handle.log(f"New rack types:       {new_count}")
         handle.log(f"Existing rack types:  {existing_count}")
@@ -709,6 +713,7 @@ class ImportRun:
             self.progress,
             plan.device_types,
             vendor_slug=plan.vendor["slug"],
+            vendor_name=plan.vendor["name"],
             task_registry=self.task_registry,
         )
         cache.pump()
@@ -720,6 +725,7 @@ class ImportRun:
                 self.reporter,
                 self.progress,
                 plan.module_types,
+                vendor_name=plan.vendor["name"],
                 task_registry=self.task_registry,
             )
             cache.pump()
@@ -730,6 +736,7 @@ class ImportRun:
             self.reporter,
             self.progress,
             plan.rack_types,
+            vendor_name=plan.vendor["name"],
             task_registry=self.task_registry,
         )
         cache.pump()

--- a/core/import_run.py
+++ b/core/import_run.py
@@ -11,6 +11,7 @@ from core.change_detector import ChangeDetector, ChangeType, IMAGE_PROPERTIES
 from core.component_cache import NullTaskDisplay, RichTaskDisplay
 from core.config import RunConfig
 from core.errors import VendorSelectionError
+from core.outcomes import EntityKind, Outcome
 
 
 _PROGRESS_DESC_WIDTH = 28
@@ -50,21 +51,32 @@ class RunSummary:
     counter: Counter
     modules: bool
     rack_types: bool
+    outcome_counts: dict
     failure_lines: tuple
     duplicate_definitions: tuple
     elapsed: timedelta
 
     @classmethod
     def capture(cls, netbox, repo, started_at):
-        """Capture mutable run state as a summary value."""
+        """Capture mutable run state as a summary value.
+
+        ``outcome_counts`` and ``failure_lines`` are both derived from the outcome
+        registry at the same instant, so the headline counts cannot disagree with
+        the itemised report below them.
+        """
         return cls(
             counter=Counter(netbox.counter),
             modules=netbox.modules,
             rack_types=netbox.rack_types,
+            outcome_counts=netbox.outcomes.summary_by_kind(),
             failure_lines=tuple(netbox.outcomes.render_failure_report()),
             duplicate_definitions=tuple(repo.duplicate_definitions),
             elapsed=datetime.now() - started_at,
         )
+
+    def outcome_count(self, kind, outcome):
+        """Return how many entities of *kind* ended with *outcome*."""
+        return self.outcome_counts.get(kind, {}).get(outcome, 0)
 
 
 def get_progress_wrapper(progress, iterable, desc=None, total=None, on_step=None, task_registry=None):
@@ -498,7 +510,7 @@ def _log_run_summary(handle, summary):
     component_updates = counter.get("device_types_component_updates", 0)
     if component_updates:
         handle.log(f"{component_updates} device types had component-only updates")
-    failed = counter.get("device_types_failed", 0)
+    failed = summary.outcome_count(EntityKind.DEVICE_TYPE, Outcome.FAILED)
     if failed:
         handle.log(f"{failed} device types FAILED to update (see error log above)")
     handle.log(f"{counter['components_updated']} components updated")
@@ -509,13 +521,18 @@ def _log_run_summary(handle, summary):
     if summary.modules:
         handle.log(f"{counter['module_added']} modules created")
         handle.log(f"{counter['module_updated']} modules updated")
-        if counter["module_update_failed"]:
-            handle.log(f"{counter['module_update_failed']} modules failed to update")
-        if counter["module_partial_update"]:
-            handle.log(f"{counter['module_partial_update']} modules partially updated")
+        module_failed = summary.outcome_count(EntityKind.MODULE_TYPE, Outcome.FAILED)
+        if module_failed:
+            handle.log(f"{module_failed} modules failed to update")
+        module_partial = summary.outcome_count(EntityKind.MODULE_TYPE, Outcome.PARTIAL)
+        if module_partial:
+            handle.log(f"{module_partial} modules partially updated")
     if summary.rack_types:
         handle.log(f"{counter['rack_type_added']} rack types created")
         handle.log(f"{counter['rack_type_updated']} rack types updated")
+        rack_failed = summary.outcome_count(EntityKind.RACK_TYPE, Outcome.FAILED)
+        if rack_failed:
+            handle.log(f"{rack_failed} rack types failed")
 
     for line in summary.failure_lines:
         handle.log(line)

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -2471,7 +2471,7 @@ class DeviceTypes:
             except pynetbox.RequestError as e:
                 self._log_component_error(f"Error updating {comp_type} (ID: {update_data['id']}): {e.error}")
             except _RETRYABLE_EXCEPTIONS as e:
-                self.handle.log(
+                self._log_component_error(
                     f"Connection error updating {comp_type} (ID: {update_data['id']}) after {_MAX_RETRIES} retries: {e}"
                 )
 
@@ -2577,7 +2577,7 @@ class DeviceTypes:
                 except pynetbox.RequestError as e:
                     self._log_component_error(f"Error removing {comp_type} (ID: {comp_id}): {e.error}")
                 except _RETRYABLE_EXCEPTIONS as e:
-                    self.handle.log(
+                    self._log_component_error(
                         f"Connection error removing {comp_type} (ID: {comp_id}) after {_MAX_RETRIES} retries: {e}"
                     )
 

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -1085,7 +1085,13 @@ class NetBox:
                 f" {device_type.get('manufacturer', {}).get('slug', '')} {device_type.get('model', '')}"
                 f" (Context: {src_file})"
             )
-            self._record_create_failure(device_type, str(e.error), src_file)
+            self._record_failure(
+                EntityKind.DEVICE_TYPE,
+                self._yaml_identity(device_type),
+                str(e.error),
+                src_file,
+                counter_key="device_types_failed",
+            )
             return None, True
         except _RETRYABLE_EXCEPTIONS as e:
             self.handle.log(
@@ -1093,24 +1099,35 @@ class NetBox:
                 f" {device_type.get('manufacturer', {}).get('slug', '')} {device_type.get('model', '')}"
                 f" after {_MAX_RETRIES} retries: {e} (Context: {src_file})"
             )
-            self._record_create_failure(device_type, f"Connection error after {_MAX_RETRIES} retries: {e}", src_file)
+            self._record_failure(
+                EntityKind.DEVICE_TYPE,
+                self._yaml_identity(device_type),
+                f"Connection error after {_MAX_RETRIES} retries: {e}",
+                src_file,
+                counter_key="device_types_failed",
+            )
             return None, True
 
-    def _record_create_failure(self, device_type, reason, src_file):
-        """Record a failed device-type creation so it reaches the end-of-run report.
+    def _record_failure(self, kind, identity, reason, src_file, *, counter_key=None):
+        """Record a failed entity so it reaches the end-of-run report.
 
-        A parsed YAML dict carries only the manufacturer slug, so the identity uses
-        the slug where the update path can use the NetBox manufacturer name.
+        Every create/update failure path must call this; logging alone leaves the
+        failure out of the summary and out of the failed count.
         """
-        identity = f"{device_type.get('manufacturer', {}).get('slug', '')}/{device_type.get('model', '')}"
-        self.counter.update({"device_types_failed": 1})
+        if counter_key:
+            self.counter.update({counter_key: 1})
         self.outcomes.record(
-            EntityKind.DEVICE_TYPE,
+            kind,
             identity,
             Outcome.FAILED,
             reason=reason,
             hint=f"Source: {src_file}" if src_file else None,
         )
+
+    @staticmethod
+    def _yaml_identity(parsed):
+        """Build a report identity from a parsed YAML dict, which carries only the slug."""
+        return f"{parsed.get('manufacturer', {}).get('slug', '')}/{parsed.get('model', '')}"
 
     def _create_device_type_components(self, device_type, dt_id, src_file, saved_images):
         """Create all component templates and upload images for a newly created device type.
@@ -1296,10 +1313,19 @@ class NetBox:
                         )
                     except pynetbox.RequestError as e:
                         self.handle.log(f"Error updating Rack Type {model}: {e.error} (Context: {src_file})")
+                        self._record_failure(
+                            EntityKind.RACK_TYPE, f"{manufacturer_slug}/{model}", str(e.error), src_file
+                        )
                     except _RETRYABLE_EXCEPTIONS as e:
                         self.handle.log(
                             f"Connection error updating Rack Type {model} after {_MAX_RETRIES} retries:"
                             f" {e} (Context: {src_file})"
+                        )
+                        self._record_failure(
+                            EntityKind.RACK_TYPE,
+                            f"{manufacturer_slug}/{model}",
+                            f"Connection error after {_MAX_RETRIES} retries: {e}",
+                            src_file,
                         )
                 else:
                     self.handle.verbose_log(f"Rack Type Unchanged: {manufacturer_slug} - {model} - {existing.id}")
@@ -1311,10 +1337,19 @@ class NetBox:
                     self.handle.verbose_log(f"Rack Type Created: {manufacturer_slug} - {model} - {rt.id}")
                 except pynetbox.RequestError as excep:
                     self.handle.log(f"Error creating Rack Type: {excep.error} (Context: {src_file})")
+                    self._record_failure(
+                        EntityKind.RACK_TYPE, f"{manufacturer_slug}/{model}", str(excep.error), src_file
+                    )
                 except _RETRYABLE_EXCEPTIONS as e:
                     self.handle.log(
                         f"Connection error creating Rack Type {model} after {_MAX_RETRIES} retries:"
                         f" {e} (Context: {src_file})"
+                    )
+                    self._record_failure(
+                        EntityKind.RACK_TYPE,
+                        f"{manufacturer_slug}/{model}",
+                        f"Connection error after {_MAX_RETRIES} retries: {e}",
+                        src_file,
                     )
 
     @staticmethod
@@ -1701,10 +1736,22 @@ class NetBox:
                 )
             except pynetbox.RequestError as excep:
                 self.handle.log(f"Error creating Module Type: {excep.error} (Context: {src_file})")
+                self._record_failure(
+                    EntityKind.MODULE_TYPE,
+                    self._yaml_identity(curr_mt),
+                    str(excep.error),
+                    src_file,
+                )
                 return False
             except _RETRYABLE_EXCEPTIONS as e:
                 self.handle.log(
                     f"Connection error creating Module Type after {_MAX_RETRIES} retries: {e} (Context: {src_file})"
+                )
+                self._record_failure(
+                    EntityKind.MODULE_TYPE,
+                    self._yaml_identity(curr_mt),
+                    f"Connection error after {_MAX_RETRIES} retries: {e}",
+                    src_file,
                 )
                 return False
 

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -1,6 +1,7 @@
 """NetBox REST and GraphQL API client for importing device and module type libraries."""
 
 from collections import Counter
+from contextlib import contextmanager
 from functools import lru_cache
 import hashlib
 import json
@@ -1048,22 +1049,21 @@ class NetBox:
                     self.counter["components_added"],
                     self.counter["components_removed"],
                 )
-                self.device_types.take_errors()
-                self.device_types.update_components(
-                    device_type,
-                    dt.id,
-                    dt_change.component_changes,
-                    parent_type="device",
-                )
-                if remove_components:
-                    self.device_types.remove_components(dt.id, dt_change.component_changes, parent_type="device")
+                with self.device_types.collect_component_errors() as component_errors:
+                    self.device_types.update_components(
+                        device_type,
+                        dt.id,
+                        dt_change.component_changes,
+                        parent_type="device",
+                    )
+                    if remove_components:
+                        self.device_types.remove_components(dt.id, dt_change.component_changes, parent_type="device")
                 after_components = (
                     self.counter["components_updated"],
                     self.counter["components_added"],
                     self.counter["components_removed"],
                 )
                 component_delta = sum(after_components) - sum(before_components)
-                component_errors = self.device_types.take_errors()
 
             # Distinguish full update, partial, and complete failure.
             self._log_device_type_change_outcome(
@@ -1155,13 +1155,22 @@ class NetBox:
             src_file (str): Filesystem path to the YAML source file (for front-port context).
             saved_images (dict): Mapping of image kind to local file path for upload.
         """
-        for component in COMPONENT_TYPES:
-            yaml_key = component.yaml_key
-            if yaml_key not in device_type:
-                continue
-            if yaml_key == "module-bays" and not self.modules:
-                continue
-            self.device_types.create_components(yaml_key, device_type[yaml_key], dt_id, context=src_file)
+        with self.device_types.collect_component_errors() as component_errors:
+            for component in COMPONENT_TYPES:
+                yaml_key = component.yaml_key
+                if yaml_key not in device_type:
+                    continue
+                if yaml_key == "module-bays" and not self.modules:
+                    continue
+                self.device_types.create_components(yaml_key, device_type[yaml_key], dt_id, context=src_file)
+        if component_errors:
+            # The type exists but not all of its components do.
+            self.outcomes.record(
+                EntityKind.DEVICE_TYPE,
+                self._yaml_identity(device_type),
+                Outcome.PARTIAL,
+                reason=_summarise_component_errors(component_errors),
+            )
         if saved_images:
             self.device_types.upload_images(self.url, self.token, saved_images, dt_id)
             _store_image_hashes(self._image_hash_cache, saved_images, log_fn=self.handle.log)
@@ -1608,12 +1617,21 @@ class NetBox:
             module_type_id (int): ID of the newly created module type in NetBox.
             src_file (str): Source file path for error context.
         """
-        for component in MODULE_TYPE_COMPONENTS:
-            yaml_key = component.yaml_key
-            if yaml_key in curr_mt:
-                self.device_types.create_components(
-                    yaml_key, curr_mt[yaml_key], module_type_id, parent_type="module", context=src_file
-                )
+        with self.device_types.collect_component_errors() as component_errors:
+            for component in MODULE_TYPE_COMPONENTS:
+                yaml_key = component.yaml_key
+                if yaml_key in curr_mt:
+                    self.device_types.create_components(
+                        yaml_key, curr_mt[yaml_key], module_type_id, parent_type="module", context=src_file
+                    )
+        if component_errors:
+            # The module type exists but not all of its components do.
+            self.outcomes.record(
+                EntityKind.MODULE_TYPE,
+                self._yaml_identity(curr_mt),
+                Outcome.PARTIAL,
+                reason=_summarise_component_errors(component_errors),
+            )
 
     def _apply_module_type_component_updates(
         self, curr_mt, module_type_res, properties_updated, remove_components, patch_ok=True
@@ -1638,9 +1656,12 @@ class NetBox:
             before_updated = self.counter["components_updated"]
             before_added = self.counter["components_added"]
             before_removed = self.counter["components_removed"]
-            self.device_types.update_components(curr_mt, module_type_res.id, component_changes, parent_type="module")
-            if remove_components:
-                self.device_types.remove_components(module_type_res.id, component_changes, parent_type="module")
+            with self.device_types.collect_component_errors() as component_errors:
+                self.device_types.update_components(
+                    curr_mt, module_type_res.id, component_changes, parent_type="module"
+                )
+                if remove_components:
+                    self.device_types.remove_components(module_type_res.id, component_changes, parent_type="module")
             component_delta = (
                 self.counter["components_updated"]
                 - before_updated
@@ -1657,7 +1678,8 @@ class NetBox:
                         EntityKind.MODULE_TYPE,
                         identity,
                         Outcome.FAILED,
-                        reason="Scalar PATCH failed; no component changes were actionable.",
+                        reason=_summarise_component_errors(component_errors)
+                        or "Scalar PATCH failed; no component changes were actionable.",
                     )
             elif component_delta == 0:
                 if properties_updated and patch_ok:
@@ -1667,10 +1689,11 @@ class NetBox:
                         EntityKind.MODULE_TYPE,
                         identity,
                         Outcome.PARTIAL,
-                        reason="Properties updated; component reconciliation applied 0 changes.",
+                        reason=_summarise_component_errors(component_errors)
+                        or "Properties updated; component reconciliation applied 0 changes.",
                     )
                 else:
-                    reason = (
+                    reason = _summarise_component_errors(component_errors) or (
                         "Scalar PATCH failed; component reconciliation ran but applied 0 changes."
                         if not patch_ok
                         else "Component reconciliation ran but applied 0 changes."
@@ -1686,11 +1709,13 @@ class NetBox:
             else:
                 reason_parts = [] if patch_ok else ["Property PATCH failed"]
                 reason_parts.append(f"applied {component_delta} of {actionable_count} component change(s)")
+                reason = "; ".join(reason_parts) + "."
+                detail = _summarise_component_errors(component_errors)
                 self.outcomes.record(
                     EntityKind.MODULE_TYPE,
                     identity,
                     Outcome.PARTIAL,
-                    reason="; ".join(reason_parts) + ".",
+                    reason=f"{reason} {detail}" if detail else reason,
                 )
         elif properties_updated and patch_ok:
             self.counter["module_updated"] += 1
@@ -2203,8 +2228,7 @@ class DeviceTypes:
             wrap_record=_FrontPortRecordWithMappings,
         )
         self._image_progress = None
-        # Component failures logged since the last take_errors(), so the caller can
-        # put NetBox's own message into the device type's outcome record.
+        # Component failures for the entity currently inside collect_component_errors().
         self._component_errors: list[str] = []
         self.existing_device_types = {}
         self.existing_device_types_by_slug = {}
@@ -2244,10 +2268,21 @@ class DeviceTypes:
             device_type_ids={record.id for record in self.existing_device_types.values()},
         )
 
-    def take_errors(self):
-        """Return the component errors recorded since the last call, and clear them."""
-        errors, self._component_errors = self._component_errors, []
-        return errors
+    @contextmanager
+    def collect_component_errors(self):
+        """Scope component failure messages to one entity's component work.
+
+        Yields a list that holds the messages logged inside the block. The buffer is
+        cleared on entry and on exit, so one entity's failures can never surface in
+        another's outcome reason, and a caller cannot forget to clear it.
+        """
+        self._component_errors = []
+        collected: list[str] = []
+        try:
+            yield collected
+        finally:
+            collected.extend(self._component_errors)
+            self._component_errors = []
 
     def _log_component_error(self, message):
         """Log a component failure and keep it for the caller's outcome record."""

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -1085,6 +1085,7 @@ class NetBox:
                 f" {device_type.get('manufacturer', {}).get('slug', '')} {device_type.get('model', '')}"
                 f" (Context: {src_file})"
             )
+            self._record_create_failure(device_type, str(e.error), src_file)
             return None, True
         except _RETRYABLE_EXCEPTIONS as e:
             self.handle.log(
@@ -1092,7 +1093,24 @@ class NetBox:
                 f" {device_type.get('manufacturer', {}).get('slug', '')} {device_type.get('model', '')}"
                 f" after {_MAX_RETRIES} retries: {e} (Context: {src_file})"
             )
+            self._record_create_failure(device_type, f"Connection error after {_MAX_RETRIES} retries: {e}", src_file)
             return None, True
+
+    def _record_create_failure(self, device_type, reason, src_file):
+        """Record a failed device-type creation so it reaches the end-of-run report.
+
+        A parsed YAML dict carries only the manufacturer slug, so the identity uses
+        the slug where the update path can use the NetBox manufacturer name.
+        """
+        identity = f"{device_type.get('manufacturer', {}).get('slug', '')}/{device_type.get('model', '')}"
+        self.counter.update({"device_types_failed": 1})
+        self.outcomes.record(
+            EntityKind.DEVICE_TYPE,
+            identity,
+            Outcome.FAILED,
+            reason=reason,
+            hint=f"Source: {src_file}" if src_file else None,
+        )
 
     def _create_device_type_components(self, device_type, dt_id, src_file, saved_images):
         """Create all component templates and upload images for a newly created device type.

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -418,6 +418,16 @@ def _count_actionable_component_changes(changes, remove_components):
     )
 
 
+def _summarise_component_errors(errors, limit=3):
+    """Join component failure messages into one reason line, or "" when there are none."""
+    if not errors:
+        return ""
+    shown = "; ".join(errors[:limit])
+    if len(errors) > limit:
+        shown += f" (+{len(errors) - limit} more)"
+    return shown
+
+
 class NetBox:
     """Interface to the NetBox API for importing device and module types."""
 
@@ -787,6 +797,7 @@ class NetBox:
         component_delta,
         actionable_count,
         failure_resolution=None,
+        component_errors=None,
     ):
         """Emit the right post-update log for an existing device type.
 
@@ -815,6 +826,9 @@ class NetBox:
             failure_resolution: Optional :class:`FailureResolution` whose
                 ``description``, ``blocking_objects`` and ``hint`` will be
                 attached to the registry record when the update failed.
+            component_errors: Component failure messages collected during this
+                device type's component work, used as the outcome reason so the
+                summary carries NetBox's own message.
         """
         identity = f"{dt.manufacturer.name}/{dt.model}"
         component_attempted = actionable_count > 0
@@ -846,6 +860,9 @@ class NetBox:
                     else:
                         reason_parts.append(f"applied {component_delta} component change(s)")
                 reason = "; ".join(reason_parts) + "." if reason_parts else "Partial update."
+                detail = _summarise_component_errors(component_errors)
+                if detail:
+                    reason = f"{reason} {detail}"
                 self.handle.verbose_log(
                     f"Device Type Partially Updated: {dt.manufacturer.name} - {dt.model} - {dt.id}. {reason}"
                 )
@@ -872,7 +889,8 @@ class NetBox:
                 reason=(
                     failure_resolution.description
                     if failure_resolution
-                    else (
+                    else _summarise_component_errors(component_errors)
+                    or (
                         "Property PATCH and component updates failed."
                         if property_attempted and component_attempted
                         else "Property PATCH failed."
@@ -1024,6 +1042,7 @@ class NetBox:
                         )
 
             # Apply component changes
+            component_errors = []
             if dt_change.component_changes:
                 actionable_count = _count_actionable_component_changes(dt_change.component_changes, remove_components)
                 before_components = (
@@ -1031,6 +1050,7 @@ class NetBox:
                     self.counter["components_added"],
                     self.counter["components_removed"],
                 )
+                self.device_types.take_errors()
                 self.device_types.update_components(
                     device_type,
                     dt.id,
@@ -1045,6 +1065,7 @@ class NetBox:
                     self.counter["components_removed"],
                 )
                 component_delta = sum(after_components) - sum(before_components)
+                component_errors = self.device_types.take_errors()
 
             # Distinguish full update, partial, and complete failure.
             self._log_device_type_change_outcome(
@@ -1055,6 +1076,7 @@ class NetBox:
                 component_delta=component_delta,
                 actionable_count=actionable_count,
                 failure_resolution=failure_resolution,
+                component_errors=component_errors,
             )
         else:
             self.handle.verbose_log(
@@ -2177,6 +2199,9 @@ class DeviceTypes:
             wrap_record=_FrontPortRecordWithMappings,
         )
         self._image_progress = None
+        # Component failures logged since the last take_errors(), so the caller can
+        # put NetBox's own message into the device type's outcome record.
+        self._component_errors: list[str] = []
         self.existing_device_types = {}
         self.existing_device_types_by_slug = {}
 
@@ -2214,6 +2239,16 @@ class DeviceTypes:
             manufacturer_slug=manufacturer_slug,
             device_type_ids={record.id for record in self.existing_device_types.values()},
         )
+
+    def take_errors(self):
+        """Return the component errors recorded since the last call, and clear them."""
+        errors, self._component_errors = self._component_errors, []
+        return errors
+
+    def _log_component_error(self, message):
+        """Log a component failure and keep it for the caller's outcome record."""
+        self.handle.log(message)
+        self._component_errors.append(message)
 
     def _create_generic(
         self,
@@ -2271,18 +2306,18 @@ class DeviceTypes:
                 for item, error in zip(to_create, per_item):
                     if error:
                         reported += 1
-                        self.handle.log(
+                        self._log_component_error(
                             f"Failed to create {component_name} '{item.get('name', 'Unknown')}': {error}{context_str}"
                         )
                 if not reported:
                     failed_items = [x["name"] for x in to_create]
-                    self.handle.log(
+                    self._log_component_error(
                         f"Error '{excep.error}' creating {component_name}. Items: {failed_items}{context_str}"
                     )
             except _RETRYABLE_EXCEPTIONS as excep:
                 context_str = f" (Context: {context})" if context else ""
                 failed_items = [x["name"] for x in to_create]
-                self.handle.log(
+                self._log_component_error(
                     f"Connection error creating {component_name} after {_MAX_RETRIES} retries: {excep}."
                     f" Items: {failed_items}{context_str}"
                 )
@@ -2434,7 +2469,7 @@ class DeviceTypes:
                 success_count += 1
                 self.handle.verbose_log(f"Updated {comp_type} (ID: {update_data['id']})")
             except pynetbox.RequestError as e:
-                self.handle.log(f"Error updating {comp_type} (ID: {update_data['id']}): {e.error}")
+                self._log_component_error(f"Error updating {comp_type} (ID: {update_data['id']}): {e.error}")
             except _RETRYABLE_EXCEPTIONS as e:
                 self.handle.log(
                     f"Connection error updating {comp_type} (ID: {update_data['id']}) after {_MAX_RETRIES} retries: {e}"
@@ -2540,7 +2575,7 @@ class DeviceTypes:
                     _retry_on_connection_error(endpoint.delete, [comp_id])
                     success_count += 1
                 except pynetbox.RequestError as e:
-                    self.handle.log(f"Error removing {comp_type} (ID: {comp_id}): {e.error}")
+                    self._log_component_error(f"Error removing {comp_type} (ID: {comp_id}): {e.error}")
                 except _RETRYABLE_EXCEPTIONS as e:
                     self.handle.log(
                         f"Connection error removing {comp_type} (ID: {comp_id}) after {_MAX_RETRIES} retries: {e}"

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -452,7 +452,6 @@ class NetBox:
             properties_updated=0,
             components_updated=0,
             components_removed=0,
-            device_types_failed=0,
         )
         self.outcomes = OutcomeRegistry()
         self.url = config.netbox_url
@@ -875,7 +874,6 @@ class NetBox:
                     hint=(failure_resolution.hint if failure_resolution else None),
                 )
         elif property_attempted or component_attempted:
-            self.counter.update({"device_types_failed": 1})
             self.handle.log(
                 f"Device Type Update Failed: {dt.manufacturer.name} - {dt.model} - {dt.id}. "
                 f"Attempted {1 if property_attempted else 0} property PATCH and "
@@ -1112,7 +1110,6 @@ class NetBox:
                 self._yaml_identity(device_type),
                 str(e.error),
                 src_file,
-                counter_key="device_types_failed",
             )
             return None, True
         except _RETRYABLE_EXCEPTIONS as e:
@@ -1126,18 +1123,16 @@ class NetBox:
                 self._yaml_identity(device_type),
                 f"Connection error after {_MAX_RETRIES} retries: {e}",
                 src_file,
-                counter_key="device_types_failed",
             )
             return None, True
 
-    def _record_failure(self, kind, identity, reason, src_file, *, counter_key=None):
+    def _record_failure(self, kind, identity, reason, src_file):
         """Record a failed entity so it reaches the end-of-run report.
 
-        Every create/update failure path must call this; logging alone leaves the
-        failure out of the summary and out of the failed count.
+        Every create/update failure path must call this. The registry is the only
+        tally of failures: the run summary derives its counts from these rows, so a
+        path that merely logs is absent from both the count and the itemised report.
         """
-        if counter_key:
-            self.counter.update({counter_key: 1})
         self.outcomes.record(
             kind,
             identity,
@@ -1658,7 +1653,6 @@ class NetBox:
                 if properties_updated and patch_ok:
                     self.counter["module_updated"] += 1
                 elif not patch_ok:
-                    self.counter["module_update_failed"] += 1
                     self.outcomes.record(
                         EntityKind.MODULE_TYPE,
                         identity,
@@ -1669,9 +1663,13 @@ class NetBox:
                 if properties_updated and patch_ok:
                     # Properties patched successfully; components were attempted but
                     # none changed — treat as a partial success, not a full failure.
-                    self.counter["module_partial_update"] += 1
+                    self.outcomes.record(
+                        EntityKind.MODULE_TYPE,
+                        identity,
+                        Outcome.PARTIAL,
+                        reason="Properties updated; component reconciliation applied 0 changes.",
+                    )
                 else:
-                    self.counter["module_update_failed"] += 1
                     reason = (
                         "Scalar PATCH failed; component reconciliation ran but applied 0 changes."
                         if not patch_ok
@@ -1686,11 +1684,17 @@ class NetBox:
             elif component_delta == actionable_count and patch_ok:
                 self.counter["module_updated"] += 1
             else:
-                self.counter["module_partial_update"] += 1
+                reason_parts = [] if patch_ok else ["Property PATCH failed"]
+                reason_parts.append(f"applied {component_delta} of {actionable_count} component change(s)")
+                self.outcomes.record(
+                    EntityKind.MODULE_TYPE,
+                    identity,
+                    Outcome.PARTIAL,
+                    reason="; ".join(reason_parts) + ".",
+                )
         elif properties_updated and patch_ok:
             self.counter["module_updated"] += 1
         elif not patch_ok:
-            self.counter["module_update_failed"] += 1
             self.outcomes.record(
                 EntityKind.MODULE_TYPE,
                 identity,

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -2348,7 +2348,9 @@ class DeviceTypes:
             rp_name, fp_pos, rp_pos = tup
             rear_port = existing_rp.get(rp_name)
             if rear_port is None:
-                self.handle.log(f'Cannot update mapping for "{comp_name}": rear port "{rp_name}" not found in cache.')
+                self._log_component_error(
+                    f'Cannot update mapping for "{comp_name}": rear port "{rp_name}" not found in cache.'
+                )
                 return None
             rear_ports_payload.append(
                 {
@@ -2393,7 +2395,7 @@ class DeviceTypes:
                 # because rear port names are unavailable via the GraphQL API.
                 # Fall back to the YAML _mappings entry which does include the name.
                 if not yaml_mappings:
-                    self.handle.log(
+                    self._log_component_error(
                         f"Warning: cannot update mappings for '{comp_name}' on NetBox < 4.5:"
                         " rear port names unavailable, skipping mapping update"
                     )
@@ -2414,7 +2416,9 @@ class DeviceTypes:
                 update_data["rear_port"] = rp.id
                 update_data["rear_port_position"] = rp_pos
             else:
-                self.handle.log(f"Warning: cannot update mappings for '{comp_name}': rear port '{rp_name}' not found")
+                self._log_component_error(
+                    f"Warning: cannot update mappings for '{comp_name}': rear port '{rp_name}' not found"
+                )
 
     def _apply_updates_for_type(self, comp_type, changes, yaml_data, device_type_id, parent_type):
         """Apply property updates for all changed components of a single type.
@@ -2619,7 +2623,7 @@ class DeviceTypes:
                 except KeyError:
                     available = list(existing_pp.keys()) if existing_pp else []
                     ctx = f" (Context: {context})" if context else ""
-                    self.handle.log(
+                    self._log_component_error(
                         f'Could not find Power Port "{outlet["power_port"]}" for '
                         f'{label} "{outlet.get("name", "Unknown")}". '
                         f"Available: {available}{ctx}"
@@ -2702,7 +2706,7 @@ class DeviceTypes:
                     if rear_port is None:
                         available = list(existing_rp.keys()) if existing_rp else []
                         ctx = f" (Context: {context})" if context else ""
-                        self.handle.log(
+                        self._log_component_error(
                             f'Could not find Rear Port "{rp_name}" for {label} "{port["name"]}". '
                             f"Available: {available}{ctx}"
                         )
@@ -2778,7 +2782,9 @@ class DeviceTypes:
             if name in all_interfaces and bridge_name in all_interfaces:
                 to_update.append({"id": all_interfaces[name].id, "bridge": all_interfaces[bridge_name].id})
             else:
-                self.handle.log(f"Error bridging {name} to {bridge_name}: Interface not found (Context: {context})")
+                self._log_component_error(
+                    f"Error bridging {name} to {bridge_name}: Interface not found (Context: {context})"
+                )
 
         if not to_update:
             return
@@ -2786,9 +2792,9 @@ class DeviceTypes:
             _retry_on_connection_error(self.netbox.dcim.interface_templates.update, to_update)
             self.handle.verbose_log(f"Bridged {len(to_update)} interfaces.")
         except pynetbox.RequestError as e:
-            self.handle.log(f"Error bridging interfaces: {e} (Context: {context})")
+            self._log_component_error(f"Error bridging interfaces: {e} (Context: {context})")
         except _RETRYABLE_EXCEPTIONS as e:
-            self.handle.log(
+            self._log_component_error(
                 f"Connection error bridging interfaces after {_MAX_RETRIES} retries: {e} (Context: {context})"
             )
 

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -33,6 +33,7 @@ from core.schema_reader import load_properties_for_type
 from core.update_failure_resolver import (
     FailureKind,
     classify_device_type_update_failure,
+    extract_error_payload,
 )
 
 
@@ -2197,12 +2198,18 @@ class DeviceTypes:
                 self.components.invalidate(cache_name, parent_type, parent_id)
             except pynetbox.RequestError as excep:
                 context_str = f" (Context: {context})" if context else ""
-                if isinstance(excep.error, list):
-                    for i, error in enumerate(excep.error):
-                        if error:
-                            item_name = to_create[i].get("name", "Unknown") if i < len(to_create) else f"index {i}"
-                            self.handle.log(f"Failed to create {component_name} '{item_name}': {error}{context_str}")
-                else:
+                # NetBox answers a rejected bulk create with one error object per submitted
+                # item, positionally aligned, so name the items it actually rejected.
+                payload = extract_error_payload(excep.error)
+                per_item = payload if isinstance(payload, list) and len(payload) == len(to_create) else []
+                reported = 0
+                for item, error in zip(to_create, per_item):
+                    if error:
+                        reported += 1
+                        self.handle.log(
+                            f"Failed to create {component_name} '{item.get('name', 'Unknown')}': {error}{context_str}"
+                        )
+                if not reported:
                     failed_items = [x["name"] for x in to_create]
                     self.handle.log(
                         f"Error '{excep.error}' creating {component_name}. Items: {failed_items}{context_str}"

--- a/core/update_failure_resolver.py
+++ b/core/update_failure_resolver.py
@@ -81,7 +81,7 @@ _SUBDEVICE_ROLE_MARKERS = (
 )
 
 
-def _extract_error_payload(error: Any) -> Any:
+def extract_error_payload(error: Any) -> Any:
     """Best-effort decode of ``pynetbox.RequestError.error`` into a dict/str.
 
     pynetbox surfaces the body either pre-parsed (dict) or as a JSON string;
@@ -198,7 +198,7 @@ def classify_device_type_update_failure(
         A :class:`FailureResolution` describing the constraint and (when safe)
         the steps required to clear it.
     """
-    payload = _extract_error_payload(error)
+    payload = extract_error_payload(error)
 
     if not _matches_subdevice_role_constraint(payload):
         return FailureResolution(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -27,3 +27,25 @@ def paginate_dispatch(data_dict):
         return r
 
     return handler
+
+
+class RecordingConsole:
+    """Capture what the real LogHandler emits."""
+
+    def __init__(self):
+        """Start with no recorded lines."""
+        self.lines = []
+
+    def print(self, message, markup=False):
+        """Record one emitted line."""
+        self.lines.append(message)
+
+
+def recording_handle():
+    """Return a real LogHandler writing into a RecordingConsole."""
+    from core.log_handler import LogHandler
+
+    handle = LogHandler(False)
+    console = RecordingConsole()
+    handle.set_console(console)
+    return handle, console

--- a/tests/test_change_detector.py
+++ b/tests/test_change_detector.py
@@ -285,6 +285,26 @@ class TestLogChangeReport:
         log_calls = [str(call) for call in detector.handle.log.call_args_list]
         assert any("cisco/X" in c for c in log_calls)
 
+    def test_report_banner_names_the_vendor(self):
+        """A multi-vendor run must say which vendor a device-type report belongs to."""
+        detector = self._make_detector()
+        dt_change = DeviceTypeChange(manufacturer_slug="tp-link", model="EAP650", slug="eap650")
+        dt_change.property_changes = [PropertyChange("u_height", 1, 2)]
+        report = ChangeReport(modified_device_types=[dt_change])
+        detector.log_change_report(report, vendor="TP-Link")
+        banner = [c.args[0] for c in detector.handle.log.call_args_list if "CHANGE DETECTION REPORT" in c.args[0]]
+        assert banner == ["CHANGE DETECTION REPORT: TP-Link"]
+
+    def test_report_banner_without_vendor_keeps_the_plain_title(self):
+        """Without a vendor the banner keeps its plain title, with no trailing colon."""
+        detector = self._make_detector()
+        dt_change = DeviceTypeChange(manufacturer_slug="tp-link", model="EAP650", slug="eap650")
+        dt_change.property_changes = [PropertyChange("u_height", 1, 2)]
+        report = ChangeReport(modified_device_types=[dt_change])
+        detector.log_change_report(report)
+        banner = [c.args[0] for c in detector.handle.log.call_args_list if "CHANGE DETECTION REPORT" in c.args[0]]
+        assert banner == ["CHANGE DETECTION REPORT"]
+
     def test_modified_with_property_change_logged(self):
         detector = self._make_detector()
         dt_change = DeviceTypeChange(manufacturer_slug="juniper", model="MX5", slug="mx5")

--- a/tests/test_import_run.py
+++ b/tests/test_import_run.py
@@ -20,6 +20,7 @@ from core.import_run import (
 from core.log_handler import LogHandler
 from core.outcomes import EntityKind, Outcome
 from core.repo import DTLRepo
+from helpers import recording_handle as _recording_handle
 
 
 class _ComponentCache:
@@ -324,25 +325,6 @@ class TestPartialLibraryLayouts:
         }
         assert parsed[present] == 1, parsed
         assert sum(parsed.values()) == 1, parsed
-
-
-class _RecordingConsole:
-    """Capture what the real LogHandler emits."""
-
-    def __init__(self):
-        self.lines = []
-
-    def print(self, message, markup=False):
-        """Record one emitted line."""
-        self.lines.append(message)
-
-
-def _recording_handle():
-    """Return a real LogHandler writing into a recording console."""
-    handle = LogHandler(False)
-    console = _RecordingConsole()
-    handle.set_console(console)
-    return handle, console
 
 
 class _ModuleNetBox:

--- a/tests/test_import_run.py
+++ b/tests/test_import_run.py
@@ -18,6 +18,7 @@ from core.import_run import (
     _process_rack_types,
 )
 from core.log_handler import LogHandler
+from core.outcomes import EntityKind, Outcome
 from core.repo import DTLRepo
 
 
@@ -488,8 +489,6 @@ def _summary_lines(netbox):
 
 def test_failed_module_type_is_counted_in_the_summary():
     """A module type that failed must be counted, not only listed in the report."""
-    from core.outcomes import EntityKind, Outcome
-
     nb = _OutcomeNetBox()
     nb.outcomes.record(EntityKind.MODULE_TYPE, "chicony/CPB09-031A", Outcome.FAILED, reason="boom")
 
@@ -500,8 +499,6 @@ def test_failed_module_type_is_counted_in_the_summary():
 
 def test_failed_rack_type_is_counted_in_the_summary():
     """A rack type that failed must appear in the headline counts."""
-    from core.outcomes import EntityKind, Outcome
-
     nb = _OutcomeNetBox()
     nb.outcomes.record(EntityKind.RACK_TYPE, "lenovo/1410HPB", Outcome.FAILED, reason="boom")
 
@@ -512,8 +509,6 @@ def test_failed_rack_type_is_counted_in_the_summary():
 
 def test_partial_module_type_is_counted_in_the_summary():
     """A partially updated module must be counted from the registry."""
-    from core.outcomes import EntityKind, Outcome
-
     nb = _OutcomeNetBox()
     nb.outcomes.record(EntityKind.MODULE_TYPE, "cisco/LC", Outcome.PARTIAL, reason="half applied")
 
@@ -524,8 +519,6 @@ def test_partial_module_type_is_counted_in_the_summary():
 
 def test_headline_counts_match_the_itemised_rows():
     """The invariant the two parallel tallies never enforced."""
-    from core.outcomes import EntityKind, Outcome
-
     nb = _OutcomeNetBox()
     nb.outcomes.record(EntityKind.DEVICE_TYPE, "ribbon/SBC 5400", Outcome.FAILED, reason="a")
     nb.outcomes.record(EntityKind.DEVICE_TYPE, "acme/SW2", Outcome.FAILED, reason="b")
@@ -540,3 +533,27 @@ def test_headline_counts_match_the_itemised_rows():
     assert "1 rack types failed" in text
     # The itemised report must agree with those headline numbers.
     assert "Failed entities: 4" in text
+
+
+def test_partial_device_type_is_counted_in_the_summary():
+    """A partially updated device type must appear in the headline counts."""
+    nb = _OutcomeNetBox()
+    nb.outcomes.record(EntityKind.DEVICE_TYPE, "acme/SW1", Outcome.PARTIAL, reason="half applied")
+
+    lines = _summary_lines(nb)
+
+    assert any("1 device types partially updated" in line for line in lines), lines
+
+
+def test_headline_partials_match_the_itemised_rows():
+    """Every kind that can record PARTIAL must also be counted in the headline."""
+    nb = _OutcomeNetBox()
+    nb.outcomes.record(EntityKind.DEVICE_TYPE, "acme/SW1", Outcome.PARTIAL, reason="a")
+    nb.outcomes.record(EntityKind.DEVICE_TYPE, "acme/SW2", Outcome.PARTIAL, reason="b")
+    nb.outcomes.record(EntityKind.MODULE_TYPE, "cisco/LC", Outcome.PARTIAL, reason="c")
+
+    text = "\n".join(_summary_lines(nb))
+
+    assert "2 device types partially updated" in text
+    assert "1 modules partially updated" in text
+    assert "Partial updates: 3" in text

--- a/tests/test_import_run.py
+++ b/tests/test_import_run.py
@@ -6,10 +6,13 @@ from contextlib import contextmanager
 import pytest
 
 from core.errors import VendorSelectionError
+from types import SimpleNamespace
+
 from core.import_run import (
     ImportRun,
     RunSummary,
     VendorPlan,
+    _log_run_summary,
     _process_device_types,
     _process_module_types,
     _process_rack_types,
@@ -37,12 +40,17 @@ class _DeviceTypes:
 
 
 class _Outcomes:
-    """Provide an empty final failure report."""
+    """Provide an empty final failure report and an empty outcome aggregate."""
 
     @staticmethod
     def render_failure_report():
         """Return no failure lines."""
         return []
+
+    @staticmethod
+    def summary_by_kind():
+        """Return no recorded outcomes."""
+        return {}
 
 
 class _NetBoxBoundary:
@@ -438,3 +446,97 @@ def test_banners_omit_the_separator_when_no_vendor_is_given(make_config):
     banner = [line for line in console.lines if "RACK TYPE CHANGE DETECTION" in line]
     assert len(banner) == 1
     assert banner[0].rstrip().endswith("RACK TYPE CHANGE DETECTION")
+
+
+class _OutcomeNetBox:
+    """Run-state stand-in carrying a real OutcomeRegistry."""
+
+    def __init__(self, *, modules=True, rack_types=True, counter=None):
+        from core.outcomes import OutcomeRegistry
+
+        self.modules = modules
+        self.rack_types = rack_types
+        self.outcomes = OutcomeRegistry()
+        base = dict(
+            added=0,
+            properties_updated=0,
+            components_updated=0,
+            components_added=0,
+            components_removed=0,
+            images=0,
+            manufacturer=0,
+            module_added=0,
+            module_updated=0,
+            rack_type_added=0,
+            rack_type_updated=0,
+        )
+        base.update(counter or {})
+        self.counter = Counter(base)
+
+
+def _summary_lines(netbox):
+    """Render a run summary through the real LogHandler and return its lines."""
+    from datetime import datetime
+
+    handle, console = _recording_handle()
+    handle.verbose = True
+    repo = SimpleNamespace(duplicate_definitions=[])
+    summary = RunSummary.capture(netbox, repo, datetime.now())
+    _log_run_summary(handle, summary)
+    return console.lines
+
+
+def test_failed_module_type_is_counted_in_the_summary():
+    """A module type that failed must be counted, not only listed in the report."""
+    from core.outcomes import EntityKind, Outcome
+
+    nb = _OutcomeNetBox()
+    nb.outcomes.record(EntityKind.MODULE_TYPE, "chicony/CPB09-031A", Outcome.FAILED, reason="boom")
+
+    lines = _summary_lines(nb)
+
+    assert any("1 modules failed" in line for line in lines), lines
+
+
+def test_failed_rack_type_is_counted_in_the_summary():
+    """A rack type that failed must appear in the headline counts."""
+    from core.outcomes import EntityKind, Outcome
+
+    nb = _OutcomeNetBox()
+    nb.outcomes.record(EntityKind.RACK_TYPE, "lenovo/1410HPB", Outcome.FAILED, reason="boom")
+
+    lines = _summary_lines(nb)
+
+    assert any("1 rack types failed" in line for line in lines), lines
+
+
+def test_partial_module_type_is_counted_in_the_summary():
+    """A partially updated module must be counted from the registry."""
+    from core.outcomes import EntityKind, Outcome
+
+    nb = _OutcomeNetBox()
+    nb.outcomes.record(EntityKind.MODULE_TYPE, "cisco/LC", Outcome.PARTIAL, reason="half applied")
+
+    lines = _summary_lines(nb)
+
+    assert any("1 modules partially updated" in line for line in lines), lines
+
+
+def test_headline_counts_match_the_itemised_rows():
+    """The invariant the two parallel tallies never enforced."""
+    from core.outcomes import EntityKind, Outcome
+
+    nb = _OutcomeNetBox()
+    nb.outcomes.record(EntityKind.DEVICE_TYPE, "ribbon/SBC 5400", Outcome.FAILED, reason="a")
+    nb.outcomes.record(EntityKind.DEVICE_TYPE, "acme/SW2", Outcome.FAILED, reason="b")
+    nb.outcomes.record(EntityKind.MODULE_TYPE, "chicony/CPB09-031A", Outcome.FAILED, reason="c")
+    nb.outcomes.record(EntityKind.RACK_TYPE, "lenovo/1410HPB", Outcome.FAILED, reason="d")
+
+    lines = _summary_lines(nb)
+    text = "\n".join(lines)
+
+    assert "2 device types FAILED" in text
+    assert "1 modules failed" in text
+    assert "1 rack types failed" in text
+    # The itemised report must agree with those headline numbers.
+    assert "Failed entities: 4" in text

--- a/tests/test_import_run.py
+++ b/tests/test_import_run.py
@@ -6,7 +6,14 @@ from contextlib import contextmanager
 import pytest
 
 from core.errors import VendorSelectionError
-from core.import_run import ImportRun, RunSummary, VendorPlan, _process_device_types
+from core.import_run import (
+    ImportRun,
+    RunSummary,
+    VendorPlan,
+    _process_device_types,
+    _process_module_types,
+    _process_rack_types,
+)
 from core.log_handler import LogHandler
 from core.repo import DTLRepo
 
@@ -308,3 +315,126 @@ class TestPartialLibraryLayouts:
         }
         assert parsed[present] == 1, parsed
         assert sum(parsed.values()) == 1, parsed
+
+
+class _RecordingConsole:
+    """Capture what the real LogHandler emits."""
+
+    def __init__(self):
+        self.lines = []
+
+    def print(self, message, markup=False):
+        """Record one emitted line."""
+        self.lines.append(message)
+
+
+def _recording_handle():
+    """Return a real LogHandler writing into a recording console."""
+    handle = LogHandler(False)
+    console = _RecordingConsole()
+    handle.set_console(console)
+    return handle, console
+
+
+class _ModuleNetBox:
+    """Report one new module type so the banner is emitted."""
+
+    modules = True
+    device_types = _DeviceTypes()
+
+    @staticmethod
+    def get_existing_module_types():
+        """Return no existing module types."""
+        return {}
+
+    @staticmethod
+    def filter_actionable_module_types(module_types, _existing, only_new=False):
+        """Treat every supplied module type as actionable."""
+        return list(module_types), {}, []
+
+    @staticmethod
+    def filter_new_module_types(module_types, _existing):
+        """Treat every supplied module type as new."""
+        return list(module_types)
+
+    @staticmethod
+    def count_module_type_images(*_args, **_kwargs):
+        """Report no images to upload."""
+        return 0
+
+    @staticmethod
+    def create_module_types(*_args, **_kwargs):
+        """Accept the import call without doing work."""
+
+    @staticmethod
+    def log_module_type_changes(_changes):
+        """Accept the change log without doing work."""
+
+
+class _RackNetBox:
+    """Report one new rack type so the banner is emitted."""
+
+    rack_types = True
+    device_types = _DeviceTypes()
+
+    @staticmethod
+    def get_existing_rack_types():
+        """Return no existing rack types."""
+        return {}
+
+    @staticmethod
+    def create_rack_types(*_args, **_kwargs):
+        """Accept the import call without doing work."""
+
+
+def test_module_type_banner_names_the_vendor(make_config):
+    """A multi-vendor run must say which vendor a module-type report belongs to."""
+    handle, console = _recording_handle()
+
+    _process_module_types(
+        make_config(only_new=True),
+        _ModuleNetBox(),
+        handle,
+        None,
+        [{"manufacturer": {"slug": "vendor-one"}, "model": "Module One", "slug": "module-one"}],
+        vendor_name="Vendor One",
+    )
+
+    banner = [line for line in console.lines if "MODULE TYPE CHANGE DETECTION" in line]
+    assert len(banner) == 1
+    assert "MODULE TYPE CHANGE DETECTION: Vendor One" in banner[0]
+
+
+def test_rack_type_banner_names_the_vendor(make_config):
+    """A multi-vendor run must say which vendor a rack-type report belongs to."""
+    handle, console = _recording_handle()
+
+    _process_rack_types(
+        make_config(),
+        _RackNetBox(),
+        handle,
+        None,
+        [{"manufacturer": {"slug": "vendor-one"}, "model": "Rack One", "slug": "rack-one"}],
+        vendor_name="Vendor One",
+    )
+
+    banner = [line for line in console.lines if "RACK TYPE CHANGE DETECTION" in line]
+    assert len(banner) == 1
+    assert "RACK TYPE CHANGE DETECTION: Vendor One" in banner[0]
+
+
+def test_banners_omit_the_separator_when_no_vendor_is_given(make_config):
+    """Without a vendor the banner keeps its plain title, with no trailing colon."""
+    handle, console = _recording_handle()
+
+    _process_rack_types(
+        make_config(),
+        _RackNetBox(),
+        handle,
+        None,
+        [{"manufacturer": {"slug": "vendor-one"}, "model": "Rack One", "slug": "rack-one"}],
+    )
+
+    banner = [line for line in console.lines if "RACK TYPE CHANGE DETECTION" in line]
+    assert len(banner) == 1
+    assert banner[0].rstrip().endswith("RACK TYPE CHANGE DETECTION")

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -7100,3 +7100,71 @@ class TestProcessSingleModuleTypeRemoveComponents:
         failures = nb.outcomes.failures()
         assert len(failures) == 1
         assert "CM-Fail-Patch" in failures[0].identity
+
+
+class TestFailuresReachTheRunReport:
+    """Every failure path must reach the end-of-run FAILED / PARTIAL report."""
+
+    def _netbox(self, mock_settings, mock_handle, mock_pynetbox):
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_pynetbox.api.return_value.version = "4.1"
+        return NetBox(mock_settings, mock_handle)
+
+    def test_rack_type_create_failure_is_reported(self, mock_settings, mock_pynetbox, mock_handle):
+        """A rejected rack-type create must appear in the report, not just inline."""
+        nb = self._netbox(mock_settings, mock_handle, mock_pynetbox)
+        mock_pynetbox.api.return_value.dcim.rack_types.create.side_effect = _request_error(
+            b'{"description":["Ensure this field has no more than 200 characters."]}'
+        )
+        rack_type = {
+            "manufacturer": {"slug": "lenovo"},
+            "model": "1410HPB",
+            "slug": "lenovo-1410hpb",
+            "src": "/repo/rack-types/Lenovo/1410HPB.yaml",
+        }
+        nb.create_rack_types([rack_type], all_rack_types={})
+
+        report = "\n".join(nb.outcomes.render_failure_report())
+        assert "[rack_type] lenovo/1410HPB" in report
+        assert "no more than 200 characters" in report
+
+    def test_module_type_create_failure_is_reported(self, mock_settings, mock_pynetbox, mock_handle):
+        """A rejected module-type create must appear in the report."""
+        nb = self._netbox(mock_settings, mock_handle, mock_pynetbox)
+        mock_pynetbox.api.return_value.dcim.module_types.create.side_effect = _request_error(
+            b'{"model":["This field may not be blank."]}'
+        )
+        curr_mt = {"manufacturer": {"slug": "panduit"}, "model": "FAP6WBUSC", "slug": "fap6wbusc"}
+
+        result = nb._process_single_module_type(
+            curr_mt, "/repo/module-types/Panduit/FAP6WBUSC.yaml", {}, {}, only_new=False
+        )
+        assert result is False
+
+        report = "\n".join(nb.outcomes.render_failure_report())
+        assert "[module_type] panduit/FAP6WBUSC" in report
+        assert "may not be blank" in report
+
+    def test_rack_type_update_failure_is_reported(self, mock_settings, mock_pynetbox, mock_handle):
+        """A rejected rack-type update must appear in the report."""
+        from core.graphql_client import DotDict
+
+        nb = self._netbox(mock_settings, mock_handle, mock_pynetbox)
+        mock_pynetbox.api.return_value.dcim.rack_types.update.side_effect = _request_error(
+            b'{"u_height":["Invalid value."]}'
+        )
+        existing = DotDict({"id": 7, "model": "1410HPB", "u_height": 40})
+        rack_type = {
+            "manufacturer": {"slug": "lenovo"},
+            "model": "1410HPB",
+            "slug": "lenovo-1410hpb",
+            "u_height": 42,
+            "src": "/repo/rack-types/Lenovo/1410HPB.yaml",
+        }
+        nb.create_rack_types([rack_type], only_new=False, all_rack_types={"lenovo": {"1410HPB": existing}})
+
+        report = "\n".join(nb.outcomes.render_failure_report())
+        assert "[rack_type] lenovo/1410HPB" in report
+        assert "Invalid value." in report

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -687,12 +687,33 @@ class TestFrontPortRecordWithMappings:
         assert wrapped.name == "FP1"
 
 
+def _request_error(body: bytes):
+    """Build a real pynetbox.RequestError from a real HTTP response body.
+
+    pynetbox sets ``RequestError.error`` to ``response.text``, so it is always a
+    string.  Building the error from a real ``requests.Response`` keeps the test
+    honest: a MagicMock response makes ``.error`` a MagicMock and lets the
+    production branch under test go unexercised.
+    """
+    import pynetbox as real_pynb
+    import requests
+
+    response = requests.Response()
+    response.status_code = 400
+    response.reason = "Bad Request"
+    response._content = body
+    response.url = "http://netbox.local/api/dcim/interface-templates/"
+    response.request = requests.Request("POST", response.url).prepare()
+    return real_pynb.RequestError(response)
+
+
 class TestCreateGenericError:
     """Tests for TestCreateGenericError."""
 
-    def test_list_error_logs_each_item(
+    def test_per_item_error_names_only_the_failing_item(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):
+        """A bulk create rejected for one item names that item, not the whole batch."""
         import pynetbox as real_pynb
 
         mock_pynetbox.RequestError = real_pynb.RequestError
@@ -700,9 +721,65 @@ class TestCreateGenericError:
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("interface_templates", "device", 1, {})
 
-        err = real_pynb.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
-        err.error = ["Name already exists", ""]
-        mock_nb_api.dcim.interface_templates.create.side_effect = err
+        mock_nb_api.dcim.interface_templates.create.side_effect = _request_error(
+            b'[{"rf_role":["Wireless role may be set only on wireless interfaces."]},{},{}]'
+        )
+
+        dt._create_generic(
+            BY_YAML_KEY["interfaces"],
+            [{"name": "Uplink"}, {"name": "Downlink 1"}, {"name": "Downlink 2"}],
+            1,
+            parent_type="device",
+            context="EAP725-Wall.yaml",
+        )
+
+        messages = [call.args[0] for call in mock_handle.log.call_args_list]
+        assert len(messages) == 1
+        assert "Uplink" in messages[0]
+        assert "Wireless role may be set only on wireless interfaces." in messages[0]
+        assert "Downlink 1" not in messages[0]
+        assert "Downlink 2" not in messages[0]
+        assert "EAP725-Wall.yaml" in messages[0]
+
+    def test_per_item_error_reports_every_failing_item(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """Each rejected item gets its own line; accepted items get none."""
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        dt = make_device_types(nb_api=mock_nb_api)
+        dt.components.record("interface_templates", "device", 1, {})
+
+        mock_nb_api.dcim.interface_templates.create.side_effect = _request_error(
+            b'[{"name":["This field must be unique."]},{},{"type":["Invalid choice."]}]'
+        )
+
+        dt._create_generic(
+            BY_YAML_KEY["interfaces"],
+            [{"name": "eth0"}, {"name": "eth1"}, {"name": "eth2"}],
+            1,
+            parent_type="device",
+        )
+
+        messages = [call.args[0] for call in mock_handle.log.call_args_list]
+        assert len(messages) == 2
+        assert "eth0" in messages[0] and "This field must be unique." in messages[0]
+        assert "eth2" in messages[1] and "Invalid choice." in messages[1]
+
+    def test_non_list_error_logs_failed_items(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """A whole-request error (not per item) falls back to listing every item."""
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        dt = make_device_types(nb_api=mock_nb_api)
+        dt.components.record("interface_templates", "device", 1, {})
+
+        mock_nb_api.dcim.interface_templates.create.side_effect = _request_error(b'{"detail":"Something went wrong"}')
 
         dt._create_generic(
             BY_YAML_KEY["interfaces"],
@@ -710,11 +787,16 @@ class TestCreateGenericError:
             1,
             parent_type="device",
         )
-        mock_handle.log.assert_called()
 
-    def test_string_error_logs_failed_items(
+        messages = [call.args[0] for call in mock_handle.log.call_args_list]
+        assert len(messages) == 1
+        assert "Something went wrong" in messages[0]
+        assert "['eth0', 'eth1']" in messages[0]
+
+    def test_length_mismatch_falls_back_to_whole_batch(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):
+        """A list that does not line up with the submitted items is not mapped by index."""
         import pynetbox as real_pynb
 
         mock_pynetbox.RequestError = real_pynb.RequestError
@@ -722,17 +804,42 @@ class TestCreateGenericError:
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("interface_templates", "device", 1, {})
 
-        err = real_pynb.RequestError(MagicMock(status_code=400, content=b'{"detail":"bad"}'))
-        err.error = "Something went wrong"
-        mock_nb_api.dcim.interface_templates.create.side_effect = err
+        mock_nb_api.dcim.interface_templates.create.side_effect = _request_error(b'["Unrelated top-level message"]')
 
         dt._create_generic(
             BY_YAML_KEY["interfaces"],
-            [{"name": "eth0"}],
+            [{"name": "eth0"}, {"name": "eth1"}],
             1,
             parent_type="device",
         )
-        mock_handle.log.assert_called()
+
+        messages = [call.args[0] for call in mock_handle.log.call_args_list]
+        assert len(messages) == 1
+        assert "['eth0', 'eth1']" in messages[0]
+
+    def test_all_empty_list_still_reports_the_batch(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """A per-item list carrying no message must not swallow the failure."""
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        dt = make_device_types(nb_api=mock_nb_api)
+        dt.components.record("interface_templates", "device", 1, {})
+
+        mock_nb_api.dcim.interface_templates.create.side_effect = _request_error(b"[{},{}]")
+
+        dt._create_generic(
+            BY_YAML_KEY["interfaces"],
+            [{"name": "eth0"}, {"name": "eth1"}],
+            1,
+            parent_type="device",
+        )
+
+        messages = [call.args[0] for call in mock_handle.log.call_args_list]
+        assert len(messages) == 1
+        assert "['eth0', 'eth1']" in messages[0]
 
 
 class TestRemoveComponents:

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -16,7 +16,7 @@ from core.netbox_api import (
     _delete_image_attachment,
     _FrontPortRecordWithMappings,
 )
-from helpers import paginate_dispatch
+from helpers import paginate_dispatch, recording_handle
 
 
 # All component list keys used by the GraphQL client for empty-response fallback.
@@ -7165,6 +7165,81 @@ class TestFailuresReachTheRunReport:
         report = "\n".join(nb.outcomes.render_failure_report())
         assert "[rack_type] lenovo/1410HPB" in report
         assert "Invalid value." in report
+
+
+class TestSummaryWordingMatchesTheFailedOperation:
+    """The headline failure lines count creates too, so they must not blame an update."""
+
+    def _summary_text(self, nb):
+        """Render the real end-of-run summary for *nb* and return it as one string."""
+        from datetime import datetime
+        from types import SimpleNamespace
+
+        from core.import_run import RunSummary, _log_run_summary
+
+        handle, console = recording_handle()
+        summary = RunSummary.capture(nb, SimpleNamespace(duplicate_definitions=[]), datetime.now())
+        _log_run_summary(handle, summary)
+        return "\n".join(console.lines)
+
+    def test_device_type_create_failure_is_not_called_an_update_failure(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """Ribbon's SBC 5400 fails to CREATE; the headline must not blame an update."""
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+        mock_nb_api.dcim.device_types.create.side_effect = _request_error(
+            b'{"manufacturer":["Related object not found using the provided attributes: slug ribbon"]}'
+        )
+
+        dt = make_device_types(nb_api=mock_nb_api)
+        dt.existing_device_types = {}
+        dt.existing_device_types_by_slug = {}
+        nb = NetBox(mock_settings, mock_handle)
+        nb.device_types = dt
+        nb.create_device_types(
+            [
+                {
+                    "manufacturer": {"slug": "ribbon"},
+                    "model": "SBC 5400",
+                    "slug": "ribbon-communications-sbc-5400",
+                    "src": "/repo/device-types/Ribbon Communications/SBC-5400.yaml",
+                }
+            ],
+            only_new=True,
+        )
+
+        text = self._summary_text(nb)
+        assert "1 device types FAILED to create or update" in text
+        assert "FAILED to update" not in text
+
+    def test_module_type_create_failure_is_not_called_an_update_failure(
+        self, mock_settings, mock_pynetbox, mock_handle
+    ):
+        """A rejected module-type create must not be counted as an update failure."""
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.dcim.module_types.create.side_effect = _request_error(
+            b'{"model":["This field may not be blank."]}'
+        )
+        nb = NetBox(mock_settings, mock_handle)
+        nb.modules = True
+        nb._process_single_module_type(
+            {"manufacturer": {"slug": "panduit"}, "model": "FAP6WBUSC", "slug": "fap6wbusc"},
+            "/repo/module-types/Panduit/FAP6WBUSC.yaml",
+            {},
+            {},
+            only_new=False,
+        )
+
+        text = self._summary_text(nb)
+        assert "1 modules failed to create or update" in text
+        assert "modules failed to update" not in text
 
 
 class TestSkippedComponentReasonReachesTheReport:

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -2324,6 +2324,43 @@ class TestCreateDeviceTypesUpdatePath:
         assert nb.counter.get("properties_updated", 0) == 0
         assert nb.counter["device_types_component_updates"] == 1
 
+    def test_create_failure_reaches_the_end_of_run_failure_report(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """A device type that fails to be CREATED must appear in the failure report.
+
+        Only the update path recorded outcomes, so a rejected create was logged
+        inline and then vanished from the end-of-run summary.
+        """
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+        mock_nb_api.dcim.device_types.create.side_effect = _request_error(
+            b"{\"manufacturer\":[\"Related object not found using the provided attributes: {'slug': 'ribbon'}\"]}"
+        )
+
+        dt = make_device_types(nb_api=mock_nb_api)
+        dt.existing_device_types = {}
+        dt.existing_device_types_by_slug = {}
+        nb = NetBox(mock_settings, mock_handle)
+        nb.device_types = dt
+
+        device_type = {
+            "manufacturer": {"slug": "ribbon"},
+            "model": "SBC 5400",
+            "slug": "ribbon-communications-sbc-5400",
+            "src": "/repo/device-types/Ribbon Communications/SBC-5400.yaml",
+        }
+        nb.create_device_types([device_type], only_new=True)
+
+        report = "\n".join(nb.outcomes.render_failure_report())
+        assert "FAILED / PARTIAL UPDATE REPORT" in report
+        assert "ribbon/SBC 5400" in report
+        assert "Related object not found" in report
+        assert nb.counter["device_types_failed"] == 1
+
     def test_update_verbose_log_when_change_applied(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -7,6 +7,7 @@ import pytest
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from unittest.mock import MagicMock, patch
 from core.component_registry import BY_YAML_KEY, COMPONENT_TYPES
+from core.outcomes import EntityKind, Outcome
 from core.netbox_api import (
     NetBox,
     NetBoxError,
@@ -1876,7 +1877,7 @@ class TestCreateDeviceTypesUpdatePath:
         """RequestError during property update is caught and logged.
 
         Regression: when the property PATCH fails AND there are no component
-        changes, ``device_types_failed`` must be incremented and the misleading
+        changes, a DEVICE_TYPE failure must be recorded and the misleading
         "Device Type Updated" log MUST NOT be emitted.
         """
         import pynetbox as real_pynb2
@@ -1919,7 +1920,7 @@ class TestCreateDeviceTypesUpdatePath:
         # Error path was logged.
         mock_handle.log.assert_called()
         # Failure surfaced via dedicated counter so summary can show it.
-        assert nb.counter["device_types_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.DEVICE_TYPE]) == 1
         # Counters that imply a successful PATCH must NOT be bumped.
         assert nb.counter["properties_updated"] == 0
         # "Device Type Updated" is misleading when nothing was applied — must
@@ -1932,7 +1933,6 @@ class TestCreateDeviceTypesUpdatePath:
         # The failure log must surface the model so operators can find it.
         assert any("Device Type Update Failed" in msg and "TestSwitch" in msg for msg in all_calls)
         # Outcome.FAILED must also be recorded in the registry so the end-of-run report reflects it.
-        from core.outcomes import EntityKind, Outcome
 
         failures = nb.outcomes.failures()
         assert len(failures) == 1
@@ -2022,14 +2022,13 @@ class TestCreateDeviceTypesUpdatePath:
         # PATCH must have been attempted exactly once (no retry).
         mock_nb_api.dcim.device_types.update.assert_called_once()
         # Failure counter bumped, success counter not.
-        assert nb.counter["device_types_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.DEVICE_TYPE]) == 1
         assert nb.counter["properties_updated"] == 0
         # Hint mentions the flag and the blocking template.
         all_logs = [c.args[0] for c in mock_handle.log.call_args_list]
         assert any("--force-resolve-conflicts" in m for m in all_logs), all_logs
         assert any("module-bay-1" in m for m in all_logs), all_logs
         # Failure recorded into the OutcomeRegistry with structured context.
-        from core.outcomes import EntityKind, Outcome
 
         failures = nb.outcomes.failures()
         assert len(failures) == 1
@@ -2054,7 +2053,7 @@ class TestCreateDeviceTypesUpdatePath:
         blocking_template.delete.assert_called_once()
         assert mock_nb_api.dcim.device_types.update.call_count == 2
         assert nb.counter["properties_updated"] == 1
-        assert nb.counter["device_types_failed"] == 0
+        assert [r for r in nb.outcomes.failures() if r.kind == EntityKind.DEVICE_TYPE] == []
         # Successful retry path must NOT record a failure into the registry.
         assert nb.outcomes.failures() == []
 
@@ -2075,7 +2074,7 @@ class TestCreateDeviceTypesUpdatePath:
         blocking_template.delete.assert_called_once()
         assert mock_nb_api.dcim.device_types.update.call_count == 2
         assert nb.counter["properties_updated"] == 0
-        assert nb.counter["device_types_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.DEVICE_TYPE]) == 1
         # The failed retry must surface in the structured failure report exactly once.
         failures = nb.outcomes.failures()
         assert len(failures) == 1
@@ -2100,7 +2099,7 @@ class TestCreateDeviceTypesUpdatePath:
         # Safety gate honoured: no delete, no retry.
         blocking_template.delete.assert_not_called()
         mock_nb_api.dcim.device_types.update.assert_called_once()
-        assert nb.counter["device_types_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.DEVICE_TYPE]) == 1
         all_logs = [c.args[0] for c in mock_handle.log.call_args_list]
         assert any("router-1" in m for m in all_logs), all_logs
 
@@ -2153,10 +2152,10 @@ class TestCreateDeviceTypesUpdatePath:
         assert nb.counter["device_types_component_updates"] == 1
         assert nb.counter.get("properties_updated", 0) == 0
 
-    def test_component_changes_all_fail_increments_device_types_failed(
+    def test_component_changes_all_fail_records_a_device_type_failure(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):
-        """When component API calls are issued but all fail, device_types_failed must be incremented.
+        """When component API calls are issued but all fail, a DEVICE_TYPE failure must be recorded.
 
         Regression: the old code set component_attempted by comparing counters
         before/after the API calls, so a total component failure was silently
@@ -2168,7 +2167,6 @@ class TestCreateDeviceTypesUpdatePath:
             ComponentChange,
             DeviceTypeChange,
         )
-        from core.outcomes import EntityKind, Outcome
 
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
@@ -2203,7 +2201,7 @@ class TestCreateDeviceTypesUpdatePath:
         nb.create_device_types([device_type], update=True, change_report=report)
 
         dt.update_components.assert_called_once()
-        assert nb.counter["device_types_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.DEVICE_TYPE]) == 1
         assert nb.counter.get("device_types_component_updates", 0) == 0
         failures = nb.outcomes.failures()
         assert len(failures) == 1
@@ -2226,7 +2224,6 @@ class TestCreateDeviceTypesUpdatePath:
             ComponentChange,
             DeviceTypeChange,
         )
-        from core.outcomes import EntityKind, Outcome
 
         mock_nb_api = mock_pynetbox.api.return_value
         dt = make_device_types(nb_api=mock_nb_api)
@@ -2268,7 +2265,7 @@ class TestCreateDeviceTypesUpdatePath:
         nb.create_device_types([device_type], update=True, change_report=report)
 
         dt.update_components.assert_called_once()
-        assert nb.counter["device_types_failed"] == 0
+        assert [r for r in nb.outcomes.failures() if r.kind == EntityKind.DEVICE_TYPE] == []
         assert nb.counter.get("device_types_component_updates", 0) == 1
         partials = nb.outcomes.partials()
         assert len(partials) == 1
@@ -2359,7 +2356,7 @@ class TestCreateDeviceTypesUpdatePath:
         assert "FAILED / PARTIAL UPDATE REPORT" in report
         assert "ribbon/SBC 5400" in report
         assert "Related object not found" in report
-        assert nb.counter["device_types_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.DEVICE_TYPE]) == 1
 
     def test_update_verbose_log_when_change_applied(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
@@ -6329,7 +6326,7 @@ class TestAdditionalModuleTypeCoverage:
         )
 
         nb.device_types.ensure_components_ready.assert_called_once_with(manufacturer_slug="cisco")
-        assert nb.counter["module_update_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.MODULE_TYPE]) == 1
         assert nb.outcomes.failures()[0].reason == "Scalar PATCH failed; no component changes detected."
 
     def test_apply_module_type_component_updates_marks_partial_on_partial_component_success(
@@ -6358,7 +6355,7 @@ class TestAdditionalModuleTypeCoverage:
             {"manufacturer": {"slug": "cisco"}}, module_type_res, False, False, patch_ok=True
         )
 
-        assert nb.counter["module_partial_update"] == 1
+        assert len([r for r in nb.outcomes.partials() if r.kind == EntityKind.MODULE_TYPE]) == 1
 
     def test_apply_module_type_component_updates_marks_partial_when_properties_only_succeed(
         self, mock_settings, mock_pynetbox, mock_handle
@@ -6379,7 +6376,7 @@ class TestAdditionalModuleTypeCoverage:
             {"manufacturer": {"slug": "cisco"}}, module_type_res, True, False, patch_ok=True
         )
 
-        assert nb.counter["module_partial_update"] == 1
+        assert len([r for r in nb.outcomes.partials() if r.kind == EntityKind.MODULE_TYPE]) == 1
 
     def test_apply_module_type_component_updates_records_failed_when_no_changes_apply(
         self, mock_settings, mock_pynetbox, mock_handle
@@ -6399,7 +6396,7 @@ class TestAdditionalModuleTypeCoverage:
             {"manufacturer": {"slug": "cisco"}}, module_type_res, False, False, patch_ok=False
         )
 
-        assert nb.counter["module_update_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.MODULE_TYPE]) == 1
         assert nb.outcomes.failures()[0].reason == "Scalar PATCH failed; no component changes were actionable."
 
 
@@ -7096,7 +7093,7 @@ class TestProcessSingleModuleTypeRemoveComponents:
         assert result is True
         nb.device_types.remove_components.assert_called_once()
         assert nb.counter["module_updated"] == 0
-        assert nb.counter["module_update_failed"] == 1
+        assert len([r for r in nb.outcomes.failures() if r.kind == EntityKind.MODULE_TYPE]) == 1
         failures = nb.outcomes.failures()
         assert len(failures) == 1
         assert "CM-Fail-Patch" in failures[0].identity

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -7173,6 +7173,102 @@ class TestFailuresReachTheRunReport:
 class TestComponentFailureReasonReachesTheReport:
     """A failed component change must carry NetBox's message into the report."""
 
+    def test_component_update_transport_failure_reports_the_transport_error(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """A retry-exhausted update must name the transport error, not the generic label."""
+        import pynetbox as real_pynb
+        import requests
+        from core.change_detector import (
+            ChangeReport,
+            ChangeType,
+            ComponentChange,
+            DeviceTypeChange,
+            PropertyChange,
+        )
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+
+        dt = make_device_types(nb_api=mock_nb_api)
+        existing_iface = MagicMock()
+        existing_iface.id = 77
+        existing_iface.name = "LAN"
+        dt.components.record("interface_templates", "device", 6119, {"LAN": existing_iface})
+        mock_nb_api.dcim.interface_templates.update.side_effect = requests.exceptions.ConnectionError("network down")
+
+        existing_dt = MagicMock()
+        existing_dt.id = 6119
+        existing_dt.model = "EAP670"
+        existing_dt.manufacturer.name = "TP-Link"
+        dt.existing_device_types = {("tp-link", "EAP670"): existing_dt}
+        dt.existing_device_types_by_slug = {}
+
+        nb = NetBox(mock_settings, mock_handle)
+        nb.device_types = dt
+
+        change = DeviceTypeChange(
+            manufacturer_slug="tp-link",
+            model="EAP670",
+            slug="tp-link-eap670",
+            component_changes=[
+                ComponentChange(
+                    "interfaces",
+                    "LAN",
+                    ChangeType.COMPONENT_CHANGED,
+                    property_changes=[PropertyChange("description", "", "uplink")],
+                )
+            ],
+        )
+        device_type = {
+            "manufacturer": {"slug": "tp-link"},
+            "model": "EAP670",
+            "slug": "tp-link-eap670",
+            "interfaces": [{"name": "LAN", "type": "2.5gbase-t", "description": "uplink"}],
+            "src": "/repo/device-types/TP-Link/EAP670.yaml",
+        }
+        with patch("core.netbox_api.time.sleep"):
+            nb.create_device_types(
+                [device_type], update=True, change_report=ChangeReport(modified_device_types=[change])
+            )
+
+        report = "\n".join(nb.outcomes.render_failure_report())
+        assert "TP-Link/EAP670" in report
+        assert "Connection error updating" in report
+        assert "network down" in report
+
+    def test_component_removal_transport_failure_reports_the_transport_error(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """A retry-exhausted removal must name the transport error too."""
+        import pynetbox as real_pynb
+        import requests
+        from core.change_detector import ChangeType, ComponentChange
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+
+        dt = make_device_types(nb_api=mock_nb_api)
+        stale = MagicMock()
+        stale.id = 88
+        stale.name = "OLD"
+        dt.components.record("interface_templates", "device", 6119, {"OLD": stale})
+        mock_nb_api.dcim.interface_templates.delete.side_effect = requests.exceptions.ConnectionError("network down")
+
+        with patch("core.netbox_api.time.sleep"):
+            dt.remove_components(
+                6119,
+                [ComponentChange("interfaces", "OLD", ChangeType.COMPONENT_REMOVED)],
+                parent_type="device",
+            )
+
+        errors = dt.take_errors()
+        assert len(errors) == 1
+        assert "Connection error removing" in errors[0]
+        assert "network down" in errors[0]
+
     def test_failed_component_create_reports_the_netbox_message(
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -7168,3 +7168,53 @@ class TestFailuresReachTheRunReport:
         report = "\n".join(nb.outcomes.render_failure_report())
         assert "[rack_type] lenovo/1410HPB" in report
         assert "Invalid value." in report
+
+
+class TestComponentFailureReasonReachesTheReport:
+    """A failed component change must carry NetBox's message into the report."""
+
+    def test_failed_component_create_reports_the_netbox_message(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """The report must name the constraint, not the generic failure label."""
+        import pynetbox as real_pynb
+        from core.change_detector import ChangeReport, ChangeType, ComponentChange, DeviceTypeChange
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+
+        dt = make_device_types(nb_api=mock_nb_api)
+        dt.components.record("interface_templates", "device", 6119, {})
+        mock_nb_api.dcim.interface_templates.create.side_effect = _request_error(
+            b'[{"rf_role":["Wireless role may be set only on wireless interfaces."]}]'
+        )
+
+        existing_dt = MagicMock()
+        existing_dt.id = 6119
+        existing_dt.model = "EAP670"
+        existing_dt.manufacturer.name = "TP-Link"
+        dt.existing_device_types = {("tp-link", "EAP670"): existing_dt}
+        dt.existing_device_types_by_slug = {}
+
+        nb = NetBox(mock_settings, mock_handle)
+        nb.device_types = dt
+
+        change = DeviceTypeChange(
+            manufacturer_slug="tp-link",
+            model="EAP670",
+            slug="tp-link-eap670",
+            component_changes=[ComponentChange("interfaces", "LAN", ChangeType.COMPONENT_ADDED)],
+        )
+        device_type = {
+            "manufacturer": {"slug": "tp-link"},
+            "model": "EAP670",
+            "slug": "tp-link-eap670",
+            "interfaces": [{"name": "LAN", "type": "2.5gbase-t", "rf_role": "ap"}],
+            "src": "/repo/device-types/TP-Link/EAP670.yaml",
+        }
+        nb.create_device_types([device_type], update=True, change_report=ChangeReport(modified_device_types=[change]))
+
+        report = "\n".join(nb.outcomes.render_failure_report())
+        assert "TP-Link/EAP670" in report
+        assert "Wireless role may be set only on wireless interfaces." in report

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -7170,6 +7170,96 @@ class TestFailuresReachTheRunReport:
         assert "Invalid value." in report
 
 
+class TestSkippedComponentReasonReachesTheReport:
+    """A component silently dropped during link resolution must reach the outcome reason."""
+
+    def _dt(self, mock_pynetbox, make_device_types, parent_id=1):
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+        dt = make_device_types(nb_api=mock_nb_api)
+        return dt
+
+    def test_unresolvable_power_port_reaches_the_report(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """The Powerman case: an outlet dropped for a bad power_port must name the reason."""
+        import pynetbox as real_pynb
+        from core.change_detector import ChangeReport, ChangeType, ComponentChange, DeviceTypeChange
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+
+        dt = make_device_types(nb_api=mock_nb_api)
+        inlet = MagicMock()
+        inlet.id = 11
+        inlet.name = "Input"
+        dt.components.record("power_port_templates", "device", 5870, {"Input": inlet})
+        dt.components.record("power_outlet_templates", "device", 5870, {})
+
+        existing_dt = MagicMock()
+        existing_dt.id = 5870
+        existing_dt.model = "Online-3000"
+        existing_dt.manufacturer.name = "Powerman"
+        dt.existing_device_types = {("powerman", "Online-3000"): existing_dt}
+        dt.existing_device_types_by_slug = {}
+
+        nb = NetBox(mock_settings, mock_handle)
+        nb.device_types = dt
+
+        change = DeviceTypeChange(
+            manufacturer_slug="powerman",
+            model="Online-3000",
+            slug="powerman-online-3000",
+            component_changes=[ComponentChange("power-outlets", "Hardwire", ChangeType.COMPONENT_ADDED)],
+        )
+        device_type = {
+            "manufacturer": {"slug": "powerman"},
+            "model": "Online-3000",
+            "slug": "powerman-online-3000",
+            "power-outlets": [{"name": "Hardwire", "type": "iec-60320-c13", "power_port": "hardwired"}],
+            "src": "/repo/device-types/Powerman/Online-3000.yaml",
+        }
+        nb.create_device_types([device_type], update=True, change_report=ChangeReport(modified_device_types=[change]))
+
+        report = "\n".join(nb.outcomes.render_failure_report())
+        assert "Powerman/Online-3000" in report
+        assert "Could not find Power Port" in report
+        assert "hardwired" in report
+
+    def test_unresolvable_rear_port_is_buffered(self, mock_pynetbox, graphql_client, make_device_types):
+        """A front port dropped for a bad rear_port reference must be buffered."""
+        dt = self._dt(mock_pynetbox, make_device_types)
+        dt.components.record("rear_port_templates", "device", 1, {})
+        dt.components.record("front_port_templates", "device", 1, {})
+
+        dt.create_components("front-ports", [{"name": "FP1", "type": "8p8c", "rear_port": "RP-missing"}], 1)
+
+        errors = dt.take_errors()
+        assert any("Could not find Rear Port" in e and "RP-missing" in e for e in errors)
+
+    def test_unresolvable_bridge_is_buffered(self, mock_pynetbox, graphql_client, make_device_types):
+        """An interface bridge that cannot be resolved must be buffered."""
+        dt = self._dt(mock_pynetbox, make_device_types)
+        dt.components.record("interface_templates", "device", 1, {})
+
+        dt.create_components("interfaces", [{"name": "xe-0", "type": "10gbase-x-sfpp", "bridge": "xe-missing"}], 1)
+
+        errors = dt.take_errors()
+        assert any("Error bridging" in e and "xe-missing" in e for e in errors)
+
+    def test_unresolvable_mapping_rear_port_is_buffered(self, mock_pynetbox, graphql_client, make_device_types):
+        """A front-port mapping patch that cannot resolve its rear port must be buffered."""
+        dt = self._dt(mock_pynetbox, make_device_types)
+        dt.components.record("rear_port_templates", "device", 1, {})
+
+        payload = dt._build_mappings_patch("FP1", frozenset({("RP-missing", 1, 1)}), 1, "device")
+
+        assert payload is None
+        errors = dt.take_errors()
+        assert any("Cannot update mapping" in e and "RP-missing" in e for e in errors)
+
+
 class TestComponentFailureReasonReachesTheReport:
     """A failed component change must carry NetBox's message into the report."""
 

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -7230,9 +7230,9 @@ class TestSkippedComponentReasonReachesTheReport:
         dt.components.record("rear_port_templates", "device", 1, {})
         dt.components.record("front_port_templates", "device", 1, {})
 
-        dt.create_components("front-ports", [{"name": "FP1", "type": "8p8c", "rear_port": "RP-missing"}], 1)
+        with dt.collect_component_errors() as errors:
+            dt.create_components("front-ports", [{"name": "FP1", "type": "8p8c", "rear_port": "RP-missing"}], 1)
 
-        errors = dt.take_errors()
         assert any("Could not find Rear Port" in e and "RP-missing" in e for e in errors)
 
     def test_unresolvable_bridge_is_buffered(self, mock_pynetbox, graphql_client, make_device_types):
@@ -7240,9 +7240,9 @@ class TestSkippedComponentReasonReachesTheReport:
         dt = self._dt(mock_pynetbox, make_device_types)
         dt.components.record("interface_templates", "device", 1, {})
 
-        dt.create_components("interfaces", [{"name": "xe-0", "type": "10gbase-x-sfpp", "bridge": "xe-missing"}], 1)
+        with dt.collect_component_errors() as errors:
+            dt.create_components("interfaces", [{"name": "xe-0", "type": "10gbase-x-sfpp", "bridge": "xe-missing"}], 1)
 
-        errors = dt.take_errors()
         assert any("Error bridging" in e and "xe-missing" in e for e in errors)
 
     def test_unresolvable_mapping_rear_port_is_buffered(self, mock_pynetbox, graphql_client, make_device_types):
@@ -7250,10 +7250,10 @@ class TestSkippedComponentReasonReachesTheReport:
         dt = self._dt(mock_pynetbox, make_device_types)
         dt.components.record("rear_port_templates", "device", 1, {})
 
-        payload = dt._build_mappings_patch("FP1", frozenset({("RP-missing", 1, 1)}), 1, "device")
+        with dt.collect_component_errors() as errors:
+            payload = dt._build_mappings_patch("FP1", frozenset({("RP-missing", 1, 1)}), 1, "device")
 
         assert payload is None
-        errors = dt.take_errors()
         assert any("Cannot update mapping" in e and "RP-missing" in e for e in errors)
 
 
@@ -7344,14 +7344,13 @@ class TestComponentFailureReasonReachesTheReport:
         dt.components.record("interface_templates", "device", 6119, {"OLD": stale})
         mock_nb_api.dcim.interface_templates.delete.side_effect = requests.exceptions.ConnectionError("network down")
 
-        with patch("core.netbox_api.time.sleep"):
+        with patch("core.netbox_api.time.sleep"), dt.collect_component_errors() as errors:
             dt.remove_components(
                 6119,
                 [ComponentChange("interfaces", "OLD", ChangeType.COMPONENT_REMOVED)],
                 parent_type="device",
             )
 
-        errors = dt.take_errors()
         assert len(errors) == 1
         assert "Connection error removing" in errors[0]
         assert "network down" in errors[0]
@@ -7401,3 +7400,85 @@ class TestComponentFailureReasonReachesTheReport:
         report = "\n".join(nb.outcomes.render_failure_report())
         assert "TP-Link/EAP670" in report
         assert "Wireless role may be set only on wireless interfaces." in report
+
+
+class TestComponentErrorScoping:
+    """Component failure detail must be scoped to, and consumed by, every entity path."""
+
+    def _nb(self, mock_settings, mock_handle, mock_pynetbox):
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_pynetbox.api.return_value.version = "4.1"
+        return NetBox(mock_settings, mock_handle)
+
+    def test_new_device_type_with_failing_component_is_partial(
+        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
+    ):
+        """A device type created with a failing component must not be reported as clean."""
+        import pynetbox as real_pynb
+
+        mock_pynetbox.RequestError = real_pynb.RequestError
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+        dt = make_device_types(nb_api=mock_nb_api)
+        dt.components.record("interface_templates", "device", 900, {})
+        mock_nb_api.dcim.interface_templates.create.side_effect = _request_error(
+            b'[{"rf_role":["Wireless role may be set only on wireless interfaces."]}]'
+        )
+        created = MagicMock()
+        created.id = 900
+        created.model = "EAP670"
+        created.manufacturer.name = "TP-Link"
+        mock_nb_api.dcim.device_types.create.return_value = created
+
+        nb = NetBox(mock_settings, mock_handle)
+        nb.device_types = dt
+        dt.existing_device_types = {}
+        dt.existing_device_types_by_slug = {}
+
+        nb.create_device_types(
+            [
+                {
+                    "manufacturer": {"slug": "tp-link"},
+                    "model": "EAP670",
+                    "slug": "tp-link-eap670",
+                    "interfaces": [{"name": "LAN", "type": "2.5gbase-t", "rf_role": "ap"}],
+                    "src": "/repo/device-types/TP-Link/EAP670.yaml",
+                }
+            ]
+        )
+
+        partials = nb.outcomes.partials()
+        assert len(partials) == 1
+        assert partials[0].kind == EntityKind.DEVICE_TYPE
+        assert "Wireless role may be set only on wireless interfaces." in (partials[0].reason or "")
+
+    def test_component_errors_do_not_leak_between_entities(self, mock_pynetbox, graphql_client, make_device_types):
+        """Errors buffered for one entity must not surface in the next entity's reason."""
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+        dt = make_device_types(nb_api=mock_nb_api)
+
+        dt._log_component_error("stale error from an earlier entity")
+        with dt.collect_component_errors() as errors:
+            pass
+
+        assert errors == []
+        with dt.collect_component_errors() as errors2:
+            dt._log_component_error("this entity's error")
+        assert errors2 == ["this entity's error"]
+
+    def test_collect_component_errors_clears_on_exit(self, mock_pynetbox, graphql_client, make_device_types):
+        """The buffer is empty after a scope closes, so the next scope starts clean."""
+        mock_nb_api = mock_pynetbox.api.return_value
+        mock_nb_api.version = "4.1"
+        dt = make_device_types(nb_api=mock_nb_api)
+
+        with dt.collect_component_errors() as first:
+            dt._log_component_error("boom")
+        assert first == ["boom"]
+
+        with dt.collect_component_errors() as second:
+            pass
+        assert second == []

--- a/tests/test_update_failure_resolver.py
+++ b/tests/test_update_failure_resolver.py
@@ -9,7 +9,7 @@ import pytest
 
 from core.update_failure_resolver import (
     FailureKind,
-    _extract_error_payload,
+    extract_error_payload,
     classify_device_type_update_failure,
 )
 
@@ -198,7 +198,7 @@ class _BrokenBytes(bytes):
 
 def test_extract_error_payload_returns_original_bytes_on_decode_failure():
     payload = _BrokenBytes(b"bad")
-    assert _extract_error_payload(payload) is payload
+    assert extract_error_payload(payload) is payload
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`pynetbox` sets `RequestError.error` to `response.text`, which is always a string. The `isinstance(excep.error, list)` branch in `_create_generic` was therefore unreachable, and every rejected bulk create fell through to the whole-batch message.

NetBox rejects the entire POST when one item is invalid, so the log named every submitted component:

```
Error '[{"rf_role":["Wireless role may be set only on wireless interfaces."]},{},{},{}]' creating Interface.
Items: ['Uplink', 'Downlink 2.5G', 'Downlink 1', 'Downlink 2']
```

Only `Uplink` was at fault. Now:

```
Failed to create Interface 'Uplink': {'rf_role': ['Wireless role may be set only on wireless interfaces.']} (Context: EAP725-Wall.yaml)
```

## Change

Decode the response body and map NetBox's per-item error array onto the submitted items by position, which is how NetBox returns it. Fall back to the whole-batch message when the payload is not a list, when its length does not match the batch, or when no item carries a message, so a failure is never swallowed.

`_extract_error_payload` already did this decoding for the `subdevice_role` classifier. Promoted to `extract_error_payload` and shared, rather than adding a second decoder.

This only changes reporting. It does not make a rejected component import; the invalid definitions still have to be fixed at the source.

## Tests

The previous tests built the error from a `MagicMock` response and then assigned `err.error = [...]` by hand, fabricating a shape pynetbox never produces, and asserted only that something was logged. That is why the dead branch survived.

Rebuilt on a real `requests.Response` and asserting message content, covering: per-item error naming only the failing item, multiple failing items, a whole-request error, a length mismatch, and an all-empty list. Confirmed red before the fix (2 failed), green after.

Full suite: 1111 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for component creation, updates, removals, mappings, and port operations.
  * Per-item API errors now identify only affected items when reliable details are available.
  * Invalid, incomplete, empty, or mismatched responses now produce clear aggregate batch errors.
  * Failure reports include relevant API and connection error details.
  * Device, module, and rack type failures and partial outcomes now appear consistently in run summaries.

* **Improvements**
  * Change-detection reports now identify the vendor when applicable.

* **Tests**
  * Expanded coverage for API failures, retry failures, outcome reporting, and vendor-specific headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->