### PR TITLE
feat: module bay types

### DIFF
--- a/core/change_detector.py
+++ b/core/change_detector.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 from typing import Any, List, Optional
 from enum import Enum
 
-from core.component_registry import COMPONENT_TYPES
+from core.component_registry import BY_YAML_KEY, COMPONENT_TYPES
 from core.normalization import normalize_values
 from core.formatting import log_property_diffs
 from core.schema_reader import load_properties_for_type
@@ -24,6 +24,110 @@ class ChangeType(Enum):
     COMPONENT_ADDED = "component_added"
     COMPONENT_CHANGED = "component_changed"
     COMPONENT_REMOVED = "component_removed"
+
+
+def _manufacturer_slug_of(yaml_data):
+    """Return the owning manufacturer's slug from a parsed definition.
+
+    ``core.repo`` rewrites every YAML manufacturer to ``{"slug": ...}`` before the importer
+    sees it, so that is the usual shape here.
+    """
+    manufacturer = (yaml_data or {}).get("manufacturer")
+    if isinstance(manufacturer, dict):
+        return manufacturer.get("slug") or ""
+    return manufacturer or ""
+
+
+def _relation_properties(comp_type):
+    """Return the relation field names the registry declares for *comp_type*."""
+    component = BY_YAML_KEY.get(comp_type)
+    return component.relations if component else ()
+
+
+def _is_relation_list(value):
+    """Return True when *value* is a list of non-empty strings, the only shape a reference takes."""
+    return isinstance(value, list) and all(isinstance(item, str) and item for item in value)
+
+
+def _relation_change(prop, yaml_comp, netbox_comp, catalog=None, manufacturer=None, handle=None):
+    """Return a PropertyChange when a relation differs, or None when there is nothing to do.
+
+    A relation is an unordered set of related objects.  Where the catalog is available the
+    comparison is between *identities*, ``(manufacturer slug, slug)``, because two
+    manufacturers may define the same class name and a bay holding the wrong one reads as
+    equal on names alone.  Without a catalog it falls back to comparing names, which is
+    what a caller that has not wired one can still do.
+
+    An omitted key leaves the relation unmanaged and an empty list clears it, but a bare
+    ``module_bay_types:`` parses as None and a malformed entry is not a name: those are left
+    unmanaged, because reading them as empty would clear a restriction nobody removed.  A
+    field the query did not return is skipped for the same reason.
+    """
+    if prop not in yaml_comp:
+        return None
+    declared = yaml_comp.get(prop)
+    if not _is_relation_list(declared):
+        if handle is not None:
+            handle.log(
+                f"Ignored {prop} on {yaml_comp.get('name', 'Unknown')!r}: expected a list of names, got {declared!r}"
+            )
+        return None
+    netbox_value = getattr(netbox_comp, prop, _MISSING)
+    if netbox_value is _MISSING:
+        return None
+
+    if catalog is not None and manufacturer:
+        from core.module_bay_types import ModuleBayTypeError
+
+        try:
+            wanted = catalog.identities_for(manufacturer, declared)
+        except ModuleBayTypeError:
+            # Reported as a change so the write path sees it; "no change" is silent.
+            return PropertyChange(
+                property_name=prop,
+                old_value=sorted(_relation_names(netbox_value)),
+                new_value=sorted(set(declared)),
+            )
+        current = _relation_identities(netbox_value)
+        if current is not None and wanted == current:
+            return None
+        if current is not None:
+            return PropertyChange(
+                property_name=prop, old_value=sorted(_relation_names(netbox_value)), new_value=sorted(set(declared))
+            )
+
+    yaml_names = frozenset(declared)
+    netbox_names = frozenset(_relation_names(netbox_value))
+    if yaml_names == netbox_names:
+        return None
+    return PropertyChange(property_name=prop, old_value=sorted(netbox_names), new_value=sorted(yaml_names))
+
+
+def _relation_identities(value):
+    """Return {(manufacturer slug, slug)} for a relation, or None if the shape lacks them.
+
+    A read path that returns only ``id`` and ``name`` cannot answer the scope question, so
+    the caller falls back to comparing names rather than inventing an identity.
+    """
+    identities = set()
+    for item in value or []:
+        slug = item.get("slug") if isinstance(item, dict) else getattr(item, "slug", None)
+        manufacturer = item.get("manufacturer") if isinstance(item, dict) else getattr(item, "manufacturer", None)
+        owner = manufacturer.get("slug") if isinstance(manufacturer, dict) else getattr(manufacturer, "slug", None)
+        if not slug or not owner:
+            return None
+        identities.add((owner, slug))
+    return frozenset(identities)
+
+
+def _relation_names(value):
+    """Return the ``name`` of each related object NetBox returned for a relation."""
+    names = []
+    for item in value or []:
+        name = item.get("name") if isinstance(item, dict) else getattr(item, "name", None)
+        if name is not None:
+            names.append(name)
+    return names
 
 
 @dataclass
@@ -339,7 +443,11 @@ class ChangeDetector:
                     # Check for property changes on existing component
                     existing = existing_components[comp_name]
                     prop_changes = self._compare_component_properties(
-                        yaml_comp, existing, component.compare_properties, comp_type=yaml_key
+                        yaml_comp,
+                        existing,
+                        component.compare_properties,
+                        comp_type=yaml_key,
+                        manufacturer=_manufacturer_slug_of(yaml_data),
                     )
                     if prop_changes:
                         changes.append(
@@ -353,14 +461,31 @@ class ChangeDetector:
 
         return changes
 
+    def _relation_catalog(self):
+        """Return the module bay type catalog, or None when this detector has no real one.
+
+        Tests build the detector around a stand-in for DeviceTypes, and a stand-in cannot
+        answer what a reference means.  Returning None there keeps the name comparison,
+        which is what those tests are asserting on.
+        """
+        from core.module_bay_types import ModuleBayTypeCatalog
+
+        catalog = getattr(self.device_types, "module_bay_types", None)
+        return catalog if isinstance(catalog, ModuleBayTypeCatalog) else None
+
     def _compare_component_properties(
         self,
         yaml_comp: dict,
         netbox_comp,
         properties: List[str],
         comp_type: str = "",
+        manufacturer: str = "",
     ) -> List[PropertyChange]:
-        """Compare properties between YAML and NetBox component."""
+        """Compare properties between YAML and NetBox component.
+
+        *manufacturer* is the owning manufacturer's slug, used to resolve a relation
+        reference to the object it means rather than the name it is written as.
+        """
         changes = []
 
         for prop in properties:
@@ -424,6 +549,14 @@ class ChangeDetector:
                             new_value=yaml_set,
                         )
                     )
+                continue
+
+            if prop in _relation_properties(comp_type):
+                relation_change = _relation_change(
+                    prop, yaml_comp, netbox_comp, self._relation_catalog(), manufacturer, self.handle
+                )
+                if relation_change is not None:
+                    changes.append(relation_change)
                 continue
 
             # Only compare properties explicitly present in the YAML component;

--- a/core/compat.py
+++ b/core/compat.py
@@ -14,6 +14,26 @@ here rather than inlining ``"device_type_id" if new_filters else "devicetype_id"
 
 from __future__ import annotations
 
+import re
+
+# Selecting or sending the relation below this release fails the whole query.
+MODULE_BAY_TYPE_MINIMUM_VERSION = (4, 7)
+
+
+def parse_netbox_version(version) -> tuple[int, int]:
+    """Return ``(major, minor)`` from a NetBox version string.
+
+    Padded to two parts so a single-component string cannot raise, and tolerant of the
+    suffixes NetBox ships ("4.7.0-beta2").
+    """
+    raw = [int(re.sub(r"\D.*", "", part.strip()) or "0") for part in str(version).split(".")]
+    return tuple((raw + [0, 0])[:2])  # type: ignore[return-value]
+
+
+def supports_module_bay_types(version) -> bool:
+    """Return True when this NetBox release exposes the module bay type relation."""
+    return parse_netbox_version(version) >= MODULE_BAY_TYPE_MINIMUM_VERSION
+
 
 def device_type_filter_key(new_filters: bool) -> str:
     """Return the correct filter parameter name for device-type component queries.

--- a/core/component_registry.py
+++ b/core/component_registry.py
@@ -17,6 +17,12 @@ LINK_BRIDGE = "bridge"
 LINK_POWER_PORT = "power_port"
 LINK_REAR_PORTS = "rear_ports"
 
+# Fields holding names that must become NetBox ids before a POST.
+RELATION_MODULE_BAY_TYPES = "module_bay_types"
+
+# Relation fields a module type carries itself, rather than through one of its components.
+MODULE_TYPE_RELATIONS = (RELATION_MODULE_BAY_TYPES,)
+
 
 @dataclass(frozen=True)
 class ComponentType:
@@ -27,19 +33,30 @@ class ComponentType:
     label: str
     fields: tuple[str, ...]
     module_types: bool = True
+    relations: tuple[str, ...] = field(default_factory=tuple)
     graphql_extra: tuple[str, ...] = field(default_factory=tuple)
     compare_extra: tuple[str, ...] = field(default_factory=tuple)
     link: Optional[str] = None
 
     @property
     def graphql_fields(self):
-        """Fields to select in a GraphQL query, including the id every consumer needs."""
-        return ["id", *self.fields, *self.graphql_extra]
+        """Fields to select in a GraphQL query, including the id every consumer needs.
+
+        A relation is a list of related objects, so it is selected by name rather than
+        read as a scalar.
+        """
+        return ["id", *self.fields, *self.graphql_extra, *self.graphql_relation_fields]
+
+    @property
+    def graphql_relation_fields(self):
+        """GraphQL selections for this row's relations, one nested block per relation."""
+        # slug plus owning manufacturer is the identity; the name alone is ambiguous.
+        return [f"{name} {{ id name slug manufacturer {{ slug }} }}" for name in self.relations]
 
     @property
     def compare_properties(self):
         """Properties change detection compares between YAML and NetBox."""
-        return [*self.fields, *self.compare_extra]
+        return [*self.fields, *self.compare_extra, *self.relations]
 
     @property
     def list_key(self):
@@ -121,6 +138,7 @@ COMPONENT_TYPES = (
         endpoint="module_bay_templates",
         label="Module Bay",
         fields=("name", "position", "label", "description"),
+        relations=(RELATION_MODULE_BAY_TYPES,),
     ),
 )
 

--- a/core/export.py
+++ b/core/export.py
@@ -241,6 +241,9 @@ class Exporter:
         )
         self.handle.log(f"Export-diff: fetching NetBox device/module/rack types{scope}")
 
+        # Decided before the first query: the selection depends on the answer.
+        self.graphql.detect_module_bay_type_support()
+
         # ── Fetch all types from NetBox ──────────────────────────────────────
         by_model, by_slug = self.graphql.get_device_types(manufacturer_slugs=self.vendor_slugs)
         all_mt = self.graphql.get_module_types(manufacturer_slugs=self.vendor_slugs)
@@ -624,13 +627,7 @@ class Exporter:
 
         def _fetch_one(endpoint_name):
             if not getattr(_thread_local, "graphql", None):
-                client = NetBoxGraphQLClient(
-                    self.graphql.url,
-                    self.graphql.token,
-                    self.graphql.ignore_ssl,
-                    self.graphql.handle,
-                    self.graphql.DEFAULT_PAGE_SIZE,
-                )
+                client = self.graphql.clone()
                 _thread_local.graphql = client
                 with _clients_lock:
                     _clients.append(client)

--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -5,12 +5,14 @@ pagination, authentication, and convenience methods that return data structures
 compatible with the existing REST-based code in ``netbox_api.py``.
 """
 
+import copy
 import threading
 import time
 from collections.abc import Sequence
 
 import requests
 
+from core.compat import supports_module_bay_types
 from core.component_registry import BY_ENDPOINT
 
 # Module-level dedup: tracks (url, requested_page_size) pairs that have already
@@ -102,6 +104,9 @@ _MAX_ERROR_BODY_CHARS = 1000
 # connections, which is transient during a long paginated run.
 _RETRYABLE_STATUSES = {429, 500, 502, 503, 504}
 
+# One small metadata read; a run that cannot get it fails at the next query anyway.
+_STATUS_TIMEOUT_SECONDS = 30
+
 
 def _response_body_detail(response):
     """Return the response body as a suffix for an error message, truncated and stripped."""
@@ -136,7 +141,7 @@ class NetBoxGraphQLClient:
         or raise the server's ``MAX_PAGE_SIZE`` setting to match.
     """
 
-    def __init__(self, url, token, ignore_ssl=False, handle=None, page_size=5000):
+    def __init__(self, url, token, ignore_ssl=False, handle=None, page_size=5000, supports_module_bay_types=False):
         """Store connection parameters for later use in :meth:`query`.
 
         Args:
@@ -148,6 +153,8 @@ class NetBoxGraphQLClient:
                 ``print`` when not provided.
             page_size: Default number of items per GraphQL page
                 (default: 5 000).
+            supports_module_bay_types: True when NetBox is >= 4.7 and its schema
+                exposes the module bay type relation.
         """
         self.DEFAULT_PAGE_SIZE = page_size
         self.url = url.rstrip("/")
@@ -155,22 +162,28 @@ class NetBoxGraphQLClient:
         self.token = token
         self.ignore_ssl = ignore_ssl
         self._handle = handle
+        self.supports_module_bay_types = supports_module_bay_types
 
-        self._session = requests.Session()
+        self._session = self._new_session()
+
+    def _new_session(self):
+        """Return an HTTP session carrying this client's auth and TLS settings."""
+        session = requests.Session()
         # v2 tokens start with "nbt_" prefix (format: nbt_<key>.<secret>);
         # v1 tokens are plain 40-char hex strings using legacy Token auth.
         auth_scheme = "Bearer" if self.token.startswith("nbt_") else "Token"
-        self._session.headers.update(
+        session.headers.update(
             {
                 "Authorization": f"{auth_scheme} {self.token}",
                 "Content-Type": "application/json",
             }
         )
-        self._session.verify = not self.ignore_ssl
+        session.verify = not self.ignore_ssl
         if self.ignore_ssl:
             import urllib3
 
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        return session
 
     @property
     def handle(self):
@@ -178,8 +191,35 @@ class NetBoxGraphQLClient:
         return self._handle
 
     def clone(self):
-        """Return an independent client with the same connection settings."""
-        return type(self)(self.url, self.token, self.ignore_ssl, self.handle, self.DEFAULT_PAGE_SIZE)
+        """Return an independent client with the same settings and its own HTTP session.
+
+        Copied rather than reconstructed, so a setting added to ``__init__`` travels with
+        the clone instead of quietly reverting to its default.  The session is the one
+        thing a worker must not share, so it is the one thing rebuilt here.
+        """
+        clone = copy.copy(self)
+        clone._session = self._new_session()
+        return clone
+
+    def detect_module_bay_type_support(self):
+        """Ask NetBox for its version and record whether the relation can be selected.
+
+        The importer learns this from its pynetbox client; the export entry point has no
+        such client, so it asks here.  Both sides decide from core.compat, so the line
+        cannot drift between them.
+        """
+        status_url = f"{self.url}/api/status/"
+        try:
+            response = self._session.get(status_url, timeout=_STATUS_TIMEOUT_SECONDS)
+            response.raise_for_status()
+            version = response.json().get("netbox-version", "")
+        except requests.RequestException as exc:
+            raise GraphQLError(f"Could not read {status_url}: {exc}{_response_body_detail(exc.response)}") from exc
+        except ValueError as exc:
+            # A proxy error page answers 200 with HTML, so the body is not JSON.
+            raise GraphQLError(f"Invalid JSON from {status_url}: {exc}") from exc
+        self.supports_module_bay_types = supports_module_bay_types(version)
+        return self.supports_module_bay_types
 
     def close(self):
         """Close the underlying HTTP session."""
@@ -477,6 +517,12 @@ class NetBoxGraphQLClient:
                 sequence of non-blank strings.
         """
         var_decl, filter_fragment, extra_vars = self._build_manufacturer_filter(manufacturer_slugs)
+        module_bay_type_selection = (
+            "module_bay_types {\n              id\n              name\n              slug\n"
+            "              manufacturer {\n                slug\n              }\n            }\n            "
+            if self.supports_module_bay_types
+            else ""
+        )
 
         query = f"""
         query($pagination: OffsetPaginationInput{var_decl}) {{
@@ -490,7 +536,7 @@ class NetBoxGraphQLClient:
             weight
             weight_unit
             last_updated
-            manufacturer {{
+            {module_bay_type_selection}manufacturer {{
               id
               name
               slug
@@ -801,6 +847,9 @@ class NetBoxGraphQLClient:
             raise ValueError("manufacturer_slug must be None or a non-empty string")
 
         fields = component.graphql_fields
+        if not self.supports_module_bay_types:
+            # Selecting a field the server's schema lacks fails the whole query.
+            fields = [f for f in fields if f not in component.graphql_relation_fields]
         list_key = component.list_key
 
         parent_fields = "device_type { id }"

--- a/core/module_bay_types.py
+++ b/core/module_bay_types.py
@@ -1,0 +1,241 @@
+"""Resolve module-bay-type reference names to NetBox ids.
+
+A device type's bay says which classes of module it accepts, and a module type says
+which classes it belongs to.  Both sides name those classes as plain strings, so
+something has to turn a name into the id of one specific NetBox object, creating it
+when the target instance has never seen it.
+
+That is this module.  Callers pass the owning manufacturer and the names; they get
+ids back.  The scope rule, the catalog files, the lookup, the creation, and the cache
+stay in here, so the four call sites (device-type create, module-type create, change
+detection, export) do not each restate them.
+"""
+
+import os
+import re
+
+import pynetbox
+import requests
+import yaml
+
+from core.errors import FatalError
+
+# Directory in the devicetype-library holding the catalog, one directory per manufacturer.
+CATALOG_DIRNAME = "module-bay-types"
+
+# Second resolution scope, for a class one vendor defines and another fills.
+FALLBACK_MANUFACTURER = "Generic"
+
+
+def manufacturer_slug(name):
+    """Slugify a manufacturer name the way the library loader does.
+
+    ``core.repo`` reduces every YAML ``manufacturer`` to this slug, because upstream data
+    disagrees on case (RuggedCOM vs RuggedCom).  The catalog keys on the same slug so both
+    sides meet on one value.
+    """
+    return re.sub(r"\W+", "-", (name or "").lower())
+
+
+class ModuleBayTypeError(FatalError):
+    """A reference could not be resolved to exactly one NetBox object.
+
+    Raised per definition so the caller can log it and continue with the next one.
+    Never raised for a difference this module could paper over: an unresolved name and
+    a conflicting identity are both reported rather than guessed at.
+    """
+
+
+class ModuleBayTypeCatalog:
+    """Turn module-bay-type names into NetBox ids, creating what is missing.
+
+    ``ids_for(manufacturer, names)`` resolves each name in the owning manufacturer's
+    scope, then in ``Generic``, and raises :class:`ModuleBayTypeError` if neither has
+    it.  Resolution creates the NetBox object, and the manufacturer that owns it, when
+    they do not exist yet.  Returned order is not meaningful; callers compare as sets.
+
+    Export does not use this class: it reads the names off the records NetBox returned,
+    because an export run resolves nothing and so has no id-to-name mapping of its own.
+    """
+
+    def __init__(self, netbox, repo_path, handle):
+        """Store the NetBox client, the library checkout to read the catalog from, and the log handle."""
+        self._netbox = netbox
+        self._catalog_dir = os.path.join(repo_path, CATALOG_DIRNAME)
+        self._handle = handle
+        self._entries = None
+        self._load_error = None
+        self._ids = {}
+        self._manufacturer_ids = {}
+
+    def ids_for(self, manufacturer, names):
+        """Return the NetBox id for each name, resolved against *manufacturer* then Generic.
+
+        *manufacturer* is a manufacturer slug, as produced by :func:`manufacturer_slug`.
+        An empty list is a valid instruction to hold no classes; anything that is not a
+        list of non-empty strings is refused rather than read as empty, because reading a
+        malformed value as empty would drop a restriction the author asked for.
+        """
+        self._validate(names)
+        # Duplicates collapse: the relationship is a set.
+        return sorted({self._id_for(manufacturer, name) for name in names})
+
+    def identities_for(self, manufacturer, names):
+        """Return the identity each name resolves to, without touching NetBox.
+
+        The identity is ``(manufacturer slug, slug)``: the object a reference means, not
+        the name it is written as.  Two manufacturers may both define a class called
+        ``X``, so a name alone cannot say which object is intended.
+
+        This is the query half of the module.  :meth:`ids_for` is the command half and
+        creates what is missing; this one reads only the catalog files, so change
+        detection can ask what a reference means without causing anything to exist.
+        """
+        self._validate(names)
+        return frozenset(
+            (manufacturer_slug(entry["manufacturer"]), entry["slug"])
+            for entry in (self._lookup(manufacturer, name) for name in names)
+        )
+
+    @staticmethod
+    def _validate(names):
+        """Reject anything that is not a list of non-empty names."""
+        if names is None or not isinstance(names, list):
+            raise ModuleBayTypeError(f"module_bay_types must be a list of names, got {names!r}")
+        for name in names:
+            if not isinstance(name, str) or not name.strip():
+                raise ModuleBayTypeError(f"module_bay_types entries must be non-empty names, got {name!r}")
+
+    def _id_for(self, manufacturer, name):
+        entry = self._lookup(manufacturer, name)
+        cache_key = (manufacturer_slug(entry["manufacturer"]), entry["name"])
+        if cache_key not in self._ids:
+            self._ids[cache_key] = self._netbox_id(entry)
+        return self._ids[cache_key]
+
+    def _lookup(self, manufacturer, name):
+        """Find the catalog entry for *name*, owner scope first, then Generic."""
+        entries = self._load_catalog()
+        for scope in (manufacturer, manufacturer_slug(FALLBACK_MANUFACTURER)):
+            entry = entries.get((scope, name))
+            if entry is not None:
+                return entry
+        raise ModuleBayTypeError(
+            f"Module bay type {name!r} is not in the catalog for manufacturer "
+            f"{manufacturer!r} or {FALLBACK_MANUFACTURER!r}"
+        )
+
+    def _load_catalog(self):
+        """Read every catalog file once, indexed by (manufacturer, name).
+
+        A failure is cached too: it is terminal for the run, and re-walking the tree for
+        every later lookup only repeats the same error more slowly.
+        """
+        if self._entries is not None:
+            return self._entries
+        if self._load_error is not None:
+            raise self._load_error
+        try:
+            self._entries = self._read_catalog()
+        except ModuleBayTypeError as exc:
+            self._load_error = exc
+            raise
+        return self._entries
+
+    def _read_catalog(self):
+        """Walk the catalog directory and return every entry, indexed by (manufacturer, name)."""
+        entries = {}
+        for root, _dirs, files in os.walk(self._catalog_dir):
+            for filename in sorted(files):
+                if not filename.endswith((".yaml", ".yml")):
+                    continue
+                path = os.path.join(root, filename)
+                try:
+                    with open(path, encoding="utf-8") as handle:
+                        data = yaml.safe_load(handle)
+                except (OSError, yaml.YAMLError) as exc:
+                    raise ModuleBayTypeError(f"Module bay type catalog file {path!r} could not be read: {exc}") from exc
+                if not isinstance(data, dict):
+                    continue
+                # Reject a half-written entry here; the readers index on name and dereference slug.
+                invalid = [
+                    field
+                    for field in ("name", "slug", "manufacturer")
+                    if not isinstance(data.get(field), str) or not data[field].strip()
+                ]
+                if invalid:
+                    raise ModuleBayTypeError(
+                        f"Module bay type in {path!r} is missing or malformed: {', '.join(invalid)}"
+                    )
+                key = (manufacturer_slug(data.get("manufacturer")), data.get("name"))
+                if key in entries:
+                    raise ModuleBayTypeError(f"Duplicate module bay type {key[1]!r} for manufacturer {key[0]!r}")
+                entries[key] = data
+        return entries
+
+    @staticmethod
+    def _request(action, description):
+        """Run one NetBox request, reporting a rejection as a catalog error.
+
+        Callers resolve one definition at a time and recover from ModuleBayTypeError.  A
+        raw RequestError or a dropped connection escapes that recovery and ends the run,
+        which can leave a parent half created and every later definition unprocessed.
+        """
+        try:
+            return action()
+        except pynetbox.RequestError as exc:
+            raise ModuleBayTypeError(f"NetBox rejected {description}: {exc}") from exc
+        except requests.exceptions.RequestException as exc:
+            raise ModuleBayTypeError(f"NetBox could not be reached for {description}: {exc}") from exc
+
+    def _netbox_id(self, entry):
+        """Return the id of the NetBox object for *entry*, creating it if absent."""
+        manufacturer_id = self._manufacturer_id(entry["manufacturer"])
+        existing = self._request(
+            lambda: list(
+                self._netbox.dcim.module_bay_types.filter(manufacturer_id=manufacturer_id, name=entry["name"])
+            ),
+            f"the lookup of module bay type {entry['name']!r}",
+        )
+        for record in existing:
+            if record.slug != entry["slug"]:
+                raise ModuleBayTypeError(
+                    f"NetBox already has module bay type {entry['name']!r} for "
+                    f"{entry['manufacturer']!r} with slug {record.slug!r}, but the catalog "
+                    f"says {entry['slug']!r}. Resolve the conflict in NetBox; this import "
+                    f"will not rename it."
+                )
+            return record.id
+
+        payload = {"name": entry["name"], "slug": entry["slug"], "manufacturer": manufacturer_id}
+        if entry.get("description"):
+            payload["description"] = entry["description"]
+        created = self._request(
+            lambda: self._netbox.dcim.module_bay_types.create(payload),
+            f"creating module bay type {entry['name']!r}",
+        )
+        self._handle.verbose_log(f"Module Bay Type Created: {entry['name']} ({entry['manufacturer']}) - {created.id}")
+        return created.id
+
+    def _manufacturer_id(self, name):
+        """Return the id of *name*, creating the manufacturer when the catalog needs it.
+
+        A Generic-scoped class is reachable from any vendor, so an import filtered to one
+        manufacturer still has to create the manufacturer that owns the class.
+        """
+        if name in self._manufacturer_ids:
+            return self._manufacturer_ids[name]
+        found = self._request(
+            lambda: list(self._netbox.dcim.manufacturers.filter(slug=manufacturer_slug(name))),
+            f"the lookup of manufacturer {name!r}",
+        )
+        if found:
+            self._manufacturer_ids[name] = found[0].id
+        else:
+            created = self._request(
+                lambda: self._netbox.dcim.manufacturers.create({"name": name, "slug": manufacturer_slug(name)}),
+                f"creating manufacturer {name!r}",
+            )
+            self._handle.verbose_log(f"Manufacturer Created: {name} - {created.id}")
+            self._manufacturer_ids[name] = created.id
+        return self._manufacturer_ids[name]

--- a/core/nb_serializer.py
+++ b/core/nb_serializer.py
@@ -7,7 +7,7 @@ comparison against existing repo YAML files.
 import warnings
 from typing import Any, Sequence
 
-from core.component_registry import BY_ENDPOINT, COMPONENT_TYPES
+from core.component_registry import BY_ENDPOINT, COMPONENT_TYPES, MODULE_TYPE_RELATIONS
 
 # Row order sets the component key order of the serialized YAML.
 COMPONENT_ENDPOINT_NAMES = [component.endpoint for component in COMPONENT_TYPES]
@@ -125,6 +125,26 @@ def _serialize_component(record: Any, fields: Sequence[str]) -> dict:
     return result
 
 
+def _serialize_relations(record: Any, relations: Sequence[str]) -> dict:
+    """Return the catalog name of each related object, which is how YAML names them.
+
+    The names come off the record the query returned, not from the import-side catalog:
+    an export run resolves nothing, so it has no id-to-name mapping of its own.
+
+    An empty relation writes no key.  Emitting an empty list instead would add the key to
+    every bay in the library and make _repo_supersedes report every existing definition as
+    differing, and it tells a fresh import nothing that omitting it does not.
+    """
+    result = {}
+    for relation in relations:
+        names = sorted(
+            name for name in (getattr(item, "name", None) for item in getattr(record, relation, None) or []) if name
+        )
+        if names:
+            result[relation] = names
+    return result
+
+
 def _serialize_front_port(record: Any) -> dict:
     """Serialize a front port template, including rear_port mapping."""
     result = _serialize_component(record, BY_ENDPOINT["front_port_templates"].fields)
@@ -161,12 +181,15 @@ def _serialize_front_port(record: Any) -> dict:
 
 def _serialize_component_list(endpoint_name: str, records: list) -> list:
     """Serialize a list of component template records for a given endpoint."""
+    component = BY_ENDPOINT[endpoint_name]
     out = []
     for record in sorted(records, key=lambda r: str(getattr(r, "name", "") or "")):
         if endpoint_name == "front_port_templates":
-            out.append(_serialize_front_port(record))
+            serialized = _serialize_front_port(record)
         else:
-            out.append(_serialize_component(record, BY_ENDPOINT[endpoint_name].fields))
+            serialized = _serialize_component(record, component.fields)
+        serialized.update(_serialize_relations(record, component.relations))
+        out.append(serialized)
     return out
 
 
@@ -236,6 +259,7 @@ def serialize_module_type(nb_record: Any, components_by_mt_id: dict) -> dict:
         if _should_include(field, val):
             result[field] = val
 
+    result.update(_serialize_relations(nb_record, MODULE_TYPE_RELATIONS))
     _add_components(result, nb_record.id, components_by_mt_id)
     return result
 

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from functools import lru_cache
 import hashlib
 import json
-import re
 import tempfile
 import time
 import pynetbox
@@ -24,7 +23,9 @@ from core.component_registry import (
     LINK_POWER_PORT,
     LINK_REAR_PORTS,
     MODULE_TYPE_COMPONENTS,
+    MODULE_TYPE_RELATIONS,
 )
+from core.compat import parse_netbox_version, supports_module_bay_types
 from core.formatting import log_property_diffs
 from core.errors import FatalError, UnknownError
 from core.graphql_client import GraphQLError, NetBoxGraphQLClient
@@ -48,6 +49,35 @@ class SSLVerificationError(FatalError):
             "Set IGNORE_SSL_ERRORS to True if you want to ignore this error. EXITING.",
             cause=cause,
         )
+
+
+# Oldest NetBox this importer is tested against; see the CI matrix and the README.
+MINIMUM_NETBOX_VERSION = (4, 3)
+
+
+def _relation_identities_differ(catalog, manufacturer, declared, related, *, names_differ):
+    """Return True when the assigned objects are not the ones the references resolve to.
+
+    Comparing names alone reports equality when NetBox holds a same-named class from
+    another manufacturer's scope, so the identity is compared where both sides can supply
+    one.  Where they cannot, the name comparison the caller already made stands.
+    """
+    from core.module_bay_types import ModuleBayTypeError, manufacturer_slug
+
+    if not catalog or not manufacturer:
+        return names_differ
+    current = set()
+    for item in related:
+        slug = getattr(item, "slug", None)
+        owner = getattr(getattr(item, "manufacturer", None), "slug", None)
+        if not slug or not owner:
+            return names_differ
+        current.add((manufacturer_slug(owner), slug))
+    try:
+        return catalog.identities_for(manufacturer, declared) != frozenset(current)
+    except ModuleBayTypeError:
+        # A matching name must not make an unresolvable reference look applied.
+        return True
 
 
 class NetBoxError(FatalError):
@@ -464,6 +494,7 @@ class NetBox:
         self.ignore_ssl = config.ignore_ssl_errors
         self.modules = False
         self.new_filters = False
+        self.module_bay_types = False
         self.m2m_front_ports = False  # True for NetBox >= 4.5 (M2M port mappings)
         self.rack_types = False
         self.force_resolve_conflicts = config.force_resolve_conflicts
@@ -495,6 +526,7 @@ class NetBox:
             self.ignore_ssl,
             handle=self.handle,
             page_size=config.graphql_page_size,
+            supports_module_bay_types=self.module_bay_types,
         )
         try:
             self.existing_manufacturers = self.get_manufacturers()
@@ -509,6 +541,7 @@ class NetBox:
                 self.new_filters,
                 graphql=self.graphql,
                 m2m_front_ports=self.m2m_front_ports,
+                module_bay_types_supported=self.module_bay_types,
                 repo_path=config.repo_path,
                 max_threads=config.preload_threads,
             )
@@ -601,8 +634,15 @@ class NetBox:
                 msg += f"\nResponse body (may be from an intermediate proxy):\n{body}"
             msg += f"\nHint: Verify that {self.url} is reachable and not blocked by a proxy."
             raise NetBoxError(msg) from e
-        _raw = [int(re.sub(r"\D.*", "", x.strip()) or "0") for x in nb_version.split(".")]
-        version_split = (_raw + [0, 0])[:2]  # pad to (major, minor) to guard against single-component strings
+        version_split = parse_netbox_version(nb_version)
+
+        # Below the floor the run dies later naming a schema field, not the real cause.
+        if tuple(version_split) < MINIMUM_NETBOX_VERSION:
+            minimum = ".".join(str(part) for part in MINIMUM_NETBOX_VERSION)
+            raise NetBoxError(
+                f"NetBox {nb_version} is not supported: this importer requires NetBox {minimum} or later. "
+                f"Older releases fail part way through with a GraphQL schema error rather than here."
+            )
 
         # Later than 3.2
         # Might want to check for the module-types entry as well?
@@ -621,6 +661,10 @@ class NetBox:
         if version_split[0] > 4 or (version_split[0] == 4 and version_split[1] >= 5):
             self.m2m_front_ports = True
             self.handle.log(f"Netbox version {self.netbox.version} found. Using M2M front/rear port mappings.")
+
+        if supports_module_bay_types(nb_version):
+            self.module_bay_types = True
+            self.handle.log(f"Netbox version {self.netbox.version} found. Module bay types are supported.")
 
     def get_manufacturers(self):
         """Fetch all manufacturers from NetBox via GraphQL and return them indexed by name."""
@@ -1162,7 +1206,13 @@ class NetBox:
                     continue
                 if yaml_key == "module-bays" and not self.modules:
                     continue
-                self.device_types.create_components(yaml_key, device_type[yaml_key], dt_id, context=src_file)
+                self.device_types.create_components(
+                    yaml_key,
+                    device_type[yaml_key],
+                    dt_id,
+                    context=src_file,
+                    manufacturer=device_type.get("manufacturer"),
+                )
         if component_errors:
             # The type exists but not all of its components do.
             self.outcomes.record(
@@ -1522,6 +1572,8 @@ class NetBox:
                 if not values_equal(module_type[f], nb_val):
                     changed_fields_info.append((f, nb_val, module_type[f]))
 
+            changed_fields_info += self._type_relation_changes(module_type, existing_module)
+
             component_changes = detector._compare_components(module_type, existing_module.id, parent_type="module")
 
             if changed_fields_info or component_changes:
@@ -1574,6 +1626,57 @@ class NetBox:
         )
         return module_type_existing_images
 
+    def _type_relation_changes(self, module_type, existing_module):
+        """Return (field, current, wanted) for each of the type's own relations that differs.
+
+        A relation is a list, so the scalar comparison loop never sees it.  A field the
+        query did not return is skipped rather than read as empty, which would otherwise
+        report a change on every run.
+        """
+        changes: list[tuple[str, list[str], list[str]]] = []
+        if not self.module_bay_types:
+            return changes
+        for field in MODULE_TYPE_RELATIONS:
+            if field not in module_type:
+                continue
+            netbox_value = getattr(existing_module, field, _MISSING)
+            if netbox_value is _MISSING:
+                continue
+            related = netbox_value if isinstance(netbox_value, (list, tuple)) else []
+            declared = module_type[field]
+            if not isinstance(declared, list) or any(not isinstance(x, str) or not x for x in declared):
+                # Malformed or bare key: leave the relation unmanaged rather than clear it.
+                continue
+            wanted = sorted(set(declared))
+            current = sorted({name for name in (getattr(item, "name", None) for item in related) if name})
+            if _relation_identities_differ(
+                self.device_types.module_bay_types,
+                self.device_types._manufacturer_slug(module_type.get("manufacturer")),
+                declared,
+                related,
+                names_differ=wanted != current,
+            ):
+                changes.append((field, current, wanted))
+        return changes
+
+    def _resolve_type_relations(self, payload):
+        """Return *payload* with its own relation fields resolved from names to ids.
+
+        Raises ModuleBayTypeError if a name does not resolve, so the caller can report the
+        module type rather than write it with the restriction silently dropped.
+        """
+        names = {field: payload[field] for field in MODULE_TYPE_RELATIONS if field in payload}
+        if not names:
+            return payload
+        if not self.module_bay_types:
+            # The server predates ModuleBayType; sending the field would be rejected.
+            return {k: v for k, v in payload.items() if k not in names}
+        manufacturer = self.device_types._manufacturer_slug(payload.get("manufacturer"))
+        resolved = {
+            field: self.device_types.module_bay_types.ids_for(manufacturer, value) for field, value in names.items()
+        }
+        return {**payload, **resolved}
+
     def _try_update_module_type(self, curr_mt, module_type_res, src_file):
         """Apply pending field updates to an existing module type in NetBox.
 
@@ -1590,6 +1693,18 @@ class NetBox:
                 continue
             if not values_equal(curr_mt[field], current_value):
                 updates[field] = curr_mt[field]
+        if self.module_bay_types:
+            from core.module_bay_types import ModuleBayTypeError
+
+            for field, _current, wanted in self._type_relation_changes(curr_mt, module_type_res):
+                try:
+                    updates[field] = self.device_types.module_bay_types.ids_for(
+                        self.device_types._manufacturer_slug(curr_mt.get("manufacturer")), wanted
+                    )
+                except ModuleBayTypeError as exc:
+                    # Not fatal to the run, but not a success either; the caller records it.
+                    self.handle.log(f"Skipped {field} on {curr_mt.get('model')}: {exc} (Context: {src_file})")
+                    return False, False
         if not updates:
             return True, False
         try:
@@ -1622,7 +1737,12 @@ class NetBox:
                 yaml_key = component.yaml_key
                 if yaml_key in curr_mt:
                     self.device_types.create_components(
-                        yaml_key, curr_mt[yaml_key], module_type_id, parent_type="module", context=src_file
+                        yaml_key,
+                        curr_mt[yaml_key],
+                        module_type_id,
+                        parent_type="module",
+                        context=src_file,
+                        manufacturer=curr_mt.get("manufacturer"),
                     )
         if component_errors:
             # The module type exists but not all of its components do.
@@ -1776,7 +1896,20 @@ class NetBox:
                     )
         else:
             try:
-                module_type_res = _retry_on_connection_error(self.netbox.dcim.module_types.create, curr_mt)
+                from core.module_bay_types import ModuleBayTypeError
+
+                try:
+                    payload = self._resolve_type_relations(curr_mt)
+                except ModuleBayTypeError as exc:
+                    self.handle.log(f"Error creating Module Type: {exc} (Context: {src_file})")
+                    self._record_failure(
+                        EntityKind.MODULE_TYPE,
+                        self._yaml_identity(curr_mt),
+                        str(exc),
+                        src_file,
+                    )
+                    return False
+                module_type_res = _retry_on_connection_error(self.netbox.dcim.module_types.create, payload)
                 self.counter["module_added"] += 1
                 is_new = True
                 manufacturer_slug = curr_mt["manufacturer"]["slug"]
@@ -2192,6 +2325,7 @@ class DeviceTypes:
         graphql,
         repo_path,
         m2m_front_ports=False,
+        module_bay_types_supported=False,
         max_threads=8,
     ):
         """Initialize empty DeviceTypes cache structures; no data is fetched at construction time.
@@ -2206,6 +2340,7 @@ class DeviceTypes:
             ignore_ssl (bool): Whether SSL certificate verification is disabled.
             new_filters (bool): Whether to use updated filter parameter names (NetBox >= 4.1).
             graphql (NetBoxGraphQLClient): GraphQL client for read queries.
+            module_bay_types_supported (bool): True when NetBox supports ModuleBayType (>= 4.7).
             repo_path (str): Local library checkout, used to read the module-type schema.
             m2m_front_ports (bool): Whether NetBox uses the 4.5+ M2M port mapping model.
             max_threads (int): Maximum number of concurrent threads for component preloading.
@@ -2218,6 +2353,7 @@ class DeviceTypes:
         self.graphql = graphql
         self.repo_path = repo_path
         self.m2m_front_ports = m2m_front_ports
+        self.module_bay_types_supported = module_bay_types_supported
         self.max_threads = max_threads
         self.components = ComponentCache(
             netbox,
@@ -2228,6 +2364,7 @@ class DeviceTypes:
             wrap_record=_FrontPortRecordWithMappings,
         )
         self._image_progress = None
+        self._module_bay_types = None
         # Component failures for the entity currently inside collect_component_errors().
         self._component_errors: list[str] = []
         self.existing_device_types = {}
@@ -2486,6 +2623,7 @@ class DeviceTypes:
             if change.component_name in existing:
                 comp = existing[change.component_name]
                 update_data = {"id": comp.id}
+                unresolved = False
                 for pc in change.property_changes:
                     if comp_type == "front-ports" and pc.property_name == "_mappings":
                         yaml_front_port = next(
@@ -2501,8 +2639,21 @@ class DeviceTypes:
                             parent_type,
                         )
                         continue
+                    if pc.property_name in component.relations:
+                        # The comparison works in names; NetBox wants ids.
+                        from core.module_bay_types import ModuleBayTypeError
+
+                        try:
+                            update_data[pc.property_name] = self.module_bay_types.ids_for(
+                                self._manufacturer_slug(yaml_data.get("manufacturer")), pc.new_value
+                            )
+                        except ModuleBayTypeError as exc:
+                            self._log_component_error(f"Skipped {component.label} '{change.component_name}': {exc}")
+                            unresolved = True
+                            break
+                        continue
                     update_data[pc.property_name] = pc.new_value
-                if len(update_data) > 1:  # has fields beyond just "id"
+                if not unresolved and len(update_data) > 1:  # has fields beyond just "id"
                     updates.append(update_data)
 
         success_count = 0
@@ -2547,7 +2698,13 @@ class DeviceTypes:
         if not components_to_add:
             return
 
-        self.create_components(comp_type, components_to_add, device_type_id, parent_type=parent_type)
+        self.create_components(
+            comp_type,
+            components_to_add,
+            device_type_id,
+            parent_type=parent_type,
+            manufacturer=yaml_data.get("manufacturer"),
+        )
 
     def update_components(self, yaml_data, device_type_id, component_changes, parent_type="device"):
         """Update existing components and add new components based on detected changes.
@@ -2837,7 +2994,66 @@ class DeviceTypes:
                 f"Connection error bridging interfaces after {_MAX_RETRIES} retries: {e} (Context: {context})"
             )
 
-    def create_components(self, yaml_key, items, parent_id, parent_type="device", context=None):
+    @property
+    def module_bay_types(self):
+        """The module-bay-type catalog, built once per run from the library checkout."""
+        if self._module_bay_types is None:
+            from core.module_bay_types import ModuleBayTypeCatalog
+
+            self._module_bay_types = ModuleBayTypeCatalog(self.netbox, self.repo_path, self.handle)
+        return self._module_bay_types
+
+    @staticmethod
+    def _manufacturer_slug(manufacturer):
+        """Return the manufacturer slug, whatever shape the caller happens to hold.
+
+        ``core.repo`` rewrites every YAML ``manufacturer`` to ``{"slug": ...}`` before the
+        importer sees it, so that is the usual shape; a plain name is slugified here.
+        """
+        from core.module_bay_types import manufacturer_slug
+
+        if isinstance(manufacturer, dict):
+            return manufacturer.get("slug") or manufacturer_slug(manufacturer.get("name"))
+        return manufacturer_slug(getattr(manufacturer, "name", manufacturer))
+
+    def _resolve_relations(self, component, items, manufacturer):
+        """Turn each relation field's names into NetBox ids, dropping items that cannot resolve.
+
+        A component whose restriction cannot be resolved is skipped and logged rather than
+        created without it: creating the bay anyway would silently discard the restriction.
+        """
+        if not component.relations:
+            return items
+        if not self.module_bay_types_supported:
+            # The server predates ModuleBayType; drop the field rather than have it rejected.
+            return [{k: v for k, v in item.items() if k not in component.relations} for item in items]
+        from core.module_bay_types import ModuleBayTypeError
+
+        manufacturer = self._manufacturer_slug(manufacturer)
+        resolved = []
+        for item in items:
+            names = {field: item[field] for field in component.relations if field in item}
+            if not names:
+                resolved.append(item)
+                continue
+            if not manufacturer:
+                # No scope to resolve in, and NetBox wants ids: sending the names would fail.
+                self._log_component_error(
+                    f"Skipped {component.label} '{item.get('name', 'Unknown')}': no manufacturer to "
+                    f"resolve {', '.join(sorted(names))} in"
+                )
+                continue
+            try:
+                replacements = {
+                    field: self.module_bay_types.ids_for(manufacturer, value) for field, value in names.items()
+                }
+            except ModuleBayTypeError as exc:
+                self._log_component_error(f"Skipped {component.label} '{item.get('name', 'Unknown')}': {exc}")
+                continue
+            resolved.append({**item, **replacements})
+        return resolved
+
+    def create_components(self, yaml_key, items, parent_id, parent_type="device", context=None, manufacturer=None):
         """Create component templates of one kind for one parent, skipping those that exist.
 
         The registry row for *yaml_key* supplies the endpoint, the cache name, the log label
@@ -2850,6 +3066,8 @@ class DeviceTypes:
             parent_id (int): NetBox ID of the parent device or module type.
             parent_type (str): ``"device"`` or ``"module"``.
             context (str | None): Optional context string appended to log messages.
+            manufacturer (dict | str | None): Owning manufacturer, used to resolve any
+                relation fields the registry row declares.
         """
         component = BY_YAML_KEY[yaml_key]
         label = component.create_label(parent_type)
@@ -2869,7 +3087,7 @@ class DeviceTypes:
 
         self._create_generic(
             component,
-            items,
+            self._resolve_relations(component, items, manufacturer),
             parent_id,
             parent_type=parent_type,
             post_process=post_process,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,8 +76,14 @@ def mock_git_repo(request):
 
 @pytest.fixture
 def mock_pynetbox():
-    """Mock pynetbox to prevent API calls."""
+    """Mock pynetbox to prevent API calls.
+
+    Defaults the reported version to the oldest supported release, so a test that does not
+    care about version gating still constructs a NetBox; the importer refuses anything
+    older. Individual tests override it to exercise a specific release.
+    """
     with patch("core.netbox_api.pynetbox") as mock_nb:
+        mock_nb.api.return_value.version = "4.3"
         yield mock_nb
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,13 @@
 """Shared test utilities for the NetBox device-type importer test suite."""
 
+import json
+import re
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from unittest.mock import MagicMock
+from urllib.parse import parse_qs, urlparse
+
+import pynetbox
 
 
 def paginate_dispatch(data_dict):
@@ -49,3 +56,195 @@ def recording_handle():
     console = RecordingConsole()
     handle.set_console(console)
     return handle, console
+
+
+class FakeNetBox:
+    """A local HTTP server answering the slice of the NetBox REST API the importer uses.
+
+    Collections are addressed by their URL segment with dashes turned into underscores,
+    so ``module-bay-types`` is ``module_bay_types``.  GET filters, POST creates and PATCH
+    bulk-updates behave the way pynetbox expects, so a real client drives it and the
+    serialising, filtering and paginating under test are the production ones.
+
+    ``/graphql/`` answers every query with an empty list, which is enough to bring a real
+    :class:`~core.netbox_api.NetBox` up; the REST half is where the assertions live.
+
+    A test using this must carry the ``real_http`` marker.  Without it the suite patches
+    ``requests.Session`` and no request ever leaves the client.
+    """
+
+    _IGNORED_FILTERS = ("limit", "offset", "brief", "exclude")
+
+    # GraphQL collections are named "<thing>_list"; the client asks for one per query.
+    _LIST_KEY = re.compile(r"\b(\w+_list)\b")
+
+    def __init__(self, errors=None, netbox_version="4.7.0", **collections):
+        """Start the server with *collections* seeded, keyed by collection name.
+
+        *errors* maps a collection name to an HTTP status the server answers it with, so a
+        test can drive a rejection the importer has to survive.  *netbox_version* is what
+        ``/api/status/`` reports, which is how the export side decides what it may select.
+        """
+        self.collections = {name: [dict(r) for r in records] for name, records in collections.items()}
+        self.errors = dict(errors or {})
+        self.netbox_version = netbox_version
+        self.requests = []
+        self._server = HTTPServer(("127.0.0.1", 0), self._handler())
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    @property
+    def url(self):
+        """Return the base URL a client should talk to."""
+        return f"http://127.0.0.1:{self._server.server_port}"
+
+    def api(self, token="test-token"):
+        """Return a real pynetbox client pointed at this server."""
+        return pynetbox.api(self.url, token=token)
+
+    def close(self):
+        """Stop serving and release the listening socket."""
+        self._server.shutdown()
+        self._server.server_close()
+
+    def collection(self, name):
+        """Return the stored records for a collection, creating it empty when unseen."""
+        return self.collections.setdefault(name, [])
+
+    def sent(self, verb, name):
+        """Return the payload of each *verb* request made to collection *name*.
+
+        A bulk create or update sends a list; its entries are returned individually, so a
+        caller asserting on what was written does not have to care which shape was used.
+        """
+        out = []
+        for method, collection, payload in self.requests:
+            if method != verb or collection != name:
+                continue
+            out.extend(payload) if isinstance(payload, list) else out.append(payload)
+        return out
+
+    def matches(self, name, query):
+        """Filter a collection the way the NetBox REST API filters it."""
+        out = []
+        for record in self.collection(name):
+            ok = True
+            for key, values in query.items():
+                if key in self._IGNORED_FILTERS:
+                    continue
+                field = key[:-3] if key.endswith("_id") else key
+                actual = record.get(field)
+                if isinstance(actual, dict):
+                    actual = actual.get("id")
+                if str(actual) not in values:
+                    ok = False
+                    break
+            if ok:
+                out.append(record)
+        return out
+
+    def _create(self, name, payload):
+        """Store the new record(s) and echo them back the way NetBox does.
+
+        A list payload is a bulk create, which is how the importer adds components, and it
+        answers with a list.
+        """
+        if isinstance(payload, list):
+            return [self._create_one(name, item) for item in payload]
+        return self._create_one(name, payload)
+
+    def _create_one(self, name, payload):
+        """Store one new record and return it as NetBox would echo it back."""
+        collection = self.collection(name)
+        record = {"id": 1000 + len(collection), **payload}
+        # NetBox echoes a foreign key back as a nested object, not the id it was given.
+        if isinstance(record.get("manufacturer"), int):
+            owner = next((m for m in self.collection("manufacturers") if m["id"] == record["manufacturer"]), {})
+            record["manufacturer"] = {"id": record["manufacturer"], "name": owner.get("name")}
+        collection.append(record)
+        return record
+
+    def _patch(self, name, payload):
+        """Merge a bulk update into the stored records and return the updated ones."""
+        updated = []
+        for entry in payload if isinstance(payload, list) else [payload]:
+            record = next((r for r in self.collection(name) if r["id"] == entry.get("id")), None)
+            if record is None:
+                continue
+            record.update(entry)
+            updated.append(record)
+        return updated
+
+    def _handler(self):
+        """Build the request handler class bound to this server's state."""
+        state = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def _collection_name(self):
+                return urlparse(self.path).path.rstrip("/").rsplit("/", 1)[-1].replace("-", "_")
+
+            def _body(self):
+                return json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0))) or b"{}")
+
+            def _reply(self, status, payload):
+                body = json.dumps(payload).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _refused(self, name):
+                """Answer with the configured status for *name*, if the test set one."""
+                status = state.errors.get(name)
+                if status is None:
+                    return False
+                self._reply(status, {"detail": f"{name} refused with {status}"})
+                return True
+
+            def do_GET(self):
+                parsed = urlparse(self.path)
+                name = self._collection_name()
+                state.requests.append(("GET", name, parsed.query))
+                if name == "status":
+                    self._reply(200, {"netbox-version": state.netbox_version})
+                    return
+                if self._refused(name):
+                    return
+                results = state.matches(name, parse_qs(parsed.query))
+                self._reply(200, {"count": len(results), "next": None, "previous": None, "results": results})
+
+            def do_POST(self):
+                name = self._collection_name()
+                payload = self._body()
+                if name == "graphql":
+                    state.requests.append(("POST", name, payload))
+                    key = state._LIST_KEY.search(payload.get("query", ""))
+                    self._reply(200, {"data": {key.group(1) if key else "unknown_list": []}})
+                    return
+                state.requests.append(("POST", name, payload))
+                if self._refused(name):
+                    return
+                self._reply(201, state._create(name, payload))
+
+            def do_PATCH(self):
+                name = self._collection_name()
+                payload = self._body()
+                state.requests.append(("PATCH", name, payload))
+                if self._refused(name):
+                    return
+                self._reply(200, state._patch(name, payload))
+
+            def log_message(self, *args):
+                """Silence the default stderr access log."""
+
+        return Handler
+
+
+def write_module_bay_type(root, manufacturer, slug, name, description=None):
+    """Write one module-bay-type catalog file where the devicetype-library puts it."""
+    directory = root / "module-bay-types" / manufacturer
+    directory.mkdir(parents=True, exist_ok=True)
+    body = f"name: {name}\nslug: {slug}\nmanufacturer: {manufacturer}\n"
+    if description:
+        body += f"description: {description}\n"
+    (directory / f"{slug}.yaml").write_text(body, encoding="utf-8")

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -131,7 +131,14 @@ class TestDerivedGraphQLTables:
                 _FRONT_PORT_MAPPINGS,
             ],
             "device_bay_templates": ["id", "name", "label", "description"],
-            "module_bay_templates": ["id", "name", "position", "label", "description"],
+            "module_bay_templates": [
+                "id",
+                "name",
+                "position",
+                "label",
+                "description",
+                "module_bay_types { id name slug manufacturer { slug } }",
+            ],
         }
 
     def test_only_the_front_port_query_selects_a_nested_block(self):
@@ -146,13 +153,17 @@ class TestDerivedComparisonAndExport:
     @pytest.mark.parametrize("component", COMPONENT_TYPES, ids=lambda c: c.yaml_key)
     def test_every_compared_property_is_fetched(self, component):
         """A property compared but never queried reads as missing and is skipped in silence."""
-        queried = set(component.graphql_fields) | {"_mappings"}
+        # A relation is selected as a nested block, so take the field name each selection
+        # opens with.  Adding component.relations here instead would make the assertion
+        # hold even if the query stopped selecting them.
+        queried = {selection.split(None, 1)[0] for selection in component.graphql_fields} | {"_mappings"}
         assert set(component.compare_properties) <= queried
 
     @pytest.mark.parametrize("component", COMPONENT_TYPES, ids=lambda c: c.yaml_key)
     def test_the_export_writes_every_scalar_the_query_reads(self, component):
         """Export fields are the query's scalars: an unexported scalar drops out of a round trip."""
-        scalars = [name for name in component.graphql_fields if name != "id" and name not in component.graphql_extra]
+        non_scalar = set(component.graphql_extra) | set(component.graphql_relation_fields)
+        scalars = [name for name in component.graphql_fields if name != "id" and name not in non_scalar]
         assert list(component.fields) == scalars
 
     def test_front_ports_compare_the_mapping_the_query_selects(self):

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -239,6 +239,26 @@ class TestYamlEqual:
 class TestRepoSupersedes:
     """Tests for _repo_supersedes / _is_subset (asymmetric containment)."""
 
+    def test_an_empty_relation_does_not_make_every_definition_differ(self):
+        """The serializer omits an empty relation, and this is why it has to.
+
+        _is_subset requires every NetBox leaf to be present in the repo YAML, and
+        _normalize_for_compare does not drop empty lists. A serialized
+        "module_bay_types: []" would therefore be absent from every library definition
+        and re-export the whole library on a NetBox 4.7 server.
+        """
+        from core.nb_serializer import _serialize_relations
+
+        bay = type("Bay", (), {"name": "FPC 0", "module_bay_types": []})()
+        assert _serialize_relations(bay, ("module_bay_types",)) == {}
+
+        repo = {"model": "MX304", "module-bays": [{"name": "FPC 0"}]}
+        as_serialized = {"model": "MX304", "module-bays": [{"name": "FPC 0"}]}
+        with_empty_key = {"model": "MX304", "module-bays": [{"name": "FPC 0", "module_bay_types": []}]}
+
+        assert _repo_supersedes(repo, as_serialized), "an unchanged definition must not re-export"
+        assert not _repo_supersedes(repo, with_empty_key), "which is exactly what the empty key would do"
+
     def test_equal_dicts(self):
         repo = {"manufacturer": "Nokia", "model": "X", "u_height": 1}
         nb = {"manufacturer": "Nokia", "model": "X", "u_height": 1}
@@ -853,11 +873,17 @@ class TestExporterAdditionalCoverage:
         def _side_effect(endpoint_name, manufacturer_slug=None):
             return [dt_rec, mt_rec] if endpoint_name == "interface_templates" else []
 
+        # A worker must fetch through its own clone, so only the clone answers.
+        worker = MagicMock()
+        worker.get_component_templates.side_effect = _side_effect
         mock_client = MagicMock()
-        mock_client.get_component_templates.side_effect = _side_effect
-        with patch("core.export.NetBoxGraphQLClient", return_value=mock_client):
-            dt_result, mt_result = exporter._fetch_vendor_components("nokia")
+        mock_client.get_component_templates.side_effect = AssertionError("worker must use clone()")
+        mock_client.clone.return_value = worker
+        exporter.graphql = mock_client
 
+        dt_result, mt_result = exporter._fetch_vendor_components("nokia")
+
+        assert mock_client.clone.called
         assert dt_result[11]["interface_templates"] == [dt_rec]
         assert mt_result[22]["interface_templates"] == [mt_rec]
 

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -118,22 +118,115 @@ class TestNetBoxGraphQLClient:
             client.handle = LogHandler(True)
 
     def test_clone_uses_an_independent_session_with_the_same_settings(self):
+        """Every stored setting is compared, so a new one cannot be dropped unnoticed.
+
+        clone() re-lists constructor arguments by hand. Listing the settings here by hand
+        too let supports_module_bay_types default back to False in every cloned worker.
+        """
         handle = MagicMock()
         sessions = [MagicMock(), MagicMock()]
 
         with patch("core.graphql_client.requests.Session", side_effect=sessions):
-            client = NetBoxGraphQLClient("http://netbox.local", "token", True, handle, 250)
+            client = NetBoxGraphQLClient(
+                "http://netbox.local", "token", True, handle, 250, supports_module_bay_types=True
+            )
             clone = client.clone()
 
         assert clone is not client
         assert clone._session is sessions[1]
-        assert (clone.url, clone.token, clone.ignore_ssl, clone.handle, clone.DEFAULT_PAGE_SIZE) == (
-            client.url,
-            client.token,
-            client.ignore_ssl,
-            client.handle,
-            client.DEFAULT_PAGE_SIZE,
-        )
+        settings = lambda c: {k: v for k, v in vars(c).items() if k != "_session"}  # noqa: E731
+        assert settings(clone) == settings(client)
+
+    @pytest.mark.real_http
+    def test_the_cloned_session_is_configured_not_merely_new(self):
+        """A bare requests.Session() would be independent and completely unauthenticated.
+
+        Marked real_http only to get real Session objects; nothing here sends a request.
+        """
+        client = NetBoxGraphQLClient("http://netbox.local", "nbt_key.secret", ignore_ssl=True)
+
+        clone = client.clone()
+
+        assert clone._session is not client._session
+        assert clone._session.headers["Authorization"] == "Bearer nbt_key.secret"
+        assert clone._session.headers["Content-Type"] == "application/json"
+        assert clone._session.verify is False
+
+    @pytest.mark.real_http
+    def test_a_v1_token_clone_keeps_the_legacy_auth_scheme(self):
+        client = NetBoxGraphQLClient("http://netbox.local", "0123456789abcdef")
+
+        assert client.clone()._session.headers["Authorization"] == "Token 0123456789abcdef"
+
+    @pytest.mark.real_http
+    def test_an_unreachable_server_fails_the_probe_as_a_graphql_error(self):
+        """It is the export's first request, so a raw transport error escapes as a traceback."""
+        from core.graphql_client import GraphQLError
+        from helpers import FakeNetBox
+
+        server = FakeNetBox()
+        url = server.url
+        server.close()  # nothing is listening on that port any more
+
+        with pytest.raises(GraphQLError):
+            NetBoxGraphQLClient(url, "tok").detect_module_bay_type_support()
+
+    @pytest.mark.real_http
+    def test_a_non_json_status_body_fails_the_probe_as_a_graphql_error(self):
+        """A proxy error page answers 200 with HTML; json() then raises ValueError."""
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        from core.graphql_client import GraphQLError
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                body = b"<html>gateway</html>"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, *args):
+                """Silence the default stderr access log."""
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            client = NetBoxGraphQLClient(f"http://127.0.0.1:{server.server_port}", "tok")
+            with pytest.raises(GraphQLError):
+                client.detect_module_bay_type_support()
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    @pytest.mark.real_http
+    def test_the_version_probe_decides_whether_the_relation_may_be_selected(self):
+        """Export has no pynetbox client, so it asks NetBox here and both sides use compat."""
+        from helpers import FakeNetBox
+
+        for version, expected in (("4.7.0", True), ("4.7.0-beta2", True), ("4.6.9", False), ("4.3.7", False)):
+            server = FakeNetBox(netbox_version=version)
+            try:
+                client = NetBoxGraphQLClient(server.url, "tok")
+                assert client.detect_module_bay_type_support() is expected, version
+                assert client.supports_module_bay_types is expected
+            finally:
+                server.close()
+
+    def test_clone_carries_a_setting_it_does_not_name(self):
+        """clone() must not enumerate settings: the one it forgets is the one that breaks.
+
+        supports_module_bay_types was lost exactly that way, and adding it to the argument
+        list only fixes the setting that was already missed.
+        """
+        with patch("core.graphql_client.requests.Session"):
+            client = NetBoxGraphQLClient("http://netbox.local", "token")
+            client.added_after_this_test_was_written = "carried"
+            clone = client.clone()
+
+        assert clone.added_after_this_test_was_written == "carried"
 
     def test_init_stores_config(self):
         from core.graphql_client import NetBoxGraphQLClient
@@ -1024,6 +1117,40 @@ class TestGetComponentTemplates:
         from core.graphql_client import NetBoxGraphQLClient
 
         return NetBoxGraphQLClient("http://netbox.local", "tok")
+
+    def test_a_clone_still_selects_the_module_bay_type_relation(self, mock_post):
+        """The prefetch runs on clones, not on the client it was cloned from.
+
+        A clone that drops the relation reads every bay without it, and the comparison
+        then skips a field it never received.
+        """
+        from core.graphql_client import NetBoxGraphQLClient
+
+        client = NetBoxGraphQLClient("http://netbox.local", "tok", supports_module_bay_types=True)
+        mock_post.side_effect = _make_paged_responses({"module_bay_template_list": []}, "module_bay_template_list")
+
+        client.clone().get_component_templates("module_bay_templates")
+
+        queries = [call.kwargs["json"]["query"] for call in mock_post.call_args_list]
+        assert queries and all("module_bay_types" in q for q in queries)
+
+    def test_the_module_type_query_selects_the_relation_only_when_supported(self, mock_post):
+        """The selection has to track the server, in both directions.
+
+        An unselected field reads as missing and is skipped by the comparison, and
+        selecting it on a server below 4.7 fails the whole query.
+        """
+        from core.graphql_client import NetBoxGraphQLClient
+
+        def _query_for(supported):
+            client = NetBoxGraphQLClient("http://netbox.local", "tok", supports_module_bay_types=supported)
+            mock_post.reset_mock()
+            mock_post.side_effect = _make_paged_responses({"module_type_list": []}, "module_type_list")
+            client.get_module_types()
+            return mock_post.call_args_list[0].kwargs["json"]["query"]
+
+        assert "module_bay_types" in _query_for(True)
+        assert "module_bay_types" not in _query_for(False)
 
     def test_returns_dotdict_records_with_parent_info(self, mock_post):
         """Records should be DotDicts with device_type/module_type and correct id types."""

--- a/tests/test_module_bay_type_sync.py
+++ b/tests/test_module_bay_type_sync.py
@@ -1,0 +1,577 @@
+"""Tests for keeping module bay type assignments in sync with NetBox.
+
+Resolving a reference name to an id is :mod:`core.module_bay_types` and is tested there.
+This file covers the wiring around it: the relation a module type carries itself, the
+component update path, and the gate that keeps the field off a server that predates it.
+
+Both sides are real.  The catalog is written to disk and read by a real
+``ModuleBayTypeCatalog``; a local HTTP server answers a real ``pynetbox`` client and the
+real GraphQL client, so the payloads asserted on here are the ones that would go over the
+wire.  Only the version handshake is stood in for, to fix the server release under test.
+"""
+
+import pynetbox
+import pytest
+
+from core.change_detector import ChangeType, ComponentChange, PropertyChange
+from core.component_registry import BY_YAML_KEY
+from core.graphql_client import NetBoxGraphQLClient
+from core.module_bay_types import ModuleBayTypeCatalog
+from core.netbox_api import DeviceTypes, NetBox
+from core.outcomes import EntityKind, Outcome
+from helpers import FakeNetBox, recording_handle, write_module_bay_type
+
+# The suite patches requests.Session by default, which would stop every request below.
+pytestmark = pytest.mark.real_http
+
+JUNIPER = {"id": 1, "name": "Juniper", "slug": "juniper"}
+
+
+def stub(**attrs):
+    """Return an object carrying exactly *attrs*, the way NetBox nests a related object."""
+    return type("Stub", (), attrs)()
+
+
+def created_id(server, slug):
+    """Return the id the server gave the module bay type it created for *slug*."""
+    return next(record["id"] for record in server.collection("module_bay_types") if record["slug"] == slug)
+
+
+def related(name, slug=None, manufacturer_slug=None):
+    """Return a module bay type as NetBox returns it nested inside a relation."""
+    return stub(name=name, slug=slug, manufacturer=stub(slug=manufacturer_slug))
+
+
+class NetBoxRecord:
+    """An existing NetBox object as the importer holds it: an id, plus what was fetched.
+
+    A field the query did not ask for is genuinely absent, which is the difference the
+    comparison turns on, so this carries only what a test hands it.
+    """
+
+    def __init__(self, record_id, **fields):
+        """Store the id and the fields this record is meant to have."""
+        self.id = record_id
+        for name, value in fields.items():
+            setattr(self, name, value)
+
+
+@pytest.fixture
+def catalog_root(tmp_path):
+    """Write the catalog these tests resolve against and return its root."""
+    root = tmp_path / "library"
+    write_module_bay_type(root, "Juniper", "mx304-re", "MX304-RE", "Juniper MX304 routing-engine slot")
+    write_module_bay_type(root, "Juniper", "mx304-lmic", "MX304-LMIC", "Juniper MX304 LMIC slot")
+    return root
+
+
+@pytest.fixture
+def server():
+    """Run a local NetBox-shaped server seeded with the manufacturers the catalog needs."""
+    fake = FakeNetBox(manufacturers=[JUNIPER])
+    yield fake
+    fake.close()
+
+
+@pytest.fixture
+def make_device_types(server, catalog_root):
+    """Build a real DeviceTypes talking to the local server, with its cache already primed."""
+
+    def _make(module_bay_types_supported=True):
+        handle, console = recording_handle()
+        device_types = DeviceTypes(
+            server.api(),
+            handle,
+            {},
+            False,
+            True,
+            graphql=NetBoxGraphQLClient(server.url, "test-token", supports_module_bay_types=True),
+            repo_path=str(catalog_root),
+            module_bay_types_supported=module_bay_types_supported,
+        )
+        device_types.components.ensure_ready()
+        return device_types, console
+
+    return _make
+
+
+@pytest.fixture
+def netbox(make_config, mock_pynetbox, server, catalog_root):
+    """Build a real NetBox against the local server, reporting the release that has the feature."""
+    mock_pynetbox.api.return_value.version = "4.7"
+    mock_pynetbox.RequestError = pynetbox.RequestError
+    handle, console = recording_handle()
+    config = make_config(netbox_url=server.url, repo_path=str(catalog_root))
+    nb = NetBox(config, handle)
+    assert nb.module_bay_types, "a 4.7 server supports module bay types; the rest of this file assumes it"
+
+    # connect_api ran against the patched pynetbox; every call under test uses a real client.
+    api = server.api()
+    nb.netbox = api
+    nb.device_types.netbox = api
+    nb.device_types.components.netbox = api
+    nb.device_types.components.ensure_ready()
+    return nb, console
+
+
+class TestModuleTypeOwnRelation:
+    """A module type says which classes it belongs to, and that has to stay in sync."""
+
+    def test_a_missing_class_is_reported_as_a_change(self, netbox):
+        nb, _ = netbox
+        existing = NetBoxRecord(7, module_bay_types=[])
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        assert nb._type_relation_changes(module_type, existing) == [("module_bay_types", [], ["MX304-RE"])]
+
+    def test_the_right_class_is_left_alone(self, netbox):
+        nb, _ = netbox
+        existing = NetBoxRecord(7, module_bay_types=[related("MX304-RE", "mx304-re", "juniper")])
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        assert nb._type_relation_changes(module_type, existing) == []
+
+    def test_the_same_name_from_the_wrong_scope_is_corrected(self, netbox):
+        """Juniper owns MX304-RE. A Generic object of that name is not the one referenced."""
+        nb, _ = netbox
+        existing = NetBoxRecord(7, module_bay_types=[related("MX304-RE", "mx304-re", "generic")])
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        assert nb._type_relation_changes(module_type, existing) == [("module_bay_types", ["MX304-RE"], ["MX304-RE"])]
+
+    def test_names_are_compared_when_netbox_returned_no_identity(self, netbox):
+        """A record carrying only a name cannot answer the scope question; names still can."""
+        nb, _ = netbox
+        existing = NetBoxRecord(7, module_bay_types=[related("MX304-LMIC")])
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        assert nb._type_relation_changes(module_type, existing) == [("module_bay_types", ["MX304-LMIC"], ["MX304-RE"])]
+
+    def test_an_unresolvable_reference_is_reported_even_when_the_name_matches(self, netbox):
+        """A name that happens to match must not make an unresolvable reference look applied.
+
+        Comparison cannot say which object the name means, so the write path has to try,
+        fail, and refuse. Reporting no change here skips that entirely.
+        """
+        nb, _ = netbox
+        existing = NetBoxRecord(7, module_bay_types=[related("NO-SUCH-CLASS", "no-such", "juniper")])
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["NO-SUCH-CLASS"]}
+
+        assert nb._type_relation_changes(module_type, existing) == [
+            ("module_bay_types", ["NO-SUCH-CLASS"], ["NO-SUCH-CLASS"])
+        ]
+
+    def test_a_matching_but_unresolvable_name_does_not_read_as_updated(self, netbox, server):
+        """The end of that path: the module type is refused, not patched with its scalars."""
+        nb, _ = netbox
+        server.collection("module_types").append({"id": 7, "model": "JNP304-RE"})
+        existing = NetBoxRecord(
+            7,
+            model="JNP304-RE",
+            manufacturer=stub(name="Juniper"),
+            module_bay_types=[related("NO-SUCH-CLASS", "no-such", "juniper")],
+            description="old",
+        )
+        module_type = {
+            "model": "JNP304-RE",
+            "manufacturer": {"slug": "juniper"},
+            "description": "new",
+            "module_bay_types": ["NO-SUCH-CLASS"],
+        }
+
+        assert nb._try_update_module_type(module_type, existing, "juniper/jnp304-re.yaml") == (False, False)
+        assert not server.sent("PATCH", "module_types")
+
+    def test_a_field_the_query_did_not_return_is_skipped(self, netbox):
+        """Reading an absent field as empty would report a change on every run."""
+        nb, _ = netbox
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        assert nb._type_relation_changes(module_type, NetBoxRecord(7)) == []
+
+    def test_an_omitted_key_leaves_the_relation_unmanaged(self, netbox):
+        nb, _ = netbox
+        existing = NetBoxRecord(7, module_bay_types=[related("MX304-RE", "mx304-re", "juniper")])
+
+        assert nb._type_relation_changes({"model": "JNP304-RE"}, existing) == []
+
+    def test_a_malformed_reference_leaves_the_relation_unmanaged(self, netbox):
+        """A bare key parses as None; clearing on it would drop a restriction nobody removed."""
+        nb, _ = netbox
+        existing = NetBoxRecord(7, module_bay_types=[related("MX304-RE", "mx304-re", "juniper")])
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": None}
+
+        assert nb._type_relation_changes(module_type, existing) == []
+
+    def test_names_are_compared_when_the_definition_names_no_manufacturer(self, netbox):
+        """Without an owning manufacturer there is no scope, so the name comparison stands."""
+        nb, _ = netbox
+        existing = NetBoxRecord(7, module_bay_types=[related("MX304-LMIC", "mx304-lmic", "juniper")])
+        module_type = {"model": "JNP304-RE", "module_bay_types": ["MX304-RE"]}
+
+        assert nb._type_relation_changes(module_type, existing) == [("module_bay_types", ["MX304-LMIC"], ["MX304-RE"])]
+
+    def test_an_older_server_reports_no_relation_changes(self, netbox):
+        """Below 4.7 the relation does not exist, so there is nothing to compare."""
+        nb, _ = netbox
+        nb.module_bay_types = False
+        existing = NetBoxRecord(7, module_bay_types=[])
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        assert nb._type_relation_changes(module_type, existing) == []
+
+
+class TestModuleTypeCreatePayload:
+    """What the create path sends for a module type's own relation."""
+
+    def test_names_are_replaced_by_ids(self, netbox, server):
+        nb, _ = netbox
+        payload = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        resolved = nb._resolve_type_relations(payload)
+
+        created = server.sent("POST", "module_bay_types")
+        assert [p["slug"] for p in created] == ["mx304-re"]
+        assert resolved["module_bay_types"] == [created_id(server, "mx304-re")]
+        assert resolved["model"] == "JNP304-RE"
+
+    def test_a_payload_without_the_relation_is_untouched(self, netbox, server):
+        nb, _ = netbox
+        payload = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}}
+
+        assert nb._resolve_type_relations(payload) == payload
+        assert not server.sent("POST", "module_bay_types")
+
+    def test_an_older_server_never_sees_the_field(self, netbox, server):
+        """Sending a field the server does not have would fail the whole create."""
+        nb, _ = netbox
+        nb.module_bay_types = False
+        payload = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        assert nb._resolve_type_relations(payload) == {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}}
+        assert not server.sent("POST", "module_bay_types")
+
+
+class TestModuleTypeUpdate:
+    """The update path patches the relation, and survives one it cannot resolve."""
+
+    def test_a_changed_relation_is_patched_as_ids(self, netbox, server):
+        nb, _ = netbox
+        server.collection("module_types").append({"id": 7, "model": "JNP304-RE"})
+        existing = NetBoxRecord(7, model="JNP304-RE", manufacturer=stub(name="Juniper"), module_bay_types=[])
+        module_type = {"model": "JNP304-RE", "manufacturer": {"slug": "juniper"}, "module_bay_types": ["MX304-RE"]}
+
+        ok, updated = nb._try_update_module_type(module_type, existing, "juniper/jnp304-re.yaml")
+
+        assert (ok, updated) == (True, True)
+        assert server.sent("PATCH", "module_types") == [{"id": 7, "module_bay_types": [created_id(server, "mx304-re")]}]
+
+    def test_an_unresolvable_reference_is_logged_and_the_run_goes_on(self, netbox, server):
+        """One bad module type must not end the run, and must not be written without it."""
+        nb, console = netbox
+        server.collection("module_types").append({"id": 7, "model": "JNP304-RE"})
+        existing = NetBoxRecord(7, model="JNP304-RE", manufacturer=stub(name="Juniper"), module_bay_types=[])
+        module_type = {
+            "model": "JNP304-RE",
+            "manufacturer": {"slug": "juniper"},
+            "module_bay_types": ["NO-SUCH-CLASS"],
+        }
+
+        ok, updated = nb._try_update_module_type(module_type, existing, "juniper/jnp304-re.yaml")
+
+        assert (ok, updated) == (False, False), "an unapplied relation must not read as success"
+        assert not server.sent("PATCH", "module_types")
+        assert any("NO-SUCH-CLASS" in line for line in console.lines)
+
+    def test_a_scalar_change_is_held_back_when_the_relation_cannot_resolve(self, netbox, server):
+        """Patching the description while dropping the restriction is a half-applied write."""
+        nb, console = netbox
+        server.collection("module_types").append({"id": 7, "model": "JNP304-RE"})
+        existing = NetBoxRecord(
+            7,
+            model="JNP304-RE",
+            manufacturer=stub(name="Juniper"),
+            module_bay_types=[],
+            description="old",
+        )
+        module_type = {
+            "model": "JNP304-RE",
+            "manufacturer": {"slug": "juniper"},
+            "description": "new",
+            "module_bay_types": ["NO-SUCH-CLASS"],
+        }
+
+        ok, updated = nb._try_update_module_type(module_type, existing, "juniper/jnp304-re.yaml")
+
+        assert (ok, updated) == (False, False)
+        assert not server.sent("PATCH", "module_types"), "the scalar PATCH must not go out alone"
+        assert any("NO-SUCH-CLASS" in line for line in console.lines)
+
+
+class TestModuleTypeCreateRefusal:
+    """A module type whose relation cannot be resolved is reported, not written without it."""
+
+    def test_an_unresolvable_reference_skips_the_module_type(self, netbox, server):
+        nb, console = netbox
+        curr_mt = {
+            "model": "JNP304-RE",
+            "manufacturer": {"slug": "juniper"},
+            "module_bay_types": ["NO-SUCH-CLASS"],
+        }
+
+        created = nb._process_single_module_type(curr_mt, "juniper/jnp304-re.yaml", {}, {}, only_new=False)
+
+        assert created is False
+        assert not server.sent("POST", "module_types")
+        assert any("NO-SUCH-CLASS" in line for line in console.lines)
+        # The registry is the only tally of failures; a path that merely logs is absent
+        # from the run summary and from the itemised report.
+        failed = [r for r in nb.outcomes.records if r.outcome is Outcome.FAILED]
+        assert [(r.kind, r.identity) for r in failed] == [(EntityKind.MODULE_TYPE, "juniper/JNP304-RE")]
+        assert "NO-SUCH-CLASS" in failed[0].reason
+
+
+class TestModuleTypeUpdateOutcome:
+    """The run summary must show the module type whose relation could not be applied."""
+
+    def test_an_unresolvable_relation_is_recorded_as_a_failure(self, netbox, server):
+        """Driven through the parent operation, because that is where the outcome is recorded."""
+        nb, console = netbox
+        server.collection("module_types").append({"id": 7, "model": "JNP304-RE"})
+        existing = NetBoxRecord(
+            7, model="JNP304-RE", manufacturer=stub(name="Juniper"), module_bay_types=[], description="old"
+        )
+        curr_mt = {
+            "model": "JNP304-RE",
+            "manufacturer": {"slug": "juniper"},
+            "description": "new",
+            "module_bay_types": ["NO-SUCH-CLASS"],
+        }
+
+        nb._process_single_module_type(
+            curr_mt, "juniper/jnp304-re.yaml", {"juniper": {"JNP304-RE": existing}}, {}, only_new=False
+        )
+
+        failed = [r for r in nb.outcomes.records if r.outcome is Outcome.FAILED]
+        assert [r.kind for r in failed] == [EntityKind.MODULE_TYPE], "the failure must reach the run summary"
+        assert not server.sent("PATCH", "module_types"), "nothing may be written for a type it could not apply"
+        assert any("NO-SUCH-CLASS" in line for line in console.lines)
+
+
+class TestComponentCreatePayload:
+    """A module bay is created with the restriction its definition asked for, or not at all."""
+
+    def test_names_are_replaced_by_ids(self, make_device_types, server):
+        device_types, _ = make_device_types()
+        component = BY_YAML_KEY["module-bays"]
+        items = [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC"]}]
+
+        resolved = device_types._resolve_relations(component, items, {"slug": "juniper"})
+
+        assert resolved == [{"name": "FPC 0", "module_bay_types": [created_id(server, "mx304-lmic")]}]
+
+    def test_an_item_without_the_field_passes_through(self, make_device_types, server):
+        device_types, _ = make_device_types()
+        component = BY_YAML_KEY["module-bays"]
+        items = [{"name": "FPC 0"}]
+
+        assert device_types._resolve_relations(component, items, {"slug": "juniper"}) == items
+        assert not server.sent("POST", "module_bay_types")
+
+    def test_an_unresolvable_restriction_drops_the_bay_rather_than_relaxing_it(self, make_device_types, server):
+        """Creating the bay without its restriction would silently accept any module."""
+        device_types, console = make_device_types()
+        component = BY_YAML_KEY["module-bays"]
+        items = [
+            {"name": "FPC 0", "module_bay_types": ["NO-SUCH-CLASS"]},
+            {"name": "FPC 1", "module_bay_types": ["MX304-LMIC"]},
+        ]
+
+        with device_types.collect_component_errors() as collected:
+            resolved = device_types._resolve_relations(component, items, {"slug": "juniper"})
+
+        assert [item["name"] for item in resolved] == ["FPC 1"]
+        # Collected, not just printed: the parent's outcome reason is built from these.
+        assert [e for e in collected if "FPC 0" in e and "NO-SUCH-CLASS" in e]
+        assert any("FPC 0" in line for line in console.lines)
+
+    def test_an_older_server_never_sees_the_field(self, make_device_types, server):
+        device_types, _ = make_device_types(module_bay_types_supported=False)
+        component = BY_YAML_KEY["module-bays"]
+        items = [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC"]}]
+
+        assert device_types._resolve_relations(component, items, {"slug": "juniper"}) == [{"name": "FPC 0"}]
+        assert not server.sent("POST", "module_bay_types")
+
+    def test_a_netbox_rejection_skips_the_bay_instead_of_ending_the_run(self, make_device_types, server):
+        """A 403 while resolving must not escape the per-component recovery.
+
+        The callers recover from ModuleBayTypeError only, so a raw RequestError ends the
+        run with a traceback and leaves a partly created parent behind.
+        """
+        device_types, _ = make_device_types()
+        server.errors["module_bay_types"] = 403
+        items = [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC"]}]
+
+        with device_types.collect_component_errors() as collected:
+            assert device_types._resolve_relations(BY_YAML_KEY["module-bays"], items, {"slug": "juniper"}) == []
+        assert [e for e in collected if "FPC 0" in e and "403" in e]
+
+    def test_a_lost_connection_skips_the_bay_instead_of_ending_the_run(self, make_device_types, server):
+        """A dropped connection is not a RequestError, so it escaped the same recovery."""
+        device_types, _ = make_device_types()
+        server.close()  # the port stops answering; resolution now hits a refused connection
+        items = [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC"]}]
+
+        with device_types.collect_component_errors() as collected:
+            assert device_types._resolve_relations(BY_YAML_KEY["module-bays"], items, {"slug": "juniper"}) == []
+        assert [e for e in collected if "FPC 0" in e]
+
+    def test_a_component_kind_with_no_relations_is_untouched(self, make_device_types):
+        device_types, _ = make_device_types()
+        items = [{"name": "xe-0/0/0", "type": "100gbase-x-qsfp28"}]
+
+        assert device_types._resolve_relations(BY_YAML_KEY["interfaces"], items, {"slug": "juniper"}) == items
+
+    def test_an_unknown_manufacturer_drops_the_bay_rather_than_sending_names(self, make_device_types):
+        """Without a scope the names cannot become ids, and NetBox rejects raw names."""
+        device_types, console = make_device_types()
+        items = [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC"]}]
+
+        assert device_types._resolve_relations(BY_YAML_KEY["module-bays"], items, None) == []
+        assert any("FPC 0" in line for line in console.lines)
+
+    def test_an_unknown_manufacturer_still_passes_through_a_bay_with_no_restriction(self, make_device_types):
+        device_types, _ = make_device_types()
+        items = [{"name": "FPC 0"}]
+
+        assert device_types._resolve_relations(BY_YAML_KEY["module-bays"], items, None) == items
+
+    def test_an_older_server_strips_the_field_even_without_a_manufacturer(self, make_device_types):
+        """The manufacturer question must not decide whether an unsupported field is sent."""
+        device_types, _ = make_device_types(module_bay_types_supported=False)
+        items = [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC"]}]
+
+        assert device_types._resolve_relations(BY_YAML_KEY["module-bays"], items, None) == [{"name": "FPC 0"}]
+
+
+class TestComponentCreateWiring:
+    """Through create_components(), so the resolution is proved to be wired in, not just present."""
+
+    def test_a_created_bay_carries_resolved_ids(self, make_device_types, server):
+        device_types, _ = make_device_types()
+        device_types.components.record("module_bay_templates", "device", 3, {})
+
+        device_types.create_components(
+            "module-bays",
+            [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC"]}],
+            3,
+            manufacturer={"slug": "juniper"},
+        )
+
+        posted = server.sent("POST", "module_bay_templates")
+        assert [p["name"] for p in posted] == ["FPC 0"]
+        assert posted[0]["module_bay_types"] == [created_id(server, "mx304-lmic")]
+
+    def test_an_older_server_creates_the_bay_without_the_field(self, make_device_types, server):
+        device_types, _ = make_device_types(module_bay_types_supported=False)
+        device_types.components.record("module_bay_templates", "device", 3, {})
+
+        device_types.create_components(
+            "module-bays",
+            [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC"]}],
+            3,
+            manufacturer={"slug": "juniper"},
+        )
+
+        posted = server.sent("POST", "module_bay_templates")
+        assert posted and "module_bay_types" not in posted[0]
+
+    def test_an_unresolvable_bay_is_never_posted(self, make_device_types, server):
+        device_types, _ = make_device_types()
+        device_types.components.record("module_bay_templates", "device", 3, {})
+
+        with device_types.collect_component_errors() as collected:
+            device_types.create_components(
+                "module-bays",
+                [{"name": "FPC 0", "module_bay_types": ["NO-SUCH-CLASS"]}],
+                3,
+                manufacturer={"slug": "juniper"},
+            )
+
+        assert not server.sent("POST", "module_bay_templates")
+        assert [e for e in collected if "FPC 0" in e]
+
+
+class TestComponentUpdatePayload:
+    """An existing bay whose restriction changed is patched with ids, not names."""
+
+    @staticmethod
+    def _change(name, new_value):
+        return ComponentChange(
+            component_type="module-bays",
+            component_name=name,
+            change_type=ChangeType.COMPONENT_CHANGED,
+            property_changes=[PropertyChange(property_name="module_bay_types", old_value=[], new_value=new_value)],
+        )
+
+    def test_a_changed_restriction_is_patched_as_ids(self, make_device_types, server):
+        device_types, _ = make_device_types()
+        server.collection("module_bay_templates").append({"id": 55, "name": "FPC 0"})
+        device_types.components.record("module_bay_templates", "device", 3, {"FPC 0": NetBoxRecord(55)})
+
+        device_types._apply_updates_for_type(
+            "module-bays", [self._change("FPC 0", ["MX304-LMIC"])], {"manufacturer": {"slug": "juniper"}}, 3, "device"
+        )
+
+        assert server.sent("PATCH", "module_bay_templates") == [
+            {"id": 55, "module_bay_types": [created_id(server, "mx304-lmic")]}
+        ]
+
+    def test_a_rejected_patch_is_collected_rather_than_raised(self, make_device_types, server):
+        """The bay resolves; NetBox refuses the write. That must land in the entity's report."""
+        device_types, _ = make_device_types()
+        server.collection("module_bay_templates").append({"id": 55, "name": "FPC 0"})
+        device_types.components.record("module_bay_templates", "device", 3, {"FPC 0": NetBoxRecord(55)})
+        server.errors["module_bay_templates"] = 400
+
+        with device_types.collect_component_errors() as collected:
+            device_types._apply_updates_for_type(
+                "module-bays",
+                [self._change("FPC 0", ["MX304-LMIC"])],
+                {"manufacturer": {"slug": "juniper"}},
+                3,
+                "device",
+            )
+
+        assert [e for e in collected if "55" in e]
+
+    def test_an_unresolvable_restriction_is_logged_and_nothing_is_patched(self, make_device_types, server):
+        device_types, _ = make_device_types()
+        server.collection("module_bay_templates").append({"id": 55, "name": "FPC 0"})
+        device_types.components.record("module_bay_templates", "device", 3, {"FPC 0": NetBoxRecord(55)})
+
+        with device_types.collect_component_errors() as collected:
+            device_types._apply_updates_for_type(
+                "module-bays",
+                [self._change("FPC 0", ["NO-SUCH-CLASS"])],
+                {"manufacturer": {"slug": "juniper"}},
+                3,
+                "device",
+            )
+
+        assert not server.sent("PATCH", "module_bay_templates")
+        assert [e for e in collected if "FPC 0" in e and "NO-SUCH-CLASS" in e]
+
+
+class TestCatalogWiring:
+    """The catalog is built once per run, from the library checkout the run is using."""
+
+    def test_the_catalog_is_built_from_the_repo_path_and_reused(self, make_device_types, catalog_root):
+        device_types, _ = make_device_types()
+
+        catalog = device_types.module_bay_types
+
+        assert isinstance(catalog, ModuleBayTypeCatalog)
+        assert device_types.module_bay_types is catalog
+        assert catalog.identities_for("juniper", ["MX304-RE"]) == frozenset({("juniper", "mx304-re")})

--- a/tests/test_module_bay_types.py
+++ b/tests/test_module_bay_types.py
@@ -1,0 +1,250 @@
+"""Tests for module bay type reference resolution.
+
+Driven through the public interface (``ids_for`` / ``identities_for``) against catalog files
+the tests write themselves and a real ``pynetbox`` client talking HTTP to a local server.
+Nothing here is mocked: the client serialises, filters and paginates for real, which is
+where the semantics that matter actually live.
+"""
+
+import pytest
+
+from core.module_bay_types import ModuleBayTypeCatalog, ModuleBayTypeError
+from helpers import FakeNetBox, write_module_bay_type
+
+
+class Handle:
+    """Capture what the catalog logs."""
+
+    def __init__(self):
+        """Start with no recorded lines."""
+        self.lines = []
+
+    def log(self, message):
+        """Record one line."""
+        self.lines.append(message)
+
+    def verbose_log(self, message):
+        """Record one verbose line."""
+        self.lines.append(message)
+
+
+DEFAULT_MANUFACTURERS = (
+    {"id": 1, "name": "Juniper", "slug": "juniper"},
+    {"id": 2, "name": "Cisco", "slug": "cisco"},
+    {"id": 3, "name": "Nokia", "slug": "nokia"},
+)
+
+
+@pytest.fixture
+def library(tmp_path):
+    """Write the catalog the resolution tests resolve against, and return its root.
+
+    QSFP-DD is defined twice on purpose, by Juniper and by Generic, so the owner-scope
+    rule has two candidates to choose between.
+    """
+    root = tmp_path / "library"
+    write_module_bay_type(root, "Juniper", "mx304-re", "MX304-RE", "Juniper MX304 routing-engine slot compatibility")
+    write_module_bay_type(root, "Juniper", "mx304-lmic", "MX304-LMIC", "Juniper MX304 LMIC slot compatibility")
+    write_module_bay_type(root, "Juniper", "qsfp-dd", "QSFP-DD", "Juniper MX304 QSFP-DD cage")
+    write_module_bay_type(root, "Generic", "qsfp-dd", "QSFP-DD", "QSFP-DD pluggable transceiver form factor")
+    return root
+
+
+@pytest.fixture
+def catalog(library):
+    """Build a catalog wired to a real pynetbox client and a local NetBox-shaped server."""
+    servers = []
+
+    def _make(module_bay_types=(), manufacturers=None, root=None):
+        server = FakeNetBox(
+            manufacturers=DEFAULT_MANUFACTURERS if manufacturers is None else manufacturers,
+            module_bay_types=module_bay_types,
+        )
+        servers.append(server)
+        return ModuleBayTypeCatalog(server.api(), str(root or library), Handle()), server
+
+    yield _make
+    for server in servers:
+        server.close()
+
+
+@pytest.mark.real_http
+class TestResolution:
+    """Names resolve to ids, in the owning manufacturer's scope and then in Generic."""
+
+    def test_resolves_in_owner_manufacturer_scope(self, catalog):
+        cat, server = catalog()
+        ids = cat.ids_for("juniper", ["MX304-RE"])
+        assert len(ids) == 1
+        created = server.sent("POST", "module_bay_types")
+        assert created == [
+            {
+                "name": "MX304-RE",
+                "slug": "mx304-re",
+                "manufacturer": 1,
+                "description": "Juniper MX304 routing-engine slot compatibility",
+            }
+        ]
+
+    def test_falls_back_to_generic_for_another_manufacturer(self, catalog):
+        """A Cisco optic reaches the Generic form factor, and Generic is created on demand."""
+        cat, server = catalog()
+        assert len(cat.ids_for("cisco", ["QSFP-DD"])) == 1
+        made = server.sent("POST", "manufacturers")
+        assert made == [{"name": "Generic", "slug": "generic"}]
+
+    def test_owner_scope_wins_over_generic(self, catalog):
+        """Juniper and Generic both define QSFP-DD, and a Juniper reference means Juniper's."""
+        cat, server = catalog()
+        cat.ids_for("juniper", ["QSFP-DD"])
+        created = server.sent("POST", "module_bay_types")
+        assert [p["manufacturer"] for p in created] == [1]
+        assert not server.sent("POST", "manufacturers")
+
+    def test_existing_object_is_reused_not_recreated(self, catalog):
+        cat, server = catalog(
+            module_bay_types=[{"id": 77, "name": "MX304-RE", "slug": "mx304-re", "manufacturer": {"id": 1}}]
+        )
+        assert cat.ids_for("juniper", ["MX304-RE"]) == [77]
+        assert not server.sent("POST", "module_bay_types")
+
+    def test_repeated_resolution_is_cached(self, catalog):
+        cat, server = catalog()
+        first = cat.ids_for("juniper", ["MX304-RE"])
+        before = len(server.requests)
+
+        assert cat.ids_for("juniper", ["MX304-RE"]) == first
+        assert len(first) == 1, "an empty result would make the request count meaningless"
+        assert len(server.requests) == before
+
+    def test_order_is_not_meaningful(self, catalog):
+        cat, _ = catalog()
+        a = cat.ids_for("juniper", ["MX304-RE", "MX304-LMIC"])
+        b = cat.ids_for("juniper", ["MX304-LMIC", "MX304-RE"])
+        assert len(a) == 2
+        assert sorted(a) == sorted(b)
+
+
+@pytest.mark.real_http
+class TestRefusals:
+    """An unresolved name and a conflicting identity are reported, never papered over."""
+
+    def test_unresolved_name_raises_rather_than_dropping(self, catalog):
+        cat, _ = catalog()
+        with pytest.raises(ModuleBayTypeError) as exc:
+            cat.ids_for("juniper", ["NO-SUCH-CLASS"])
+        assert "NO-SUCH-CLASS" in str(exc.value)
+
+    def test_same_name_different_slug_is_an_error_not_a_rename(self, catalog):
+        """The catalog says mx304-re; NetBox holds mx304_re.  Never silently rename."""
+        cat, server = catalog(
+            module_bay_types=[{"id": 88, "name": "MX304-RE", "slug": "mx304_re", "manufacturer": {"id": 1}}]
+        )
+        with pytest.raises(ModuleBayTypeError) as exc:
+            cat.ids_for("juniper", ["MX304-RE"])
+        assert "mx304_re" in str(exc.value) and "mx304-re" in str(exc.value)
+        assert not server.sent("POST", "module_bay_types")
+
+
+@pytest.mark.real_http
+class TestCatalogReading:
+    """The catalog is read from real files on disk, including the shapes that are rejected."""
+
+    def test_entry_without_a_description_is_created_without_one(self, tmp_path, catalog):
+        write_module_bay_type(tmp_path, "Generic", "sfp", "SFP")
+        cat, server = catalog(root=tmp_path)
+        cat.ids_for("generic", ["SFP"])
+        created = server.sent("POST", "module_bay_types")
+        generic = next(m for m in server.collection("manufacturers") if m["slug"] == "generic")
+        assert created == [{"name": "SFP", "slug": "sfp", "manufacturer": generic["id"]}]
+
+    def test_non_yaml_files_and_empty_documents_are_skipped(self, tmp_path, catalog):
+        write_module_bay_type(tmp_path, "Generic", "sfp", "SFP")
+        (tmp_path / "module-bay-types" / "Generic" / "README.md").write_text("not a catalog entry\n")
+        (tmp_path / "module-bay-types" / "Generic" / "blank.yaml").write_text("# only a comment\n")
+        cat, _ = catalog(root=tmp_path)
+        assert len(cat.ids_for("generic", ["SFP"])) == 1
+
+    def test_an_entry_missing_a_required_field_is_refused_at_load(self, tmp_path, catalog):
+        """A half-written entry must fail as a catalog error, not as a KeyError mid-run."""
+        directory = tmp_path / "module-bay-types" / "Generic"
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "sfp.yaml").write_text("name: SFP\nmanufacturer: Generic\n", encoding="utf-8")
+        cat, _ = catalog(root=tmp_path)
+
+        with pytest.raises(ModuleBayTypeError) as exc:
+            cat.identities_for("generic", ["SFP"])
+        assert "slug" in str(exc.value) and "sfp.yaml" in str(exc.value)
+
+    def test_unparseable_yaml_is_refused_as_a_catalog_error(self, tmp_path, catalog):
+        """A parser error escaping the boundary ends the run before it reports anything."""
+        directory = tmp_path / "module-bay-types" / "Generic"
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "sfp.yaml").write_text("name: [\n", encoding="utf-8")
+        cat, _ = catalog(root=tmp_path)
+
+        with pytest.raises(ModuleBayTypeError) as exc:
+            cat.identities_for("generic", ["SFP"])
+        assert "sfp.yaml" in str(exc.value)
+
+    def test_a_broken_catalog_is_read_once_not_on_every_lookup(self, tmp_path, catalog, monkeypatch):
+        """The load caches only on success, so a bad catalog re-walked the tree every time."""
+        import core.module_bay_types as module
+
+        write_module_bay_type(tmp_path, "Generic", "sfp", "SFP")
+        write_module_bay_type(tmp_path, "Generic", "sfp-again", "SFP")
+        cat, _ = catalog(root=tmp_path)
+
+        walks = []
+        real_walk = module.os.walk
+        monkeypatch.setattr(module.os, "walk", lambda *a, **k: walks.append(1) or real_walk(*a, **k))
+
+        for _ in range(3):
+            with pytest.raises(ModuleBayTypeError):
+                cat.identities_for("generic", ["SFP"])
+        assert len(walks) == 1
+
+    def test_duplicate_scoped_entry_is_refused(self, tmp_path, catalog):
+        """Two files claiming the same (manufacturer, name) would make a reference ambiguous."""
+        write_module_bay_type(tmp_path, "Generic", "sfp", "SFP")
+        write_module_bay_type(tmp_path, "Generic", "sfp-again", "SFP")
+        cat, _ = catalog(root=tmp_path)
+        with pytest.raises(ModuleBayTypeError) as exc:
+            cat.ids_for("generic", ["SFP"])
+        assert "Duplicate" in str(exc.value) and "SFP" in str(exc.value)
+
+
+@pytest.mark.real_http
+class TestMalformedReferences:
+    """A reference list that is not a list of names is refused, never read as empty."""
+
+    def test_a_bare_key_is_refused_rather_than_clearing(self, catalog):
+        """`module_bay_types:` with no value parses as None; treating it as [] would clear."""
+        cat, server = catalog()
+        with pytest.raises(ModuleBayTypeError) as exc:
+            cat.ids_for("juniper", None)
+        assert "list of names" in str(exc.value)
+        assert not server.sent("POST", "module_bay_types") and not server.sent("POST", "manufacturers")
+
+    def test_a_non_string_entry_is_refused(self, catalog):
+        cat, _ = catalog()
+        with pytest.raises(ModuleBayTypeError):
+            cat.ids_for("juniper", [{"name": "MX304-RE"}])
+        with pytest.raises(ModuleBayTypeError):
+            cat.ids_for("juniper", ["MX304-RE", 7])
+        with pytest.raises(ModuleBayTypeError):
+            cat.ids_for("juniper", ["  "])
+
+    def test_an_empty_list_is_allowed_and_holds_no_classes(self, catalog):
+        """`module_bay_types: []` is an explicit instruction, not a malformed value."""
+        cat, server = catalog()
+        assert cat.ids_for("juniper", []) == []
+        assert not server.sent("POST", "module_bay_types") and not server.sent("POST", "manufacturers")
+
+    def test_duplicate_names_collapse(self, catalog):
+        """The relationship is a set, so a repeated name must not produce a repeated id."""
+        cat, _ = catalog()
+        once = cat.ids_for("juniper", ["MX304-RE"])
+
+        assert len(once) == 1
+        assert cat.ids_for("juniper", ["MX304-RE", "MX304-RE"]) == once

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -2190,7 +2190,7 @@ class TestExportDiffVendorFilterOverRealHTTP:
     """Same run against a local HTTP server, so the filter is asserted as it is serialized on the wire."""
 
     @staticmethod
-    def _serve():
+    def _serve(netbox_version="4.7.0"):
         """Serve empty GraphQL pages and record every decoded request body."""
         import json
         import threading
@@ -2199,15 +2199,21 @@ class TestExportDiffVendorFilterOverRealHTTP:
         bodies = []
 
         class Handler(BaseHTTPRequestHandler):
-            def do_POST(self):
-                length = int(self.headers["Content-Length"])
-                bodies.append(json.loads(self.rfile.read(length)))
-                payload = b'{"data": {}}'
+            def _reply(self, payload):
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(payload)))
                 self.end_headers()
                 self.wfile.write(payload)
+
+            def do_GET(self):
+                """Answer the version probe the export runs before its first query."""
+                self._reply(json.dumps({"netbox-version": netbox_version}).encode())
+
+            def do_POST(self):
+                length = int(self.headers["Content-Length"])
+                bodies.append(json.loads(self.rfile.read(length)))
+                self._reply(b'{"data": {}}')
 
             def log_message(self, *args):
                 """Silence the default stderr access log."""
@@ -2229,3 +2235,33 @@ class TestExportDiffVendorFilterOverRealHTTP:
         assert set(filters) == set(_LIST_FIELDS)
         for field, variables in filters.items():
             assert variables["manufacturer_slugs"] == ["cisco", "juniper"], field
+
+    def _queries_for_version(self, nb_dt_import, monkeypatch, tmp_path, library_root, version):
+        """Run one whole export against a server reporting *version* and return its queries."""
+        url, server, bodies = self._serve(version)
+        monkeypatch.setenv("NETBOX_URL", url)
+        try:
+            _run_export_diff_cli(nb_dt_import, monkeypatch, tmp_path, library_root, "Juniper")
+        finally:
+            server.shutdown()
+            server.server_close()
+        return [payload["query"] for payload in bodies]
+
+    def test_a_47_server_is_asked_for_the_module_bay_type_relation(
+        self, nb_dt_import, monkeypatch, tmp_path, _real_library_root
+    ):
+        """Not selecting it exports every bay without its restriction, silently.
+
+        Asserted on the module-type query, which this run always issues; the component
+        queries only run once there is something to export.
+        """
+        queries = self._queries_for_version(nb_dt_import, monkeypatch, tmp_path, _real_library_root, "4.7.0")
+
+        module_types = [q for q in queries if "module_type_list(" in q]
+        assert module_types and all("module_bay_types" in q for q in module_types)
+
+    def test_an_older_server_is_never_asked_for_it(self, nb_dt_import, monkeypatch, tmp_path, _real_library_root):
+        """Selecting a field the schema lacks fails the whole query."""
+        queries = self._queries_for_version(nb_dt_import, monkeypatch, tmp_path, _real_library_root, "4.6.9")
+
+        assert not [q for q in queries if "module_bay_types" in q]

--- a/tests/test_nb_serializer.py
+++ b/tests/test_nb_serializer.py
@@ -677,3 +677,69 @@ class TestFrontPortSerialization:
         result = serialize_device_type(record, components)
         names = [i["name"] for i in result["interfaces"]]
         assert names == sorted(names)
+
+
+class TestRelationSerialization:
+    """A module bay's restriction has to survive the trip back out to YAML."""
+
+    @staticmethod
+    def _bay(name, module_bay_types=None, **extra):
+        """Build a module bay template as the GraphQL query returns it."""
+        return _dotdict(
+            name=name,
+            position=None,
+            label="",
+            description="",
+            module_bay_types=module_bay_types,
+            **extra,
+        )
+
+    def test_a_bay_exports_the_names_of_its_classes(self):
+        record = _dotdict(id=1, model="MX304", manufacturer=_make_mfr(), part_number=None)
+        bay = self._bay("FPC 0", [_dotdict(id=9, name="MX304-LMIC"), _dotdict(id=8, name="QSFP-DD")])
+
+        result = serialize_module_type(record, {1: {"module_bay_templates": [bay]}})
+
+        assert result["module-bays"] == [{"name": "FPC 0", "module_bay_types": ["MX304-LMIC", "QSFP-DD"]}]
+
+    def test_a_bay_with_no_classes_writes_no_key(self):
+        """An empty list here would add the key to every bay in the library.
+
+        See test_an_empty_relation_does_not_make_every_definition_differ for the effect
+        that has on the export diff.
+        """
+        record = _dotdict(id=1, model="MX304", manufacturer=_make_mfr(), part_number=None)
+
+        result = serialize_module_type(record, {1: {"module_bay_templates": [self._bay("FPC 0", [])]}})
+
+        assert result["module-bays"] == [{"name": "FPC 0"}]
+
+    def test_a_server_that_never_returned_the_field_omits_the_key(self):
+        """Below 4.7 the relation is not selected, and absent must not become empty."""
+        record = _dotdict(id=1, model="MX304", manufacturer=_make_mfr(), part_number=None)
+        bay = _dotdict(name="FPC 0", position=None, label="", description="")
+
+        result = serialize_module_type(record, {1: {"module_bay_templates": [bay]}})
+
+        assert result["module-bays"] == [{"name": "FPC 0"}]
+
+    def test_a_module_type_exports_the_classes_it_belongs_to(self):
+        record = _dotdict(
+            id=5,
+            model="JNP304-RE",
+            manufacturer=_make_mfr(name="Juniper", slug="juniper"),
+            part_number=None,
+            module_bay_types=[_dotdict(id=9, name="MX304-RE")],
+        )
+
+        assert serialize_module_type(record, {})["module_bay_types"] == ["MX304-RE"]
+
+    def test_a_device_type_bay_exports_its_classes_too(self):
+        record = _dotdict(
+            id=2, model="MX304", slug="mx304", manufacturer=_make_mfr(), u_height=None, is_full_depth=None
+        )
+        bay = self._bay("RE0", [_dotdict(id=9, name="MX304-RE")])
+
+        result = serialize_device_type(record, {2: {"module_bay_templates": [bay]}})
+
+        assert result["module-bays"] == [{"name": "RE0", "module_bay_types": ["MX304-RE"]}]

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -112,7 +112,7 @@ def _mark_cache_ready(device_types):
 
 def test_netbox_init(mock_settings, mock_pynetbox, mock_handle):
     # Mock api call
-    mock_pynetbox.api.return_value.version = "3.5"
+    mock_pynetbox.api.return_value.version = "4.3"
 
     nb = NetBox(mock_settings, mock_handle)
     assert nb.url == "http://mock-netbox"
@@ -128,7 +128,7 @@ def test_netbox_init_applies_import_policy_flags(make_config, mock_pynetbox, moc
         remove_unmanaged_types=True,
         verify_images=True,
     )
-    mock_pynetbox.api.return_value.version = "3.5"
+    mock_pynetbox.api.return_value.version = "4.3"
 
     netbox = NetBox(config, mock_handle)
 
@@ -138,24 +138,16 @@ def test_netbox_init_applies_import_policy_flags(make_config, mock_pynetbox, moc
 
 
 def test_netbox_version_check(mock_settings, mock_pynetbox, mock_handle):
-    # Test 5.0
-    mock_pynetbox.api.return_value.version = "5.0"
-    nb = NetBox(mock_settings, mock_handle)
-    assert nb.new_filters
-
-    # Test 4.0
-    mock_pynetbox.api.return_value.version = "4.0"
-    nb = NetBox(mock_settings, mock_handle)
-    assert not nb.new_filters
-
-    # Test 4.1
-    mock_pynetbox.api.return_value.version = "4.1"
-    nb = NetBox(mock_settings, mock_handle)
-    assert nb.new_filters
+    """Every supported release uses the new filter names; 4.7 adds module bay types."""
+    for version, module_bay_types in (("4.3", False), ("4.5", False), ("4.7", True), ("5.0", True)):
+        mock_pynetbox.api.return_value.version = version
+        nb = NetBox(mock_settings, mock_handle)
+        assert nb.new_filters, version
+        assert nb.module_bay_types is module_bay_types, version
 
 
 def test_create_manufacturers(mock_settings, mock_pynetbox, mock_handle):
-    mock_pynetbox.api.return_value.version = "3.5"
+    mock_pynetbox.api.return_value.version = "4.3"
     mock_pynetbox.api.return_value.dcim.manufacturers.all.return_value = []
 
     nb = NetBox(mock_settings, mock_handle)
@@ -168,7 +160,7 @@ def test_create_manufacturers(mock_settings, mock_pynetbox, mock_handle):
 
 
 def test_create_manufacturers_no_new_is_verbose_only(mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle):
-    mock_pynetbox.api.return_value.version = "3.5"
+    mock_pynetbox.api.return_value.version = "4.3"
 
     mock_graphql_requests.side_effect = paginate_dispatch(
         {
@@ -233,7 +225,7 @@ def test_create_generic_counts_the_created_list_at_the_caller(mock_pynetbox, mak
 def test_redundant_image_upload(mock_settings, mock_pynetbox, mock_handle):
     # Setup
     # Ensure modules check doesn't fail
-    mock_pynetbox.api.return_value.version = "3.5"
+    mock_pynetbox.api.return_value.version = "4.3"
 
     nb = NetBox(mock_settings, mock_handle)
     nb.device_types = MagicMock()
@@ -611,7 +603,7 @@ class TestNetBoxConnectApi:
 
     def test_ssl_ignore_sets_verify_false(self, mock_pynetbox, mock_handle, make_config):
         mock_settings = make_config(ignore_ssl_errors=True)
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         assert nb.netbox.http_session.verify is False
 
@@ -622,7 +614,7 @@ class TestCreateManufacturersError:
     def test_request_error_logged(self, mock_settings, mock_pynetbox, mock_handle):
         import pynetbox as real_pynb
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         # Make pynetbox.RequestError in the module under test be the real exception class
         mock_pynetbox.RequestError = real_pynb.RequestError
         nb = NetBox(mock_settings, mock_handle)
@@ -930,7 +922,7 @@ class TestCreateDeviceTypesNewDT:
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
+        mock_nb_api.version = "4.3"
 
         dt = make_device_types(nb_api=mock_nb_api)
 
@@ -1118,14 +1110,14 @@ class TestCreateModuleTypes:
     """Tests for TestCreateModuleTypes."""
 
     def test_empty_module_types_returns_immediately(self, mock_settings, mock_pynetbox, mock_handle):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         # Should not raise and should not call create
         nb.create_module_types([])
         nb.netbox.dcim.module_types.create.assert_not_called()
 
     def test_creates_new_module_type(self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -1250,7 +1242,7 @@ class TestCreateModuleTypesBody:
     """Tests for TestCreateModuleTypesBody."""
 
     def test_cached_module_type_skips_creation(self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -1285,7 +1277,7 @@ class TestCreateModuleTypesBody:
         import pynetbox as real_pynb
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -1310,7 +1302,7 @@ class TestCreateModuleTypesBody:
     def test_creates_module_type_with_components(
         self, mock_settings, mock_pynetbox, mock_graphql_requests, graphql_client, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -1606,7 +1598,7 @@ class TestCreateManufacturersSuccessLog:
 
     def test_verbose_log_per_created_manufacturer(self, mock_settings, mock_pynetbox, mock_handle):
         """verbose_log should be called for each created manufacturer."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
 
         created_m = MagicMock()
@@ -2333,7 +2325,7 @@ class TestCreateDeviceTypesUpdatePath:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
         mock_nb_api.dcim.device_types.create.side_effect = _request_error(
             b"{\"manufacturer\":[\"Related object not found using the provided attributes: {'slug': 'ribbon'}\"]}"
         )
@@ -2574,7 +2566,7 @@ class TestFilterActionableModuleTypesEdge:
 
     def test_empty_module_types_returns_empty(self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle):
         """Empty module_types list returns [], {} immediately."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         result, images, _ = nb.filter_actionable_module_types([], {}, only_new=False)
         assert result == []
@@ -2582,7 +2574,7 @@ class TestFilterActionableModuleTypesEdge:
 
     def test_only_new_delegates_to_filter_new(self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle):
         """only_new=True returns only genuinely new module types."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         existing_mt = MagicMock()
         all_mts = {"cisco": {"LC": existing_mt}}
@@ -2599,7 +2591,7 @@ class TestFilterActionableModuleTypesEdge:
         self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
     ):
         """Module type not in all_module_types is added to actionable."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -2622,7 +2614,7 @@ class TestFilterActionableModuleTypesEdge:
         self, mock_settings, mock_pynetbox, mock_graphql_requests, tmp_path, mock_handle
     ):
         """Existing module type with an image not yet in NetBox is actionable."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -2673,7 +2665,7 @@ class TestFilterActionableModuleTypesEdge:
         """Existing module type with a changed scalar property (e.g. part_number) is actionable."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -2726,7 +2718,7 @@ class TestFilterActionableModuleTypesEdge:
         """
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -2782,7 +2774,7 @@ class TestFilterActionableModuleTypesEdge:
         """
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -2827,7 +2819,7 @@ class TestFilterActionableModuleTypesEdge:
         """Existing module type whose properties all match NetBox is not actionable."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -2868,7 +2860,7 @@ class TestCreateModuleTypesEdge:
 
     def test_existing_module_type_verbose_logged(self, mock_settings, mock_pynetbox, mock_handle):
         """When a module type already exists, verbose_log is called with 'Cached'."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
 
         existing_mt = MagicMock()
@@ -2894,7 +2886,7 @@ class TestCreateModuleTypesEdge:
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):
         """only_new=True + existing module → skip component creation."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         nb.device_types.components.record("interface_templates", "module", 5, {})
@@ -2923,7 +2915,7 @@ class TestCreateModuleTypesEdge:
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):
         """power-outlets, console-server-ports, front-ports branches in create_module_types."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         for endpoint_name in ("power_outlet_templates", "console_server_port_templates", "front_port_templates"):
@@ -2955,7 +2947,7 @@ class TestCreateModuleTypesEdge:
         self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
     ):
         """The DTL module-type schema allows module-bays, so creation must not skip them."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         nb.device_types.components.record("module_bay_templates", "module", 5, {})
@@ -2981,7 +2973,7 @@ class TestCreateModuleTypesEdge:
         """Existing module type with changed part_number calls module_types.update and increments counter."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
 
         existing_mt = DotDict(
@@ -3017,7 +3009,7 @@ class TestCreateModuleTypesEdge:
         """Existing module type with matching part_number does not call module_types.update."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
 
         existing_mt = DotDict(
@@ -3048,7 +3040,7 @@ class TestCreateModuleTypesEdge:
         """only_new=True skips property update even when part_number differs."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
 
         existing_mt = DotDict(
@@ -3082,7 +3074,7 @@ class TestCreateModuleTypesEdge:
         """Existing module type with changed component property calls update_components and increments counter."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         _mark_cache_ready(nb.device_types)
@@ -3146,7 +3138,7 @@ class TestCreateModuleTypesEdge:
         """Both property and component change → module_updated incremented only once."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         _mark_cache_ready(nb.device_types)
@@ -3214,7 +3206,7 @@ class TestCreateModuleTypesEdge:
         """COMPONENT_REMOVED-only changes call update_components but do NOT increment module_updated."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         _mark_cache_ready(nb.device_types)
@@ -3275,7 +3267,7 @@ class TestCreateModuleTypesEdge:
         """Properties changed + removal-only diff with remove_components=False → module_updated incremented."""
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = make_device_types(nb_api=mock_pynetbox.api.return_value)
         nb.device_types.update_components = MagicMock()
@@ -3358,7 +3350,7 @@ class TestUploadModuleTypeImages:
         self, mock_settings, mock_pynetbox, mock_graphql_requests, tmp_path, mock_handle
     ):
         """If the image name is already in module_type_existing_images, upload is skipped."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
 
         module_dir = tmp_path / "module-types" / "vendor"
@@ -3388,7 +3380,7 @@ class TestUploadModuleTypeImages:
         self, mock_settings, mock_pynetbox, mock_graphql_requests, tmp_path, mock_handle
     ):
         """When image is not yet in existing_images, upload_image_attachment is called."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
 
         module_dir = tmp_path / "module-types" / "vendor"
@@ -4218,7 +4210,7 @@ class TestCreateModuleTypesCornerCases:
 
     def test_progress_iterator_used(self, mock_settings, mock_pynetbox, mock_handle):
         """When progress is provided, iteration goes through it."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
 
         created_mt = MagicMock()
@@ -4252,7 +4244,7 @@ class TestCreateModuleTypesCornerCases:
 
     def test_all_module_types_fetched_when_none(self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle):
         """all_module_types is fetched when not supplied."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -4277,7 +4269,7 @@ class TestCreateModuleTypesCornerCases:
         self, mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
     ):
         """module_type_existing_images is fetched when not supplied."""
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
                 "manufacturer_list": [],
@@ -4421,7 +4413,7 @@ class TestGetExistingRackTypes:
 
     def test_delegates_to_graphql(self, mock_settings, mock_pynetbox, graphql_client, mock_handle):
         """get_existing_rack_types() returns whatever graphql.get_rack_types() returns."""
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.graphql = graphql_client
         expected = {"apc": {"AR1300": MagicMock()}}
@@ -4442,7 +4434,7 @@ class TestCreateRackTypes:
     """Tests for NetBox.create_rack_types()."""
 
     def _make_nb(self, mock_settings, mock_handle, mock_pynetbox):
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         return NetBox(mock_settings, mock_handle)
 
     def test_empty_list_returns_immediately(self, mock_settings, mock_pynetbox, mock_handle):
@@ -4510,7 +4502,7 @@ class TestCreateRackTypes:
 
     def test_new_rack_type_calls_create(self, mock_settings, mock_pynetbox, mock_handle):
         """Non-existing rack type: create called, counter incremented, added to cache."""
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         created_rt = MagicMock()
         created_rt.id = 99
         mock_pynetbox.api.return_value.dcim.rack_types.create.return_value = created_rt
@@ -4532,7 +4524,7 @@ class TestCreateRackTypes:
         """RequestError during create is logged; processing continues."""
         import pynetbox
 
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         err = pynetbox.RequestError(MagicMock(status_code=400, url="u", content=b'{"detail":"bad"}'))
         mock_pynetbox.api.return_value.dcim.rack_types.create.side_effect = err
         mock_pynetbox.RequestError = pynetbox.RequestError
@@ -4553,7 +4545,7 @@ class TestCreateRackTypes:
         import pynetbox
         from core.graphql_client import DotDict
 
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         err = pynetbox.RequestError(MagicMock(status_code=400, url="u", content=b'{"detail":"bad"}'))
         mock_pynetbox.api.return_value.dcim.rack_types.update.side_effect = err
         mock_pynetbox.RequestError = pynetbox.RequestError
@@ -4573,7 +4565,7 @@ class TestCreateRackTypes:
 
     def test_all_rack_types_none_triggers_fetch(self, mock_settings, mock_pynetbox, mock_handle):
         """When all_rack_types=None, get_existing_rack_types() is called to populate the cache."""
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = self._make_nb(mock_settings, mock_handle, mock_pynetbox)
         nb.get_existing_rack_types = MagicMock(return_value={})
         rack_type = {
@@ -4587,7 +4579,7 @@ class TestCreateRackTypes:
 
     def test_progress_iterator_used(self, mock_settings, mock_pynetbox, mock_handle):
         """When a progress wrapper is provided, it is used as the iterator."""
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         created_rt = MagicMock()
         created_rt.id = 1
         mock_pynetbox.api.return_value.dcim.rack_types.create.return_value = created_rt
@@ -4615,16 +4607,15 @@ class TestVerifyCompatibility:
     @pytest.mark.parametrize(
         "version_str, expected_modules, expected_new_filters, expected_rack_types, expected_m2m",
         [
-            ("3.1", False, False, False, False),
-            ("3.2", True, False, False, False),
-            ("4.0", True, False, False, False),
-            ("4.1", True, True, True, False),
+            ("4.3", True, True, True, False),
             ("4.4", True, True, True, False),
             ("4.5", True, True, True, True),
             ("4.6", True, True, True, True),
+            ("4.7", True, True, True, True),
+            ("5.0", True, True, True, True),
             # Version strings with non-numeric suffixes
             ("4.5-beta", True, True, True, True),
-            ("4.1.0", True, True, True, False),
+            ("4.3.0", True, True, True, False),
         ],
     )
     def test_version_thresholds(
@@ -4646,16 +4637,19 @@ class TestVerifyCompatibility:
         assert nb.m2m_front_ports == expected_m2m, f"m2m_front_ports mismatch for {version_str}"
 
     def test_single_component_version_string(self, mock_settings, mock_pynetbox, mock_handle):
-        """Version string with only major component (e.g. '4') does not crash."""
-        mock_pynetbox.api.return_value.version = "4"
+        """A version string with only a major component (e.g. '5') does not crash."""
+        mock_pynetbox.api.return_value.version = "5"
         nb = NetBox(mock_settings, mock_handle)
-        assert nb.new_filters is False  # 4.0 → no new filters
+        assert nb.new_filters is True
 
-    def test_version_42_enables_new_filters_not_m2m(self, mock_settings, mock_pynetbox, mock_handle):
-        mock_pynetbox.api.return_value.version = "4.2"
+    def test_the_oldest_supported_release_has_no_m2m_or_module_bay_types(
+        self, mock_settings, mock_pynetbox, mock_handle
+    ):
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         assert nb.new_filters is True
         assert nb.m2m_front_ports is False
+        assert nb.module_bay_types is False
 
 
 # ============================================================
@@ -4855,7 +4849,7 @@ class TestLogModuleTypeChanges:
     def test_non_empty_log_emits_verbose_output(self, mock_settings, mock_pynetbox, mock_handle):
         """A non-empty changed_property_log triggers verbose logging."""
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
+        mock_nb_api.version = "4.3"
 
         nb = NetBox(mock_settings, mock_handle)
         mock_handle.verbose_log.reset_mock()
@@ -4868,7 +4862,7 @@ class TestLogModuleTypeChanges:
     def test_empty_log_emits_nothing(self, mock_settings, mock_pynetbox, mock_handle):
         """An empty changed_property_log does not trigger any logging calls."""
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
+        mock_nb_api.version = "4.3"
 
         nb = NetBox(mock_settings, mock_handle)
         mock_handle.verbose_log.reset_mock()
@@ -4887,7 +4881,7 @@ class TestTryUpdateModuleTypeErrors:
     """Tests for RequestError and retryable-exception handlers in _try_update_module_type."""
 
     def _make_nb(self, mock_settings, mock_handle, mock_pynetbox):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         return NetBox(mock_settings, mock_handle)
 
     def _make_module_type_res(self):
@@ -4901,7 +4895,7 @@ class TestTryUpdateModuleTypeErrors:
         """pynetbox.RequestError during update causes (False, False) return and log."""
         import pynetbox as real_pynb
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_pynetbox.RequestError = real_pynb.RequestError
 
         nb = self._make_nb(mock_settings, mock_handle, mock_pynetbox)
@@ -4926,7 +4920,7 @@ class TestTryUpdateModuleTypeErrors:
         import requests
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
 
         nb = self._make_nb(mock_settings, mock_handle, mock_pynetbox)
         mock_handle.log.reset_mock()
@@ -4969,7 +4963,7 @@ class TestProcessSingleModuleTypeCreateRetryable:
         import requests
 
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
+        mock_nb_api.version = "4.3"
         mock_pynetbox.RequestError = real_pynb.RequestError
 
         nb = NetBox(mock_settings, mock_handle)
@@ -5777,7 +5771,7 @@ class TestUploadModuleTypeImagesVerify:
     """Tests for _upload_module_type_images with verify_images=True."""
 
     def _make_nb(self, mock_settings, mock_handle, mock_pynetbox):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types.upload_image_attachment = MagicMock(return_value=True)
         nb.verify_images = True
@@ -5936,7 +5930,7 @@ class TestAdditionalNetBoxCoverage:
     def test_init_raises_typed_graphql_error_from_get_manufacturers(self, mock_settings, mock_pynetbox, mock_handle):
         from core.graphql_client import GraphQLError
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
 
         with patch.object(NetBox, "get_manufacturers", side_effect=GraphQLError("bad query")):
             with pytest.raises(NetBoxError, match="GraphQL error: bad query"):
@@ -5945,7 +5939,7 @@ class TestAdditionalNetBoxCoverage:
     def test_init_raises_typed_error_when_device_types_initialization_fails(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
 
         with (
             patch.object(NetBox, "get_manufacturers", return_value=[]),
@@ -6022,7 +6016,7 @@ class TestAdditionalNetBoxCoverage:
         import requests
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.netbox.dcim.manufacturers.create.side_effect = requests.exceptions.ConnectionError("offline")
 
@@ -6032,7 +6026,7 @@ class TestAdditionalNetBoxCoverage:
         assert any("Connection error creating manufacturers" in str(c) for c in mock_handle.log.call_args_list)
 
     def test_try_resolve_update_logs_classifier_exception(self, mock_settings, mock_pynetbox, mock_handle):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         dt = MagicMock(id=1, model="Model-1")
 
@@ -6049,7 +6043,7 @@ class TestAdditionalNetBoxCoverage:
         from types import SimpleNamespace
         from core.update_failure_resolver import FailureKind
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         dt = MagicMock(id=1, model="Model-1")
         resolution = SimpleNamespace(
@@ -6072,7 +6066,7 @@ class TestAdditionalNetBoxCoverage:
         from types import SimpleNamespace
         from core.update_failure_resolver import FailureKind
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.force_resolve_conflicts = True
         dt = MagicMock(id=1, model="Model-1")
@@ -6105,7 +6099,7 @@ class TestAdditionalNetBoxCoverage:
         from core.update_failure_resolver import FailureKind
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.force_resolve_conflicts = True
         dt = MagicMock(id=1, model="Model-1")
@@ -6132,7 +6126,7 @@ class TestAdditionalNetBoxCoverage:
     def test_log_device_type_change_outcome_partial_success_mentions_property_failure(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         dt = MagicMock(id=1, model="Model-1")
         dt.manufacturer.name = "Cisco"
@@ -6151,7 +6145,7 @@ class TestAdditionalNetBoxCoverage:
     def test_log_device_type_change_outcome_logs_cached_when_nothing_happened(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         dt = MagicMock(id=1, model="Model-1")
         dt.manufacturer.name = "Cisco"
@@ -6168,7 +6162,7 @@ class TestAdditionalNetBoxCoverage:
         assert any("Device Type Cached" in str(c) for c in mock_handle.verbose_log.call_args_list)
 
     def test_filter_images_for_upload_keeps_changed_image(self, mock_settings, mock_pynetbox, tmp_path, mock_handle):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.verify_images = True
 
@@ -6194,7 +6188,7 @@ class TestAdditionalNetBoxCoverage:
         from core.change_detector import PropertyChange
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.netbox.dcim.device_types.update.side_effect = requests.exceptions.ConnectionError("offline")
         nb._log_device_type_change_outcome = MagicMock()
@@ -6217,7 +6211,7 @@ class TestAdditionalNetBoxCoverage:
         import requests
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.netbox.dcim.device_types.create.side_effect = requests.exceptions.ConnectionError("offline")
 
@@ -6238,7 +6232,7 @@ class TestAdditionalNetBoxCoverage:
     ):
         from core.change_detector import ChangeType, ComponentChange, PropertyChange
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         changes = [
             ComponentChange("interfaces", "xe-0", ChangeType.COMPONENT_ADDED),
@@ -6261,7 +6255,7 @@ class TestAdditionalNetBoxCoverage:
     def test_fetch_module_type_existing_images_uses_detailed_query_in_verify_mode(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.verify_images = True
         details = {7: {"linecard.front": {"att_id": 5, "url": "/media/linecard.front.jpg"}}}
@@ -6273,7 +6267,7 @@ class TestAdditionalNetBoxCoverage:
         assert nb._module_image_details == details
 
     def test_try_update_module_type_skips_missing_netbox_fields(self, mock_settings, mock_pynetbox, mock_handle):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         module_type_res = MagicMock(spec=["id", "manufacturer", "model"])
         module_type_res.id = 1
@@ -6290,7 +6284,7 @@ class TestAdditionalNetBoxCoverage:
     def test_filter_actionable_module_types_marks_verify_images_module_actionable(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.verify_images = True
         _mark_cache_ready(nb.device_types)
@@ -6314,7 +6308,7 @@ class TestAdditionalModuleTypeCoverage:
     def test_apply_module_type_component_updates_records_failed_no_actionable_changes(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         module_type_res = MagicMock(id=7, model="LC")
         module_type_res.manufacturer.name = "Cisco"
@@ -6334,7 +6328,7 @@ class TestAdditionalModuleTypeCoverage:
     ):
         from core.change_detector import ChangeType, ComponentChange
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         module_type_res = MagicMock(id=7, model="LC")
         module_type_res.manufacturer.name = "Cisco"
@@ -6362,7 +6356,7 @@ class TestAdditionalModuleTypeCoverage:
     ):
         from core.change_detector import ChangeType, ComponentChange
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         module_type_res = MagicMock(id=7, model="LC")
         module_type_res.manufacturer.name = "Cisco"
@@ -6383,7 +6377,7 @@ class TestAdditionalModuleTypeCoverage:
     ):
         from core.change_detector import ChangeType, ComponentChange
 
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         module_type_res = MagicMock(id=7, model="LC")
         module_type_res.manufacturer.name = "Cisco"
@@ -6510,7 +6504,7 @@ class TestRemainingCoverageBranches:
         from core.graphql_client import DotDict
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_pynetbox.api.return_value.dcim.rack_types.update.side_effect = requests.exceptions.ConnectionError(
             "offline"
         )
@@ -6530,7 +6524,7 @@ class TestRemainingCoverageBranches:
         import requests
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_pynetbox.api.return_value.dcim.rack_types.create.side_effect = requests.exceptions.ConnectionError(
             "offline"
         )
@@ -6547,7 +6541,7 @@ class TestRemainingCoverageBranches:
     def test_upload_module_type_images_discards_missing_attachment_before_failed_upload(
         self, mock_settings, mock_pynetbox, tmp_path, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.verify_images = True
         nb.device_types.upload_image_attachment = MagicMock(return_value=False)
@@ -6575,7 +6569,7 @@ class TestRemainingCoverageBranches:
     def test_upload_module_type_images_skips_changed_image_when_delete_fails(
         self, mock_settings, mock_pynetbox, tmp_path, mock_handle
     ):
-        mock_pynetbox.api.return_value.version = "3.5"
+        mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
         nb.verify_images = True
         nb.device_types.upload_image_attachment = MagicMock(return_value=True)
@@ -6825,7 +6819,7 @@ def test_filter_actionable_module_types_skips_unchanged_existing_module(
     mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
 ):
     mock_nb_api = mock_pynetbox.api.return_value
-    mock_nb_api.version = "3.5"
+    mock_nb_api.version = "4.3"
 
     mock_graphql_requests.side_effect = paginate_dispatch(
         {
@@ -6874,7 +6868,7 @@ def test_filter_actionable_module_types_includes_module_with_missing_component(
     mock_settings, mock_pynetbox, mock_graphql_requests, mock_handle
 ):
     mock_nb_api = mock_pynetbox.api.return_value
-    mock_nb_api.version = "3.5"
+    mock_nb_api.version = "4.3"
 
     mock_graphql_requests.side_effect = paginate_dispatch(
         {
@@ -6922,7 +6916,7 @@ class TestFilterActionableModuleTypesMissingAttr:
     ):
         """When existing module lacks an attribute, it's skipped — no false positive change."""
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
+        mock_nb_api.version = "4.3"
 
         mock_graphql_requests.side_effect = paginate_dispatch(
             {
@@ -6979,7 +6973,7 @@ class TestProcessSingleModuleTypeRemoveComponents:
     ):
         """When remove_components=True and there are component changes, remove_components is called."""
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
+        mock_nb_api.version = "4.3"
 
         nb = NetBox(mock_settings, mock_handle)
 
@@ -7037,7 +7031,7 @@ class TestProcessSingleModuleTypeRemoveComponents:
         skipped entirely.
         """
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "3.5"
+        mock_nb_api.version = "4.3"
 
         nb = NetBox(mock_settings, mock_handle)
 
@@ -7106,7 +7100,7 @@ class TestFailuresReachTheRunReport:
         import pynetbox as real_pynb
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         return NetBox(mock_settings, mock_handle)
 
     def test_rack_type_create_failure_is_reported(self, mock_settings, mock_pynetbox, mock_handle):
@@ -7190,7 +7184,7 @@ class TestSummaryWordingMatchesTheFailedOperation:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
         mock_nb_api.dcim.device_types.create.side_effect = _request_error(
             b'{"manufacturer":["Related object not found using the provided attributes: slug ribbon"]}'
         )
@@ -7223,7 +7217,7 @@ class TestSummaryWordingMatchesTheFailedOperation:
         import pynetbox as real_pynb
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         mock_pynetbox.api.return_value.dcim.module_types.create.side_effect = _request_error(
             b'{"model":["This field may not be blank."]}'
         )
@@ -7247,7 +7241,7 @@ class TestSkippedComponentReasonReachesTheReport:
 
     def _dt(self, mock_pynetbox, make_device_types, parent_id=1):
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
         dt = make_device_types(nb_api=mock_nb_api)
         return dt
 
@@ -7260,7 +7254,7 @@ class TestSkippedComponentReasonReachesTheReport:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
 
         dt = make_device_types(nb_api=mock_nb_api)
         inlet = MagicMock()
@@ -7351,7 +7345,7 @@ class TestComponentFailureReasonReachesTheReport:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
 
         dt = make_device_types(nb_api=mock_nb_api)
         existing_iface = MagicMock()
@@ -7410,7 +7404,7 @@ class TestComponentFailureReasonReachesTheReport:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
 
         dt = make_device_types(nb_api=mock_nb_api)
         stale = MagicMock()
@@ -7439,7 +7433,7 @@ class TestComponentFailureReasonReachesTheReport:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
 
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("interface_templates", "device", 6119, {})
@@ -7484,7 +7478,7 @@ class TestComponentErrorScoping:
         import pynetbox as real_pynb
 
         mock_pynetbox.RequestError = real_pynb.RequestError
-        mock_pynetbox.api.return_value.version = "4.1"
+        mock_pynetbox.api.return_value.version = "4.3"
         return NetBox(mock_settings, mock_handle)
 
     def test_new_device_type_with_failing_component_is_partial(
@@ -7495,7 +7489,7 @@ class TestComponentErrorScoping:
 
         mock_pynetbox.RequestError = real_pynb.RequestError
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
         dt = make_device_types(nb_api=mock_nb_api)
         dt.components.record("interface_templates", "device", 900, {})
         mock_nb_api.dcim.interface_templates.create.side_effect = _request_error(
@@ -7532,7 +7526,7 @@ class TestComponentErrorScoping:
     def test_component_errors_do_not_leak_between_entities(self, mock_pynetbox, graphql_client, make_device_types):
         """Errors buffered for one entity must not surface in the next entity's reason."""
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
         dt = make_device_types(nb_api=mock_nb_api)
 
         dt._log_component_error("stale error from an earlier entity")
@@ -7547,7 +7541,7 @@ class TestComponentErrorScoping:
     def test_collect_component_errors_clears_on_exit(self, mock_pynetbox, graphql_client, make_device_types):
         """The buffer is empty after a scope closes, so the next scope starts clean."""
         mock_nb_api = mock_pynetbox.api.return_value
-        mock_nb_api.version = "4.1"
+        mock_nb_api.version = "4.3"
         dt = make_device_types(nb_api=mock_nb_api)
 
         with dt.collect_component_errors() as first:
@@ -7557,3 +7551,16 @@ class TestComponentErrorScoping:
         with dt.collect_component_errors() as second:
             pass
         assert second == []
+
+
+def test_netbox_below_minimum_version_is_refused_with_a_clear_message(mock_settings, mock_pynetbox, mock_handle):
+    """A GraphQL schema error is a poor way to learn the server is too old."""
+    from core.netbox_api import NetBoxError
+
+    for version in ("4.1", "4.2", "3.5"):
+        mock_pynetbox.api.return_value.version = version
+        with pytest.raises(NetBoxError) as exc:
+            NetBox(mock_settings, mock_handle)
+        message = str(exc.value)
+        assert "4.3" in message, f"{version}: the message must name the minimum"
+        assert version in message, f"{version}: the message must name what was found"

--- a/tests/test_relation_scope.py
+++ b/tests/test_relation_scope.py
@@ -1,0 +1,188 @@
+"""A relation assigned from the wrong manufacturer scope must be detected as a change.
+
+The catalog resolves a reference name in the owning manufacturer's scope first and only
+then in Generic.  If NetBox already holds the Generic object where the owner has one of
+its own, comparing names alone reports equality and the wrong object survives.
+"""
+
+import pytest
+
+from core.change_detector import ChangeDetector
+from core.module_bay_types import ModuleBayTypeCatalog
+
+
+class Handle:
+    """Capture what the detector logs."""
+
+    def __init__(self):
+        """Start with no recorded lines."""
+        self.lines = []
+
+    def log(self, message):
+        """Record one line."""
+        self.lines.append(message)
+
+    def verbose_log(self, message):
+        """Record one verbose line."""
+        self.lines.append(message)
+
+
+class Related:
+    """A module bay type as NetBox returns it inside a relation."""
+
+    def __init__(self, name, slug, manufacturer_slug):
+        """Store the identity fields the comparison needs."""
+        self.name = name
+        self.slug = slug
+        self.manufacturer = type("M", (), {"slug": manufacturer_slug})()
+
+
+class NetBoxBay:
+    """A module bay template as the cache hands it to the detector."""
+
+    def __init__(self, name, module_bay_types):
+        """Store the bay name and its assigned classes."""
+        self.name = name
+        self.module_bay_types = module_bay_types
+
+
+@pytest.fixture
+def two_scope_catalog(tmp_path):
+    """Build a catalog where the same class name exists under Acme and under Generic."""
+    for manufacturer, slug in (("Acme", "acme-x"), ("Generic", "generic-x")):
+        directory = tmp_path / "module-bay-types" / manufacturer
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / f"{slug}.yaml").write_text(
+            f"name: X\nslug: {slug}\nmanufacturer: {manufacturer}\n", encoding="utf-8"
+        )
+    return str(tmp_path)
+
+
+def _detector(catalog, handle=None):
+    """Build a detector whose device_types exposes the catalog, as the real one does."""
+    device_types = type("DeviceTypes", (), {"module_bay_types": catalog, "module_bay_types_supported": True})()
+    return ChangeDetector(device_types, handle or Handle())
+
+
+def test_wrong_scope_assignment_is_detected(two_scope_catalog):
+    """Acme owns X, but NetBox assigned Generic's X. The names match; the objects do not."""
+    catalog = ModuleBayTypeCatalog(None, two_scope_catalog, Handle())
+    detector = _detector(catalog)
+
+    yaml_comp = {"name": "Slot 0", "module_bay_types": ["X"]}
+    netbox_comp = NetBoxBay("Slot 0", [Related("X", "generic-x", "generic")])
+
+    changes = detector._compare_component_properties(
+        yaml_comp, netbox_comp, ["module_bay_types"], comp_type="module-bays", manufacturer="acme"
+    )
+    assert [c.property_name for c in changes] == ["module_bay_types"], (
+        "a bay owned by Acme holding Generic's X must be corrected to Acme's X"
+    )
+
+
+def test_right_scope_assignment_is_left_alone(two_scope_catalog):
+    """The same bay already holding Acme's X is correct and must not be rewritten."""
+    catalog = ModuleBayTypeCatalog(None, two_scope_catalog, Handle())
+    detector = _detector(catalog)
+
+    yaml_comp = {"name": "Slot 0", "module_bay_types": ["X"]}
+    netbox_comp = NetBoxBay("Slot 0", [Related("X", "acme-x", "acme")])
+
+    changes = detector._compare_component_properties(
+        yaml_comp, netbox_comp, ["module_bay_types"], comp_type="module-bays", manufacturer="acme"
+    )
+    assert changes == []
+
+
+def test_generic_fallback_is_correct_when_the_owner_has_no_such_class(two_scope_catalog):
+    """A Nokia bay resolves X to Generic's X, so holding Generic's X is right."""
+    catalog = ModuleBayTypeCatalog(None, two_scope_catalog, Handle())
+    detector = _detector(catalog)
+
+    yaml_comp = {"name": "Slot 0", "module_bay_types": ["X"]}
+    netbox_comp = NetBoxBay("Slot 0", [Related("X", "generic-x", "generic")])
+
+    changes = detector._compare_component_properties(
+        yaml_comp, netbox_comp, ["module_bay_types"], comp_type="module-bays", manufacturer="nokia"
+    )
+    assert changes == []
+
+
+def _changes(detector, yaml_comp, netbox_comp, manufacturer="acme"):
+    """Run the real property comparison for the relation and return what it found."""
+    return detector._compare_component_properties(
+        yaml_comp, netbox_comp, ["module_bay_types"], comp_type="module-bays", manufacturer=manufacturer
+    )
+
+
+class TestUnmanagedRelations:
+    """A relation is only rewritten when both sides say something about it."""
+
+    def test_an_omitted_key_leaves_the_relation_alone(self, two_scope_catalog):
+        """A definition that never mentions the relation is not asking for it to be cleared."""
+        detector = _detector(ModuleBayTypeCatalog(None, two_scope_catalog, Handle()))
+        netbox_comp = NetBoxBay("Slot 0", [Related("X", "acme-x", "acme")])
+        assert _changes(detector, {"name": "Slot 0"}, netbox_comp) == []
+
+    def test_a_bare_key_leaves_the_relation_alone_but_says_so(self, two_scope_catalog):
+        """Parses as None, so nothing is cleared; a typo must still not be invisible."""
+        handle = Handle()
+        detector = _detector(ModuleBayTypeCatalog(None, two_scope_catalog, Handle()), handle)
+        netbox_comp = NetBoxBay("Slot 0", [Related("X", "acme-x", "acme")])
+
+        assert _changes(detector, {"name": "Slot 0", "module_bay_types": None}, netbox_comp) == []
+        assert any("module_bay_types" in line and "Slot 0" in line for line in handle.lines)
+
+    def test_a_non_name_entry_leaves_the_relation_alone(self, two_scope_catalog):
+        detector = _detector(ModuleBayTypeCatalog(None, two_scope_catalog, Handle()))
+        netbox_comp = NetBoxBay("Slot 0", [Related("X", "acme-x", "acme")])
+        assert _changes(detector, {"name": "Slot 0", "module_bay_types": [{"name": "X"}]}, netbox_comp) == []
+
+    def test_a_field_the_query_did_not_return_is_skipped(self, two_scope_catalog):
+        """Reading an absent field as empty would report a change on every run."""
+        detector = _detector(ModuleBayTypeCatalog(None, two_scope_catalog, Handle()))
+        netbox_comp = type("Bay", (), {"name": "Slot 0"})()
+        assert _changes(detector, {"name": "Slot 0", "module_bay_types": ["X"]}, netbox_comp) == []
+
+    def test_an_unresolvable_reference_reaches_the_write_path(self, two_scope_catalog):
+        """Reporting "no change" leaves the bay unrestricted in silence.
+
+        The write path is the only thing that logs and records an unresolvable name, and it
+        only ever sees a component the detector reported as changed.
+        """
+        detector = _detector(ModuleBayTypeCatalog(None, two_scope_catalog, Handle()))
+        netbox_comp = NetBoxBay("Slot 0", [Related("X", "acme-x", "acme")])
+
+        changes = _changes(detector, {"name": "Slot 0", "module_bay_types": ["NO-SUCH-CLASS"]}, netbox_comp)
+
+        assert [(c.property_name, c.new_value) for c in changes] == [("module_bay_types", ["NO-SUCH-CLASS"])]
+
+
+class TestNameComparisonFallback:
+    """Where an identity cannot be had, comparing names is still better than doing nothing."""
+
+    def test_names_are_compared_when_netbox_returned_no_slug(self, two_scope_catalog):
+        """A read path returning only id and name cannot answer the scope question."""
+        detector = _detector(ModuleBayTypeCatalog(None, two_scope_catalog, Handle()))
+        netbox_comp = NetBoxBay("Slot 0", [Related("Y", None, None)])
+        changes = _changes(detector, {"name": "Slot 0", "module_bay_types": ["X"]}, netbox_comp)
+        assert [(c.property_name, c.old_value, c.new_value) for c in changes] == [("module_bay_types", ["Y"], ["X"])]
+
+    def test_matching_names_are_left_alone_when_netbox_returned_no_slug(self, two_scope_catalog):
+        detector = _detector(ModuleBayTypeCatalog(None, two_scope_catalog, Handle()))
+        netbox_comp = NetBoxBay("Slot 0", [Related("X", None, None)])
+        assert _changes(detector, {"name": "Slot 0", "module_bay_types": ["X"]}, netbox_comp) == []
+
+    def test_names_are_compared_without_a_catalog(self):
+        """A caller that has not wired a catalog still gets the name comparison."""
+        detector = _detector(None)
+        netbox_comp = NetBoxBay("Slot 0", [Related("Y", "generic-y", "generic")])
+        changes = _changes(detector, {"name": "Slot 0", "module_bay_types": ["X"]}, netbox_comp)
+        assert [(c.old_value, c.new_value) for c in changes] == [(["Y"], ["X"])]
+
+    def test_an_empty_list_clears_the_relation(self, two_scope_catalog):
+        """`module_bay_types: []` is an explicit instruction to hold no classes."""
+        detector = _detector(ModuleBayTypeCatalog(None, two_scope_catalog, Handle()))
+        netbox_comp = NetBoxBay("Slot 0", [Related("X", "acme-x", "acme")])
+        changes = _changes(detector, {"name": "Slot 0", "module_bay_types": []}, netbox_comp)
+        assert [(c.old_value, c.new_value) for c in changes] == [(["X"], [])]

--- a/tests/test_suite_hygiene.py
+++ b/tests/test_suite_hygiene.py
@@ -82,6 +82,25 @@ def test_integration_collection_reads_credentials_from_a_local_env_file(tmp_path
     assert "1 passed" in result.stdout, result.stdout + result.stderr
 
 
+def test_the_fake_netbox_releases_its_listening_socket():
+    """shutdown() only stops the serve loop. One server per test leaks a descriptor each."""
+    import socket
+
+    from helpers import FakeNetBox
+
+    server = FakeNetBox(manufacturers=[{"id": 1, "name": "Juniper", "slug": "juniper"}])
+    port = server._server.server_port
+    server.close()
+
+    probe = socket.socket()
+    try:
+        probe.bind(("127.0.0.1", port))
+    except OSError as exc:  # pragma: no cover - only reached when close() leaks
+        raise AssertionError(f"FakeNetBox.close() left port {port} bound: {exc}") from exc
+    finally:
+        probe.close()
+
+
 def test_no_test_function_contains_an_orphaned_docstring():
     """A dropped ``def`` header silently merges two tests into one.
 


### PR DESCRIPTION
## What

NetBox 4.7 added `ModuleBayType`: a module bay declares which classes of module it accepts, a module type declares which classes it belongs to, and NetBox permits installation when the two sets share a member. An empty set on either side disables the check.

The devicetype-library expresses this as `module_bay_types:`, an array of **names**, on each `module-bays` entry and at a module type's root. This teaches the importer to resolve those names to NetBox ids and keep them in sync.

Depends on the corresponding library change, which adds the `module-bay-types/` catalog and the schema fields.

## How

`ModuleBayTypeCatalog` (`core/module_bay_types.py`) is the whole feature behind two methods:

```python
ids_for(manufacturer_slug, names) -> list[int]
names_for(ids) -> list[str]
```

Behind them sit the catalog files, the scope rule, the NetBox lookup, object creation and the caches, so the four call sites (device-type create, module-type create, change detection, export) do not each restate them. Resolution tries the owning manufacturer, then `Generic`, then fails. It keys on the manufacturer **slug** because `core/repo.py` already rewrites every YAML manufacturer to a slug.

The component registry gained a `relations` attribute; `module-bays` declares `module_bay_types`. That one row drives the GraphQL selection (a nested block, not a scalar), the comparison list and the create path, so no consumer special-cases a component type. The two registry contract tests were extended rather than bypassed.

Comparison treats the relation as an unordered set of names: reordering the YAML produces no write.

## Semantics

| YAML | Creating | Existing, with `--update` |
|---|---|---|
| key omitted | no restriction assigned | preserved, unmanaged |
| `module_bay_types: []` | created with none | explicitly cleared |
| non-empty list | resolved and assigned | replaced, not merged |

An unresolvable name, and a name already in NetBox under a different slug, are both reported and skipped per component so the run continues. A bay is never written without the restriction it asked for, and an existing object is never renamed.

## Compatibility

The relation exists only in NetBox 4.7. Support is detected the same way the 4.5 port-mapping change is, and the relation is dropped from the query, the create payload and the comparison on older servers, so 4.3 through 4.6 are unaffected.

## Testing

`tests/test_module_bay_types.py` drives the public interface against a real `pynetbox` client over a local HTTP server, using the repo's existing `real_http` pattern, plus real catalog files on disk via `tmp_path`. No mocks: the client serialises, filters and paginates for real, which is where the semantics that matter live. 100% coverage of the new module.

Verified end to end against a live NetBox 4.7 on a Juniper MX304: bay templates and module types typed on create and on update, and repeat runs report `0 components updated, 0 components added, 0 modules updated`.

## Comparing identities, not names

A reference resolves in the owning manufacturer's scope before `Generic`, so a name alone cannot say which object is meant when two manufacturers define the same class name. The catalog therefore exposes two halves:

```python
identities_for(manufacturer_slug, names) -> frozenset[(manufacturer_slug, slug)]   # pure query
ids_for(manufacturer_slug, names) -> list[int]                                      # creates
```

Change detection uses the query half, so it can ask what a reference means without causing anything to exist, and the relation is selected with its slug and owning manufacturer so both sides supply the same kind of thing. Where a read path cannot supply an identity the name comparison stands, rather than an identity being invented.

## Minimum supported version

A server below 4.3 now fails immediately and says so. The importer has required 4.3 since these GraphQL queries were written, but a 4.1 server previously got as far as a query and reported a missing schema field, naming the symptom rather than the cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Manage module bay types through manufacturer-specific catalogs with Generic fallback support.
  - Create, update, compare, and export module bay type relationships.
  - Support module bay type relationships in NetBox 4.7 and later.

- **Bug Fixes**
  - Relationship comparisons distinguish same-named types from different manufacturers.
  - Invalid references are reported per item or type without stopping the import.
  - Unsupported servers no longer receive unavailable relationship fields.

- **Compatibility**
  - NetBox versions older than 4.3 are rejected with a clear error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->