### PR TITLE
feat(export): write the NetBox 4.5 port-mappings stanza

### DIFF
--- a/core/component_registry.py
+++ b/core/component_registry.py
@@ -119,7 +119,8 @@ COMPONENT_TYPES = (
         yaml_key="front-ports",
         endpoint="front_port_templates",
         label="Front Port",
-        fields=("name", "type", "label", "description", "color"),
+        # positions arrived with the 4.5 mapping model; the query drops it on older servers.
+        fields=("name", "type", "label", "description", "color", "positions"),
         graphql_extra=("mappings { id front_port_position rear_port_position rear_port { id name } }",),
         compare_extra=("_mappings",),
         link=LINK_REAR_PORTS,

--- a/core/graphql_client.py
+++ b/core/graphql_client.py
@@ -744,7 +744,7 @@ class NetBoxGraphQLClient:
     def _front_port_field_variants(fields):
         """Yield successive field-list tiers for the front_port_templates fallback.
 
-        Tier 1: mappings block (NetBox 4.5+)
+        Tier 1: mappings block and positions (NetBox 4.5+)
         Tier 2: rear_port_position scalar (<4.5)
         Tier 3: neither (field removed entirely)
         """
@@ -753,7 +753,8 @@ class NetBoxGraphQLClient:
         for f in fields:
             if "mappings" in f:
                 fallback.extend(["rear_port_position", "rear_port { id name }"])
-            else:
+            elif f != "positions":
+                # positions arrived with the mapping model, so no pre-4.5 tier may ask for it.
                 fallback.append(f)
         yield fallback
         stripped = [f for f in fallback if f != "rear_port_position" and "rear_port" not in f]

--- a/core/nb_serializer.py
+++ b/core/nb_serializer.py
@@ -4,7 +4,6 @@ Direction: NetBox record → Python dict suitable for ``yaml.dump()`` and
 comparison against existing repo YAML files.
 """
 
-import warnings
 from typing import Any, Sequence
 
 from core.component_registry import BY_ENDPOINT, COMPONENT_TYPES, MODULE_TYPE_RELATIONS
@@ -26,7 +25,6 @@ _OMIT_IF_EQUAL = {
     "feed_leg": None,
     "maximum_draw": None,
     "allocated_draw": None,
-    "positions": 1,  # rear port default; include only when > 1
 }
 
 # Device type scalar field order for output.
@@ -146,37 +144,53 @@ def _serialize_relations(record: Any, relations: Sequence[str]) -> dict:
 
 
 def _serialize_front_port(record: Any) -> dict:
-    """Serialize a front port template, including rear_port mapping."""
-    result = _serialize_component(record, BY_ENDPOINT["front_port_templates"].fields)
-    mappings = getattr(record, "mappings", None) or []
-    if mappings:
-        if len(mappings) > 1:
-            port_name = getattr(record, "name", "<unknown>")
-            warnings.warn(
-                f"Front port '{port_name}' has {len(mappings)} mappings; "
-                "only the first will be exported. "
-                "Full multi-mapping support requires DTL schema update (see issue #78).",
-                UserWarning,
-                stacklevel=4,
+    """Serialize a front port template's own fields.
+
+    The rear-port linkage is no longer written here: NetBox 4.5 moved it to a through
+    table and the library schema follows, carrying it in a top-level ``port-mappings``
+    stanza built by :func:`_port_mappings`.
+    """
+    return _serialize_component(record, BY_ENDPOINT["front_port_templates"].fields)
+
+
+def _port_mappings(records: list) -> list:
+    """Return the ``port-mappings`` stanza for a type's front port templates.
+
+    Every mapping is written, not just the first: one front port may occupy several
+    positions across rear ports, which is what the through table exists to express.
+
+    A server below 4.5 has no through table and answers with ``rear_port`` and
+    ``rear_port_position`` scalars instead.  Those describe one mapping, so they are
+    written as one entry rather than dropped.
+    """
+    stanza = []
+    for record in sorted(records, key=lambda r: str(getattr(r, "name", "") or "")):
+        name = getattr(record, "name", None)
+        for mapping in getattr(record, "mappings", None) or []:
+            rear_port = getattr(mapping, "rear_port", None)
+            if not rear_port:
+                continue
+            stanza.append(
+                {
+                    "front_port": name,
+                    "front_port_position": _coerce_numeric(getattr(mapping, "front_port_position", None)) or 1,
+                    "rear_port": rear_port.name,
+                    "rear_port_position": _coerce_numeric(getattr(mapping, "rear_port_position", None)) or 1,
+                }
             )
-        m = mappings[0]
-        rear_port = getattr(m, "rear_port", None)
-        if rear_port:
-            result["rear_port"] = rear_port.name
-        rear_pos = getattr(m, "rear_port_position", None)
-        rear_pos = _coerce_numeric(rear_pos)
-        if rear_pos is not None and rear_pos > 1:
-            result["rear_port_position"] = rear_pos
-    else:
-        # Legacy: pre-4.5 NetBox returns rear_port / rear_port_position as direct scalar fields
-        legacy_rp = getattr(record, "rear_port", None)
-        if legacy_rp:
-            result["rear_port"] = legacy_rp.name
-        legacy_pos = getattr(record, "rear_port_position", None)
-        legacy_pos = _coerce_numeric(legacy_pos)
-        if legacy_pos is not None and legacy_pos > 1:
-            result["rear_port_position"] = legacy_pos
-    return result
+        if getattr(record, "mappings", None):
+            continue
+        legacy = getattr(record, "rear_port", None)
+        if legacy:
+            stanza.append(
+                {
+                    "front_port": name,
+                    "front_port_position": 1,
+                    "rear_port": legacy.name,
+                    "rear_port_position": _coerce_numeric(getattr(record, "rear_port_position", None)) or 1,
+                }
+            )
+    return stanza
 
 
 def _serialize_component_list(endpoint_name: str, records: list) -> list:
@@ -200,6 +214,9 @@ def _add_components(result: dict, type_id: int, components_by_id: dict) -> None:
         records = type_components.get(component.endpoint, [])
         if records:
             result[component.yaml_key] = _serialize_component_list(component.endpoint, records)
+    mappings = _port_mappings(type_components.get("front_port_templates", []))
+    if mappings:
+        result["port-mappings"] = mappings
 
 
 def serialize_device_type(nb_record: Any, components_by_dt_id: dict) -> dict:

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -128,6 +128,7 @@ class TestDerivedGraphQLTables:
                 "label",
                 "description",
                 "color",
+                "positions",
                 _FRONT_PORT_MAPPINGS,
             ],
             "device_bay_templates": ["id", "name", "label", "description"],

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -1152,6 +1152,24 @@ class TestGetComponentTemplates:
         assert "module_bay_types" in _query_for(True)
         assert "module_bay_types" not in _query_for(False)
 
+    def test_the_front_port_fallback_drops_every_45_only_field(self, mock_post):
+        """Positions arrived with the mapping model, so a pre-4.5 tier must not ask for it.
+
+        Leaving it in a fallback tier makes every tier fail the same way, and the whole
+        front-port preload dies on a server that would answer the older shape.
+        """
+        from core.component_registry import BY_ENDPOINT
+        from core.graphql_client import NetBoxGraphQLClient
+
+        fields = list(BY_ENDPOINT["front_port_templates"].graphql_fields)
+        assert "positions" in fields, "guard: the registry is expected to select positions"
+
+        tiers = list(NetBoxGraphQLClient._front_port_field_variants(fields))
+
+        assert any("positions" in f for f in tiers[0]), "the 4.5 tier keeps it"
+        for tier in tiers[1:]:
+            assert not any("positions" in f for f in tier), f"pre-4.5 tier still asks for it: {tier}"
+
     def test_returns_dotdict_records_with_parent_info(self, mock_post):
         """Records should be DotDicts with device_type/module_type and correct id types."""
         data = {

--- a/tests/test_nb_serializer.py
+++ b/tests/test_nb_serializer.py
@@ -441,195 +441,7 @@ class TestManufacturerSerialization:
 
 
 class TestFrontPortSerialization:
-    """Tests for front port rear_port extraction."""
-
-    def test_front_port_rear_port_extracted_from_mapping(self):
-        from types import SimpleNamespace
-
-        mapping = SimpleNamespace(rear_port=SimpleNamespace(name="RP1"), rear_port_position=1)
-        fp = SimpleNamespace(name="FP1", type="8p8c", label="", description="", color="", mappings=[mapping])
-        record = _dotdict(
-            id=1,
-            model="X",
-            slug="acme-x",
-            manufacturer=_make_mfr(),
-            u_height=1,
-            is_full_depth=True,
-            part_number=None,
-            airflow=None,
-            weight=None,
-            weight_unit=None,
-            description="",
-            comments="",
-            subdevice_role=None,
-            front_image=None,
-            rear_image=None,
-        )
-        components = {1: {"front_port_templates": [fp]}}
-        result = serialize_device_type(record, components)
-        assert result["front-ports"][0]["rear_port"] == "RP1"
-        assert "rear_port_position" not in result["front-ports"][0]
-
-    def test_front_port_rear_port_position_included_when_gt_1(self):
-        from types import SimpleNamespace
-
-        mapping = SimpleNamespace(rear_port=SimpleNamespace(name="RP1"), rear_port_position=3)
-        fp = SimpleNamespace(name="FP1", type="8p8c", label="", description="", color="", mappings=[mapping])
-        record = _dotdict(
-            id=1,
-            model="X",
-            slug="acme-x",
-            manufacturer=_make_mfr(),
-            u_height=1,
-            is_full_depth=True,
-            part_number=None,
-            airflow=None,
-            weight=None,
-            weight_unit=None,
-            description="",
-            comments="",
-            subdevice_role=None,
-            front_image=None,
-            rear_image=None,
-        )
-        components = {1: {"front_port_templates": [fp]}}
-        result = serialize_device_type(record, components)
-        assert result["front-ports"][0]["rear_port_position"] == 3
-
-    def test_front_port_rear_port_position_zero_omitted(self):
-        """Position 0 is not a valid DTL value and should be omitted."""
-        from types import SimpleNamespace
-
-        mapping = SimpleNamespace(rear_port=SimpleNamespace(name="RP1"), rear_port_position=0)
-        fp = SimpleNamespace(name="FP1", type="8p8c", label="", description="", color="", mappings=[mapping])
-        record = _dotdict(
-            id=1,
-            model="X",
-            slug="acme-x",
-            manufacturer=_make_mfr(),
-            u_height=1,
-            is_full_depth=True,
-            part_number=None,
-            airflow=None,
-            weight=None,
-            weight_unit=None,
-            description="",
-            comments="",
-            subdevice_role=None,
-            front_image=None,
-            rear_image=None,
-        )
-        components = {1: {"front_port_templates": [fp]}}
-        result = serialize_device_type(record, components)
-        assert "rear_port_position" not in result["front-ports"][0]
-
-    def test_front_port_multiple_mappings_warns_and_uses_first(self):
-        """When a front port has >1 mappings a UserWarning is raised and only the first is used."""
-        import warnings
-        from types import SimpleNamespace
-
-        m1 = SimpleNamespace(rear_port=SimpleNamespace(name="RP1"), rear_port_position=1)
-        m2 = SimpleNamespace(rear_port=SimpleNamespace(name="RP2"), rear_port_position=1)
-        fp = SimpleNamespace(name="FP1", type="8p8c", label="", description="", color="", mappings=[m1, m2])
-        record = _dotdict(
-            id=1,
-            model="X",
-            slug="acme-x",
-            manufacturer=_make_mfr(),
-            u_height=1,
-            is_full_depth=True,
-            part_number=None,
-            airflow=None,
-            weight=None,
-            weight_unit=None,
-            description="",
-            comments="",
-            subdevice_role=None,
-            front_image=None,
-            rear_image=None,
-        )
-        components = {1: {"front_port_templates": [fp]}}
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            result = serialize_device_type(record, components)
-        assert result["front-ports"][0]["rear_port"] == "RP1"
-        assert len(caught) == 1
-        assert issubclass(caught[0].category, UserWarning)
-        assert "FP1" in str(caught[0].message)
-        assert "2 mappings" in str(caught[0].message)
-        assert "issue #78" in str(caught[0].message)
-
-    def test_front_port_legacy_rear_port_scalars(self):
-        """pre-4.5 NetBox: record has rear_port/rear_port_position as direct attrs (no mappings)."""
-        from types import SimpleNamespace
-
-        fp = SimpleNamespace(
-            name="FP1",
-            type="8p8c",
-            label="",
-            description="",
-            color="",
-            mappings=None,
-            rear_port=SimpleNamespace(name="RP1"),
-            rear_port_position=3,
-        )
-        record = _dotdict(
-            id=1,
-            model="X",
-            slug="acme-x",
-            manufacturer=_make_mfr(),
-            u_height=1,
-            is_full_depth=True,
-            part_number=None,
-            airflow=None,
-            weight=None,
-            weight_unit=None,
-            description="",
-            comments="",
-            subdevice_role=None,
-            front_image=None,
-            rear_image=None,
-        )
-        components = {1: {"front_port_templates": [fp]}}
-        result = serialize_device_type(record, components)
-        assert result["front-ports"][0]["rear_port"] == "RP1"
-        assert result["front-ports"][0]["rear_port_position"] == 3
-
-    def test_front_port_legacy_rear_port_position_1_omitted(self):
-        """pre-4.5: rear_port_position == 1 should be omitted (same as mappings path)."""
-        from types import SimpleNamespace
-
-        fp = SimpleNamespace(
-            name="FP1",
-            type="8p8c",
-            label="",
-            description="",
-            color="",
-            mappings=None,
-            rear_port=SimpleNamespace(name="RP1"),
-            rear_port_position=1,
-        )
-        record = _dotdict(
-            id=1,
-            model="X",
-            slug="acme-x",
-            manufacturer=_make_mfr(),
-            u_height=1,
-            is_full_depth=True,
-            part_number=None,
-            airflow=None,
-            weight=None,
-            weight_unit=None,
-            description="",
-            comments="",
-            subdevice_role=None,
-            front_image=None,
-            rear_image=None,
-        )
-        components = {1: {"front_port_templates": [fp]}}
-        result = serialize_device_type(record, components)
-        assert result["front-ports"][0]["rear_port"] == "RP1"
-        assert "rear_port_position" not in result["front-ports"][0]
+    """Front port scalars. The rear-port linkage lives in TestPortMappingsStanza."""
 
     def test_components_sorted_by_name(self):
         from types import SimpleNamespace
@@ -743,3 +555,127 @@ class TestRelationSerialization:
         result = serialize_device_type(record, {2: {"module_bay_templates": [bay]}})
 
         assert result["module-bays"] == [{"name": "RE0", "module_bay_types": ["MX304-RE"]}]
+
+
+class TestPortMappingsStanza:
+    """Export writes the NetBox 4.5 port-mappings stanza the DTL schema now requires."""
+
+    @staticmethod
+    def _mapping(rear_port, rear_position=1, front_position=1):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            rear_port=SimpleNamespace(name=rear_port),
+            rear_port_position=rear_position,
+            front_port_position=front_position,
+        )
+
+    @staticmethod
+    def _front_port(name, mappings=None, positions=1, **extra):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            name=name,
+            type="lc-upc",
+            label="",
+            description="",
+            color="",
+            positions=positions,
+            mappings=mappings or [],
+            **extra,
+        )
+
+    def _device(self):
+        return _dotdict(
+            id=1,
+            model="X",
+            slug="acme-x",
+            manufacturer=_make_mfr(),
+            u_height=1,
+            is_full_depth=True,
+            part_number=None,
+            airflow=None,
+            weight=None,
+            weight_unit=None,
+            description="",
+            comments="",
+            subdevice_role=None,
+            front_image=None,
+            rear_image=None,
+        )
+
+    def test_a_front_port_carries_positions_and_no_inline_rear_port(self):
+        """The schema dropped rear_port from front-port entries and made positions required."""
+        fp = self._front_port("FP1", [self._mapping("RP1")], positions=1)
+
+        result = serialize_device_type(self._device(), {1: {"front_port_templates": [fp]}})
+
+        assert result["front-ports"] == [{"name": "FP1", "type": "lc-upc", "positions": 1}]
+
+    def test_every_mapping_reaches_the_stanza_not_just_the_first(self):
+        """The issue: a crossover front port mapped to two rear ports lost the second."""
+        fp = self._front_port("FP1", [self._mapping("RP1", 1), self._mapping("RP2", 3, front_position=2)], positions=2)
+
+        result = serialize_device_type(self._device(), {1: {"front_port_templates": [fp]}})
+
+        assert result["port-mappings"] == [
+            {"front_port": "FP1", "front_port_position": 1, "rear_port": "RP1", "rear_port_position": 1},
+            {"front_port": "FP1", "front_port_position": 2, "rear_port": "RP2", "rear_port_position": 3},
+        ]
+
+    def test_an_mpo_cassette_maps_every_front_port_to_its_rear_position(self):
+        """The shape the library actually carries: many front ports onto one MPO rear port."""
+        ports = [self._front_port(f"FP{i}", [self._mapping("MPO1", i)]) for i in (1, 2, 3)]
+
+        result = serialize_device_type(self._device(), {1: {"front_port_templates": ports}})
+
+        assert [(m["front_port"], m["rear_port_position"]) for m in result["port-mappings"]] == [
+            ("FP1", 1),
+            ("FP2", 2),
+            ("FP3", 3),
+        ]
+
+    def test_a_pre_45_server_still_exports_its_mappings(self):
+        """Below 4.5 NetBox returns rear_port scalars; dropping them would lose the linkage."""
+        from types import SimpleNamespace
+
+        fp = SimpleNamespace(
+            name="FP1",
+            type="8p8c",
+            label="",
+            description="",
+            color="",
+            rear_port=SimpleNamespace(name="RP1"),
+            rear_port_position=4,
+        )
+
+        result = serialize_device_type(self._device(), {1: {"front_port_templates": [fp]}})
+
+        assert result["port-mappings"] == [
+            {"front_port": "FP1", "front_port_position": 1, "rear_port": "RP1", "rear_port_position": 4}
+        ]
+
+    def test_a_front_port_with_no_mapping_adds_no_stanza(self):
+        result = serialize_device_type(self._device(), {1: {"front_port_templates": [self._front_port("FP1")]}})
+
+        assert "port-mappings" not in result
+
+    def test_a_type_without_front_ports_adds_no_stanza(self):
+        assert "port-mappings" not in serialize_device_type(self._device(), {1: {}})
+
+    def test_the_importer_reads_back_what_the_export_wrote(self):
+        """Serializer to normalizer, both real: the stanza is the seam between them."""
+        from core.repo import normalize_port_mappings
+
+        ports = [
+            self._front_port("1", [self._mapping("MPO1", 1)]),
+            self._front_port("2", [self._mapping("MPO1", 2)]),
+        ]
+        exported = serialize_device_type(self._device(), {1: {"front_port_templates": ports}})
+
+        assert normalize_port_mappings(exported) is None
+        assert [fp["_mappings"] for fp in exported["front-ports"]] == [
+            [{"rear_port": "MPO1", "front_port_position": 1, "rear_port_position": 1}],
+            [{"rear_port": "MPO1", "front_port_position": 1, "rear_port_position": 2}],
+        ]
+        assert "port-mappings" not in exported, "the normalizer consumes the stanza"


### PR DESCRIPTION
Closes #78. Was stacked on #132, which has since been squash-merged; this branch is now rebased onto `develop` and stands alone.

## The problem

NetBox 4.5 replaced `FrontPortTemplate.rear_port` (FK) + `rear_port_position` (int) with a through table, so one front port can occupy several positions across several rear ports. `_serialize_front_port` took `mappings[0]`, warned that it was dropping the rest, and wrote the linkage inline on the front-port entry.

The device-type library has since taken the same model ([devicetype-library#4552](https://github.com/netbox-community/devicetype-library/pull/4552)): a front-port entry carries no rear port, the linkage lives in a top-level `port-mappings` stanza, and `additionalProperties` is `false` — so the old inline shape no longer validates at all.

## The change

- Every mapping is written into a top-level `port-mappings` stanza with all four fields, not just the first.
- Front-port entries no longer carry `rear_port` / `rear_port_position`.
- A server below 4.5 answers with the `rear_port` / `rear_port_position` scalars. Those describe one mapping, so they become one stanza entry rather than being dropped — the output format follows the library schema, not the server release. Without this, exports from an older server would have silently lost all mapping data.
- `positions` is now required on front and rear ports and is written even at `1`, so it is no longer omitted at its default, and the front-port row selects it.
- `positions` arrived with the mapping model, so the pre-4.5 tiers of the front-port query fallback must not ask for it. Leaving it in made every tier fail the same way and took the whole front-port preload down on a server that would have answered the older shape.

## Verification

- Output validated against the real `schema/devicetype.json` from the library, using an MPO-cassette shape (3 front ports across 2 MPO rear ports).
- Round-tripped through `normalize_port_mappings`, which reads the stanza back and rebuilds the same per-port `_mappings`. That is a committed test — real serializer through real normalizer.
- The first-mapping-only behaviour was re-introduced as a mutation and fails the new test.

1223 tests, 97.64% coverage, ruff and mypy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Front-port exports now include all port mappings in a dedicated `port-mappings` section.
  - MPO cassette mappings preserve each front port’s corresponding rear position.
  - Exported port mappings can be re-imported without losing information.

- **Bug Fixes**
  - Multiple mappings are no longer reduced to only the first mapping.
  - Front-port mapping exports remain compatible with older NetBox versions.
  - Unmapped front ports no longer produce unnecessary mapping data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->