### PR TITLE
refactor: drop version branches unreachable at the NetBox 4.3 floor

### DIFF
--- a/core/compat.py
+++ b/core/compat.py
@@ -1,15 +1,7 @@
 """NetBox version-compatibility helpers.
 
-Centralises filter parameter names that changed between NetBox releases so
-that every caller uses the same logic and drift is impossible.
-
-NetBox 4.1 renamed several filter keys on the DCIM endpoints:
-
-    devicetype_id  →  device_type_id
-    moduletype_id  →  module_type_id
-
-Any code that constructs endpoint filter kwargs should call the helpers
-here rather than inlining ``"device_type_id" if new_filters else "devicetype_id"``.
+Centralises the version line each feature sits behind so that every caller uses the
+same logic and drift is impossible.
 """
 
 from __future__ import annotations
@@ -33,49 +25,3 @@ def parse_netbox_version(version) -> tuple[int, int]:
 def supports_module_bay_types(version) -> bool:
     """Return True when this NetBox release exposes the module bay type relation."""
     return parse_netbox_version(version) >= MODULE_BAY_TYPE_MINIMUM_VERSION
-
-
-def device_type_filter_key(new_filters: bool) -> str:
-    """Return the correct filter parameter name for device-type component queries.
-
-    Args:
-        new_filters: ``True`` for NetBox ≥ 4.1 (returns ``"device_type_id"``);
-            ``False`` for older releases (returns ``"devicetype_id"``).
-    """
-    return "device_type_id" if new_filters else "devicetype_id"
-
-
-def module_type_filter_key(new_filters: bool) -> str:
-    """Return the correct filter parameter name for module-type component queries.
-
-    Args:
-        new_filters: ``True`` for NetBox ≥ 4.1 (returns ``"module_type_id"``);
-            ``False`` for older releases (returns ``"moduletype_id"``).
-    """
-    return "module_type_id" if new_filters else "moduletype_id"
-
-
-def device_type_filter_kwargs(device_type_id: int, *, new_filters: bool) -> dict:
-    """Return filter kwargs for querying components of a device type.
-
-    Args:
-        device_type_id: NetBox ID of the device type.
-        new_filters: ``True`` for NetBox ≥ 4.1; ``False`` for older releases.
-
-    Returns:
-        A dict suitable for unpacking into ``endpoint.filter(**kwargs)``.
-    """
-    return {device_type_filter_key(new_filters): device_type_id}
-
-
-def module_type_filter_kwargs(module_type_id: int, *, new_filters: bool) -> dict:
-    """Return filter kwargs for querying components of a module type.
-
-    Args:
-        module_type_id: NetBox ID of the module type.
-        new_filters: ``True`` for NetBox ≥ 4.1; ``False`` for older releases.
-
-    Returns:
-        A dict suitable for unpacking into ``endpoint.filter(**kwargs)``.
-    """
-    return {module_type_filter_key(new_filters): module_type_id}

--- a/core/component_cache.py
+++ b/core/component_cache.py
@@ -14,12 +14,6 @@ import queue
 import threading
 from typing import Any
 
-from core.compat import (
-    device_type_filter_key,
-    device_type_filter_kwargs,
-    module_type_filter_key,
-    module_type_filter_kwargs,
-)
 from core.component_registry import COMPONENT_TYPES
 from core.graphql_client import GraphQLCountMismatchError, GraphQLSchemaError
 
@@ -118,14 +112,13 @@ class ComponentCache:
     filter, which happens for types created during this run and after an invalidation.
     """
 
-    def __init__(self, netbox, graphql, handle, new_filters, max_threads, wrap_record=None):
+    def __init__(self, netbox, graphql, handle, max_threads, wrap_record=None):
         """Build a cache over the *netbox* REST client and the *graphql* client.
 
         Args:
             netbox: pynetbox API object, used for REST fallbacks and count checks.
             graphql: GraphQL client used for the bulk fetch.
             handle: Log handler.
-            new_filters (bool): Whether this NetBox takes the newer filter parameter names.
             max_threads (int): Upper bound on concurrent endpoint fetches.
             wrap_record (callable | None): Applied to every front-port record, so change
                 detection sees one mappings shape across NetBox versions.
@@ -133,7 +126,6 @@ class ComponentCache:
         self.netbox = netbox
         self.graphql = graphql
         self.handle = handle
-        self.new_filters = new_filters
         self.max_threads = max_threads
         self._wrap_record = wrap_record or (lambda record: record)
 
@@ -313,9 +305,9 @@ class ComponentCache:
             return cached[key]
 
         if parent_type == "device":
-            filter_kwargs = device_type_filter_kwargs(parent_id, new_filters=self.new_filters)
+            filter_kwargs = {"device_type_id": parent_id}
         else:
-            filter_kwargs = module_type_filter_kwargs(parent_id, new_filters=self.new_filters)
+            filter_kwargs = {"module_type_id": parent_id}
         result = {item.name: item for item in endpoint.filter(**filter_kwargs)}
         self.record(endpoint_name, parent_type, parent_id, result)
         return result
@@ -479,8 +471,6 @@ class ComponentCache:
         Raises:
             GraphQLCountMismatchError: When an endpoint holds fewer records than REST reports.
         """
-        dt_filter_key = device_type_filter_key(self.new_filters)
-        mt_filter_key = module_type_filter_key(self.new_filters)
         dt_ids = list(device_type_ids)
         mt_ids = list(module_type_ids)
 
@@ -495,9 +485,9 @@ class ComponentCache:
             rest_endpoint = getattr(self.netbox.dcim, endpoint_name)
             rest_count = 0
             if dt_ids:
-                rest_count += self._rest_count(rest_endpoint, dt_filter_key, dt_ids)
+                rest_count += self._rest_count(rest_endpoint, "device_type_id", dt_ids)
             if mt_ids and component.module_types:
-                rest_count += self._rest_count(rest_endpoint, mt_filter_key, mt_ids)
+                rest_count += self._rest_count(rest_endpoint, "module_type_id", mt_ids)
 
             if cached_count != rest_count:
                 if vendor_scope_valid:

--- a/core/import_run.py
+++ b/core/import_run.py
@@ -49,8 +49,6 @@ class RunSummary:
     """Snapshot of the result of one completed import run."""
 
     counter: Counter
-    modules: bool
-    rack_types: bool
     outcome_counts: dict
     failure_lines: tuple
     duplicate_definitions: tuple
@@ -66,8 +64,6 @@ class RunSummary:
         """
         return cls(
             counter=Counter(netbox.counter),
-            modules=netbox.modules,
-            rack_types=netbox.rack_types,
             outcome_counts=netbox.outcomes.summary_by_kind(),
             failure_lines=tuple(netbox.outcomes.render_failure_report()),
             duplicate_definitions=tuple(repo.duplicate_definitions),
@@ -455,10 +451,6 @@ def _process_rack_types(config, netbox, handle, progress, rack_types, vendor_nam
     if not rack_types:
         return
 
-    if not netbox.rack_types:
-        handle.log("Rack types require NetBox >= 4.1. Skipping rack type import.")
-        return
-
     handle.verbose_log(f"{len(rack_types)} Rack-Types Found")
 
     all_rack_types = netbox.get_existing_rack_types()
@@ -521,21 +513,19 @@ def _log_run_summary(handle, summary):
     handle.log(f"{counter['components_removed']} components removed")
     handle.verbose_log(f"{counter['images']} images uploaded")
     handle.log(f"{counter['manufacturer']} manufacturers created")
-    if summary.modules:
-        handle.log(f"{counter['module_added']} modules created")
-        handle.log(f"{counter['module_updated']} modules updated")
-        module_failed = summary.outcome_count(EntityKind.MODULE_TYPE, Outcome.FAILED)
-        if module_failed:
-            handle.log(f"{module_failed} modules failed to create or update")
-        module_partial = summary.outcome_count(EntityKind.MODULE_TYPE, Outcome.PARTIAL)
-        if module_partial:
-            handle.log(f"{module_partial} modules partially updated")
-    if summary.rack_types:
-        handle.log(f"{counter['rack_type_added']} rack types created")
-        handle.log(f"{counter['rack_type_updated']} rack types updated")
-        rack_failed = summary.outcome_count(EntityKind.RACK_TYPE, Outcome.FAILED)
-        if rack_failed:
-            handle.log(f"{rack_failed} rack types failed")
+    handle.log(f"{counter['module_added']} modules created")
+    handle.log(f"{counter['module_updated']} modules updated")
+    module_failed = summary.outcome_count(EntityKind.MODULE_TYPE, Outcome.FAILED)
+    if module_failed:
+        handle.log(f"{module_failed} modules failed to create or update")
+    module_partial = summary.outcome_count(EntityKind.MODULE_TYPE, Outcome.PARTIAL)
+    if module_partial:
+        handle.log(f"{module_partial} modules partially updated")
+    handle.log(f"{counter['rack_type_added']} rack types created")
+    handle.log(f"{counter['rack_type_updated']} rack types updated")
+    rack_failed = summary.outcome_count(EntityKind.RACK_TYPE, Outcome.FAILED)
+    if rack_failed:
+        handle.log(f"{rack_failed} rack types failed")
 
     for line in summary.failure_lines:
         handle.log(line)
@@ -673,30 +663,24 @@ class ImportRun:
                 self.repo, selection.devices_path, vendor["name"], self.config.slugs or []
             )
 
-        if self.netbox.modules:
-            module_hint = slug_resolved["module_vendors"] if slug_resolved is not None else None
-            if module_hint is not None and vendor["slug"] not in module_hint:
-                module_types = []
-            else:
-                module_types = _parse_vendor_files(
-                    self.repo, selection.modules_path, vendor["name"], self.config.slugs or []
-                )
-        else:
+        module_hint = slug_resolved["module_vendors"] if slug_resolved is not None else None
+        if module_hint is not None and vendor["slug"] not in module_hint:
             module_types = []
-
-        if self.netbox.rack_types:
-            rack_hint = slug_resolved["rack_vendors"] if slug_resolved is not None else None
-            if rack_hint is not None and vendor["slug"] not in rack_hint:
-                rack_types = []
-            else:
-                rack_types = _parse_vendor_files(
-                    self.repo,
-                    selection.racks_path,
-                    vendor["name"],
-                    self.config.slugs or [],
-                )
         else:
+            module_types = _parse_vendor_files(
+                self.repo, selection.modules_path, vendor["name"], self.config.slugs or []
+            )
+
+        rack_hint = slug_resolved["rack_vendors"] if slug_resolved is not None else None
+        if rack_hint is not None and vendor["slug"] not in rack_hint:
             rack_types = []
+        else:
+            rack_types = _parse_vendor_files(
+                self.repo,
+                selection.racks_path,
+                vendor["name"],
+                self.config.slugs or [],
+            )
 
         return VendorPlan(
             vendor=vendor,
@@ -738,17 +722,16 @@ class ImportRun:
         )
         cache.pump()
 
-        if self.netbox.modules:
-            _process_module_types(
-                self.config,
-                self.netbox,
-                self.reporter,
-                self.progress,
-                plan.module_types,
-                vendor_name=plan.vendor["name"],
-                task_registry=self.task_registry,
-            )
-            cache.pump()
+        _process_module_types(
+            self.config,
+            self.netbox,
+            self.reporter,
+            self.progress,
+            plan.module_types,
+            vendor_name=plan.vendor["name"],
+            task_registry=self.task_registry,
+        )
+        cache.pump()
 
         _process_rack_types(
             self.config,

--- a/core/netbox_api.py
+++ b/core/netbox_api.py
@@ -492,11 +492,8 @@ class NetBox:
         self.handle = handle
         self.netbox: Any = None
         self.ignore_ssl = config.ignore_ssl_errors
-        self.modules = False
-        self.new_filters = False
         self.module_bay_types = False
         self.m2m_front_ports = False  # True for NetBox >= 4.5 (M2M port mappings)
-        self.rack_types = False
         self.force_resolve_conflicts = config.force_resolve_conflicts
         self.remove_unmanaged_types = config.remove_unmanaged_types
         self.verify_images = config.verify_images
@@ -538,7 +535,6 @@ class NetBox:
                 self.handle,
                 self.counter,
                 self.ignore_ssl,
-                self.new_filters,
                 graphql=self.graphql,
                 m2m_front_ports=self.m2m_front_ports,
                 module_bay_types_supported=self.module_bay_types,
@@ -603,10 +599,10 @@ class NetBox:
             raise UnknownError("NetBox API Error", cause=e) from e
 
     def verify_compatibility(self):
-        """Check the connected NetBox version and configure feature flags accordingly.
+        """Refuse a server below the supported floor and set the feature flags above it.
 
-        Sets ``self.modules = True`` for NetBox >= 3.2 and ``self.new_filters = True``
-        for >= 4.1. Logs the detected version when the new-filter flag is enabled.
+        Only the flags that still vary across supported releases are set here: the 4.3
+        floor makes everything introduced at or below 4.1 unconditional.
         """
         # nb.version should be the version in the form '3.2'
         # Strip non-numeric suffixes (e.g. "4.1-beta") before converting to int.
@@ -643,17 +639,6 @@ class NetBox:
                 f"NetBox {nb_version} is not supported: this importer requires NetBox {minimum} or later. "
                 f"Older releases fail part way through with a GraphQL schema error rather than here."
             )
-
-        # Later than 3.2
-        # Might want to check for the module-types entry as well?
-        if version_split[0] > 3 or (version_split[0] == 3 and version_split[1] >= 2):
-            self.modules = True
-
-        # check if version >= 4.1 in order to use new filter names (https://github.com/netbox-community/netbox/issues/15410)
-        if version_split[0] > 4 or (version_split[0] == 4 and version_split[1] >= 1):
-            self.new_filters = True
-            self.rack_types = True
-            self.handle.log(f"Netbox version {self.netbox.version} found. Using new filters.")
 
         # NetBox 4.5 replaced FrontPortTemplate.rear_port (FK) + rear_port_position (int)
         # with a ManyToMany through table (PortMapping).  The creation and read APIs differ.
@@ -777,7 +762,6 @@ class NetBox:
                 netbox=self.netbox,
                 device_type_id=dt.id,
                 device_type_yaml=device_type,
-                new_filters=self.new_filters,
             )
         except Exception as exc:  # defensive: classifier must never break the run
             self.handle.verbose_log(f"Failure classifier raised {type(exc).__name__}: {exc}")
@@ -1203,8 +1187,6 @@ class NetBox:
             for component in COMPONENT_TYPES:
                 yaml_key = component.yaml_key
                 if yaml_key not in device_type:
-                    continue
-                if yaml_key == "module-bays" and not self.modules:
                     continue
                 self.device_types.create_components(
                     yaml_key,
@@ -2320,7 +2302,6 @@ class DeviceTypes:
         handle,
         counter,
         ignore_ssl,
-        new_filters,
         *,
         graphql,
         repo_path,
@@ -2338,7 +2319,6 @@ class DeviceTypes:
             handle (LogHandler): Sink for creation and error messages.
             counter (Counter): Shared operation counter updated during creation.
             ignore_ssl (bool): Whether SSL certificate verification is disabled.
-            new_filters (bool): Whether to use updated filter parameter names (NetBox >= 4.1).
             graphql (NetBoxGraphQLClient): GraphQL client for read queries.
             module_bay_types_supported (bool): True when NetBox supports ModuleBayType (>= 4.7).
             repo_path (str): Local library checkout, used to read the module-type schema.
@@ -2349,7 +2329,6 @@ class DeviceTypes:
         self.handle = handle
         self.counter = counter
         self.ignore_ssl = ignore_ssl
-        self.new_filters = new_filters
         self.graphql = graphql
         self.repo_path = repo_path
         self.m2m_front_ports = m2m_front_ports
@@ -2359,7 +2338,6 @@ class DeviceTypes:
             netbox,
             graphql,
             handle,
-            new_filters,
             max_threads,
             wrap_record=_FrontPortRecordWithMappings,
         )

--- a/core/update_failure_resolver.py
+++ b/core/update_failure_resolver.py
@@ -24,8 +24,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Callable, List, Optional
 
-from core.compat import device_type_filter_kwargs
-
 
 class FailureKind(str, Enum):
     """High-level classification of a NetBox update failure."""
@@ -122,7 +120,7 @@ def _matches_subdevice_role_constraint(payload: Any) -> bool:
     return False
 
 
-def _count_dependent_devices(netbox: Any, device_type_id: int, *, new_filters: bool = False) -> tuple[int, List[str]]:
+def _count_dependent_devices(netbox: Any, device_type_id: int) -> tuple[int, List[str]]:
     """Query NetBox for devices using *device_type_id*.
 
     Returns ``(count, sample_names)`` where ``sample_names`` is up to 5 names
@@ -133,10 +131,8 @@ def _count_dependent_devices(netbox: Any, device_type_id: int, *, new_filters: b
     Args:
         netbox: pynetbox API client.
         device_type_id: ID of the device type to query.
-        new_filters: When True, use ``device_type_id`` filter name (NetBox ≥ 4.1);
-            otherwise use the legacy ``devicetype_id`` name.
     """
-    filter_kwargs = device_type_filter_kwargs(device_type_id, new_filters=new_filters)
+    filter_kwargs = {"device_type_id": device_type_id}
     try:
         devices = list(netbox.dcim.devices.filter(**filter_kwargs, limit=5))
     except Exception:
@@ -152,7 +148,7 @@ def _count_dependent_devices(netbox: Any, device_type_id: int, *, new_filters: b
     return total, sample
 
 
-def _list_device_bay_templates(netbox: Any, device_type_id: int, *, new_filters: bool = False) -> Optional[List[Any]]:
+def _list_device_bay_templates(netbox: Any, device_type_id: int) -> Optional[List[Any]]:
     """Return all ``DeviceBayTemplate`` records attached to *device_type_id*.
 
     Returns ``None`` when the NetBox query itself fails (network error, 5xx, etc.)
@@ -161,15 +157,9 @@ def _list_device_bay_templates(netbox: Any, device_type_id: int, *, new_filters:
     Args:
         netbox: pynetbox API client.
         device_type_id: ID of the device type to query.
-        new_filters: When True, use ``device_type_id`` filter name (NetBox ≥ 4.1);
-            otherwise use the legacy ``devicetype_id`` name.
     """
     try:
-        return list(
-            netbox.dcim.device_bay_templates.filter(
-                **device_type_filter_kwargs(device_type_id, new_filters=new_filters)
-            )
-        )
+        return list(netbox.dcim.device_bay_templates.filter(device_type_id=device_type_id))
     except Exception:
         return None
 
@@ -180,7 +170,6 @@ def classify_device_type_update_failure(
     netbox: Any,
     device_type_id: int,
     device_type_yaml: dict,
-    new_filters: bool = False,
 ) -> FailureResolution:
     """Classify a ``pynetbox.RequestError`` raised while updating a device type.
 
@@ -192,7 +181,6 @@ def classify_device_type_update_failure(
         device_type_yaml: Parsed YAML dict for this device-type (used to detect
             whether the YAML *also* lists device bays — in which case we cannot
             blindly delete them).
-        new_filters: When True, use updated filter parameter names (NetBox ≥ 4.1).
 
     Returns:
         A :class:`FailureResolution` describing the constraint and (when safe)
@@ -207,7 +195,7 @@ def classify_device_type_update_failure(
         )
 
     # SUBDEVICE_ROLE_FLIP path -------------------------------------------------
-    blocking_templates = _list_device_bay_templates(netbox, device_type_id, new_filters=new_filters)
+    blocking_templates = _list_device_bay_templates(netbox, device_type_id)
     if blocking_templates is None:
         return FailureResolution(
             kind=FailureKind.MANUAL_REQUIRED,
@@ -216,7 +204,7 @@ def classify_device_type_update_failure(
         )
     blocking_names = [getattr(t, "name", str(getattr(t, "id", "?"))) for t in blocking_templates]
 
-    dep_count, dep_sample = _count_dependent_devices(netbox, device_type_id, new_filters=new_filters)
+    dep_count, dep_sample = _count_dependent_devices(netbox, device_type_id)
 
     # YAML must NOT redefine device-bays — otherwise deleting them would just
     # cause our own component-creation step to fail or thrash.  This catches

--- a/tests/test_change_detector.py
+++ b/tests/test_change_detector.py
@@ -19,7 +19,7 @@ def _cache(**records):
     Populating through the real object means these tests read the same index the
     importer builds, rather than a dict that merely looks like it.
     """
-    cache = ComponentCache(MagicMock(), MagicMock(), MagicMock(), new_filters=True, max_threads=1)
+    cache = ComponentCache(MagicMock(), MagicMock(), MagicMock(), max_threads=1)
     for endpoint_name, items in records.items():
         cache.populate(endpoint_name, items)
     return cache

--- a/tests/test_component_cache.py
+++ b/tests/test_component_cache.py
@@ -187,7 +187,6 @@ def make_cache(netbox=None, graphql=None, handle=None, **kwargs):
         netbox or FakeNetBox(),
         graphql or FakeGraphQL(),
         handle or FakeHandle(),
-        kwargs.pop("new_filters", True),
         kwargs.pop("max_threads", 4),
         **kwargs,
     )
@@ -278,14 +277,6 @@ class TestLookupFallback:
         cache.get("interface_templates", "module", 5, endpoint)
 
         assert endpoint.filter_calls == [{"module_type_id": 5}]
-
-    def test_old_netbox_filter_names_are_used_when_asked(self):
-        cache = make_cache(new_filters=False)
-        endpoint = FakeEndpoint()
-
-        cache.get("interface_templates", "device", 1, endpoint)
-
-        assert endpoint.filter_calls == [{"devicetype_id": 1}]
 
     def test_an_empty_result_still_becomes_a_hit(self):
         """Otherwise every parent with no components is re-read on each lookup."""

--- a/tests/test_import_run.py
+++ b/tests/test_import_run.py
@@ -59,7 +59,6 @@ class _NetBoxBoundary:
     """Expose run state and fail if planning starts an import."""
 
     def __init__(self):
-        self.modules = True
         self.rack_types = True
         self.device_types = _DeviceTypes()
         self.outcomes = _Outcomes()
@@ -271,8 +270,6 @@ def test_execute_returns_snapshot_and_owns_console_lifecycle(make_config, tmp_pa
 
     assert isinstance(summary, RunSummary)
     assert summary.counter["added"] == 2
-    assert summary.modules is True
-    assert summary.rack_types is True
     assert progress_factory.entered is True
     assert progress_factory.exited is True
     assert handle.console is None
@@ -434,11 +431,9 @@ def test_banners_omit_the_separator_when_no_vendor_is_given(make_config):
 class _OutcomeNetBox:
     """Run-state stand-in carrying a real OutcomeRegistry."""
 
-    def __init__(self, *, modules=True, rack_types=True, counter=None):
+    def __init__(self, *, counter=None):
         from core.outcomes import OutcomeRegistry
 
-        self.modules = modules
-        self.rack_types = rack_types
         self.outcomes = OutcomeRegistry()
         base = dict(
             added=0,

--- a/tests/test_module_bay_type_sync.py
+++ b/tests/test_module_bay_type_sync.py
@@ -84,7 +84,6 @@ def make_device_types(server, catalog_root):
             handle,
             {},
             False,
-            True,
             graphql=NetBoxGraphQLClient(server.url, "test-token", supports_module_bay_types=True),
             repo_path=str(catalog_root),
             module_bay_types_supported=module_bay_types_supported,

--- a/tests/test_nb_dt_import.py
+++ b/tests/test_nb_dt_import.py
@@ -335,13 +335,11 @@ def _make_mock_repo(device_types=None):
     return mock_repo
 
 
-def _make_mock_netbox(modules=False, rack_types=False):
+def _make_mock_netbox():
     """Return a pre-configured NetBox mock."""
     from collections import Counter
 
     mock_nb = MagicMock()
-    mock_nb.modules = modules
-    mock_nb.rack_types = rack_types
     mock_nb.device_types.existing_device_types = {}
     mock_nb.device_types.existing_device_types_by_slug = {}
     mock_nb.count_device_type_images.return_value = 0
@@ -884,7 +882,7 @@ class TestMain:
             patch("nb_dt_import.NetBox") as MockNetBox,
             patch("core.import_run.ChangeDetector") as MockDetector,
         ):
-            mock_nb = _make_mock_netbox(modules=True)
+            mock_nb = _make_mock_netbox()
             mock_nb.filter_actionable_module_types.return_value = ([module_type], {}, [])
             MockNetBox.return_value = mock_nb
             MockNetBox.filter_new_module_types.return_value = []
@@ -912,7 +910,7 @@ class TestMain:
             patch("nb_dt_import.NetBox") as MockNetBox,
             patch("core.import_run.ChangeDetector") as MockDetector,
         ):
-            mock_nb = _make_mock_netbox(modules=True)
+            mock_nb = _make_mock_netbox()
             mock_nb.filter_actionable_module_types.return_value = ([], {}, change_log)
             mock_nb.filter_new_module_types.return_value = []
             MockNetBox.return_value = mock_nb
@@ -930,7 +928,7 @@ class TestMain:
         mock_nb.log_module_type_changes.assert_called_once_with(change_log)
 
     def test_settings_netbox_features_modules_logs_module_count(self, nb_dt_import):
-        """When netbox.modules is True, module_added/updated counters are logged."""
+        """Module counters are always logged: every supported release has module types."""
         with (
             patch.object(sys, "argv", ["nb-dt-import.py", "--only-new"]),
             patch("nb_dt_import.DTLRepo") as MockRepo,
@@ -938,7 +936,7 @@ class TestMain:
             patch("nb_dt_import.LogHandler") as MockLogHandler,
         ):
             MockRepo.return_value = _make_mock_repo()
-            mock_nb = _make_mock_netbox(modules=True)
+            mock_nb = _make_mock_netbox()
             MockNetBox.return_value = mock_nb
 
             nb_dt_import.main()
@@ -986,19 +984,6 @@ class TestProcessRackTypes:
 
     def _make_args(self, only_new=False):
         return SimpleNamespace(only_new=only_new)
-
-    def test_rack_types_disabled_logs_warning_and_returns(self, nb_dt_import):
-        """netbox.rack_types=False with actual rack types: warning logged, no further processing."""
-        handle = MagicMock()
-        netbox = MagicMock()
-        netbox.rack_types = False
-
-        rack_type = {"manufacturer": {"slug": "apc"}, "model": "AR1300", "slug": "apc-ar1300"}
-        import_run_module._process_rack_types(self._make_args(), netbox, handle, None, [rack_type])
-
-        handle.log.assert_called_once()
-        assert "4.1" in handle.log.call_args[0][0]
-        netbox.get_existing_rack_types.assert_not_called()
 
     def test_empty_rack_types_returns_early(self, nb_dt_import):
         """rack_types=[]: returns immediately without any logging or API calls."""
@@ -1252,7 +1237,7 @@ class TestPerVendorLoop:
         """
         mt = {"manufacturer": {"slug": "acbel"}, "model": "M1", "slug": "acbel-m1"}
 
-        mock_nb = _make_mock_netbox(modules=True)
+        mock_nb = _make_mock_netbox()
         mock_repo = _make_mock_repo()
         mock_repo.discover_vendors.return_value = [{"name": "Acbel", "slug": "acbel"}]
 
@@ -1371,8 +1356,6 @@ class TestLogRunSummary:
 
         handle = MagicMock()
         mock_nb = MagicMock()
-        mock_nb.modules = False
-        mock_nb.rack_types = True
         from collections import Counter
 
         mock_nb.counter = Counter(
@@ -1404,8 +1387,6 @@ class TestLogRunSummary:
 
         handle = MagicMock()
         mock_nb = MagicMock()
-        mock_nb.modules = False
-        mock_nb.rack_types = False
         from collections import Counter
 
         mock_nb.counter = Counter(
@@ -1988,7 +1969,7 @@ class TestMainAdditionalCoverage:
             if files == ["cisco-module-types.yaml"]
             else []
         )
-        netbox = _make_mock_netbox(modules=True)
+        netbox = _make_mock_netbox()
         slug_resolved = {
             "device_files": {"empty": [], "cisco": ["resolved.yaml"]},
             "module_vendors": {"cisco"},

--- a/tests/test_netbox_api.py
+++ b/tests/test_netbox_api.py
@@ -80,7 +80,6 @@ def make_device_types(mock_settings, mock_handle, graphql_client):
             handle if handle is not None else mock_handle,
             counter if counter is not None else MagicMock(),
             False,
-            False,
             graphql=kwargs.pop("graphql", graphql_client),
             repo_path=kwargs.pop("repo_path", mock_settings.repo_path),
             **kwargs,
@@ -118,7 +117,6 @@ def test_netbox_init(mock_settings, mock_pynetbox, mock_handle):
     assert nb.url == "http://mock-netbox"
     assert nb.token == "mock-token"
     # Verify module support detection
-    assert nb.modules
 
 
 def test_netbox_init_applies_import_policy_flags(make_config, mock_pynetbox, mock_handle):
@@ -142,7 +140,6 @@ def test_netbox_version_check(mock_settings, mock_pynetbox, mock_handle):
     for version, module_bay_types in (("4.3", False), ("4.5", False), ("4.7", True), ("5.0", True)):
         mock_pynetbox.api.return_value.version = version
         nb = NetBox(mock_settings, mock_handle)
-        assert nb.new_filters, version
         assert nb.module_bay_types is module_bay_types, version
 
 
@@ -2479,7 +2476,6 @@ class TestCreateDeviceTypesRequestErrorAndComponents:
 
         nb = NetBox(mock_settings, mock_handle)
         nb.device_types = dt
-        nb.modules = True
 
         created_dt = MagicMock()
         created_dt.id = 1
@@ -4174,40 +4170,6 @@ class TestCreateDeviceTypesCornerCases:
             nb.create_device_types([device_type])
         assert any("Error locating image file" in str(c) for c in mock_handle.log.call_args_list)
 
-    def test_module_bays_not_created_when_modules_false(
-        self, mock_settings, mock_pynetbox, graphql_client, make_device_types, mock_handle
-    ):
-        """module-bays are only created when self.modules is True."""
-        mock_nb_api = mock_pynetbox.api.return_value
-        dt = make_device_types(nb_api=mock_nb_api)
-        dt.existing_device_types = {}
-        dt.existing_device_types_by_slug = {}
-        dt.components.record("module_bay_templates", "device", 1, {})
-
-        nb = NetBox(mock_settings, mock_handle)
-        nb.device_types = dt
-        nb.modules = False  # explicitly disabled
-
-        created_dt = MagicMock()
-        created_dt.id = 1
-        created_dt.manufacturer.name = "Cisco"
-        created_dt.model = "TestSwitch"
-        mock_nb_api.dcim.device_types.create.return_value = created_dt
-
-        device_type = {
-            "manufacturer": {"slug": "cisco"},
-            "model": "TestSwitch",
-            "slug": "testswitch",
-            "module-bays": [{"name": "MB1"}],
-            "src": "/tmp/device-types/cisco/testswitch.yaml",
-        }
-        nb.create_device_types([device_type])
-        mock_nb_api.dcim.module_bay_templates.create.assert_not_called()
-
-
-class TestCreateModuleTypesCornerCases:
-    """Corner-case tests for create_module_types (cognitive complexity 16)."""
-
     def test_progress_iterator_used(self, mock_settings, mock_pynetbox, mock_handle):
         """When progress is provided, iteration goes through it."""
         mock_pynetbox.api.return_value.version = "4.3"
@@ -4605,49 +4567,45 @@ class TestVerifyCompatibility:
     """Tests for NetBox.verify_compatibility() version thresholds."""
 
     @pytest.mark.parametrize(
-        "version_str, expected_modules, expected_new_filters, expected_rack_types, expected_m2m",
+        "version_str, expected_m2m, expected_module_bay_types",
         [
-            ("4.3", True, True, True, False),
-            ("4.4", True, True, True, False),
-            ("4.5", True, True, True, True),
-            ("4.6", True, True, True, True),
-            ("4.7", True, True, True, True),
-            ("5.0", True, True, True, True),
+            ("4.3", False, False),
+            ("4.4", False, False),
+            ("4.5", True, False),
+            ("4.6", True, False),
+            ("4.7", True, True),
+            ("5.0", True, True),
             # Version strings with non-numeric suffixes
-            ("4.5-beta", True, True, True, True),
-            ("4.3.0", True, True, True, False),
+            ("4.5-beta", True, False),
+            ("4.3.0", False, False),
         ],
     )
     def test_version_thresholds(
         self,
         version_str,
-        expected_modules,
-        expected_new_filters,
-        expected_rack_types,
         expected_m2m,
+        expected_module_bay_types,
         mock_settings,
         mock_pynetbox,
         mock_handle,
     ):
+        """Only the flags that still vary above the 4.3 floor are set."""
         mock_pynetbox.api.return_value.version = version_str
         nb = NetBox(mock_settings, mock_handle)
-        assert nb.modules == expected_modules, f"modules mismatch for {version_str}"
-        assert nb.new_filters == expected_new_filters, f"new_filters mismatch for {version_str}"
-        assert nb.rack_types == expected_rack_types, f"rack_types mismatch for {version_str}"
         assert nb.m2m_front_ports == expected_m2m, f"m2m_front_ports mismatch for {version_str}"
+        assert nb.module_bay_types == expected_module_bay_types, f"module_bay_types mismatch for {version_str}"
 
     def test_single_component_version_string(self, mock_settings, mock_pynetbox, mock_handle):
         """A version string with only a major component (e.g. '5') does not crash."""
         mock_pynetbox.api.return_value.version = "5"
         nb = NetBox(mock_settings, mock_handle)
-        assert nb.new_filters is True
+        assert nb.m2m_front_ports is True
 
     def test_the_oldest_supported_release_has_no_m2m_or_module_bay_types(
         self, mock_settings, mock_pynetbox, mock_handle
     ):
         mock_pynetbox.api.return_value.version = "4.3"
         nb = NetBox(mock_settings, mock_handle)
-        assert nb.new_filters is True
         assert nb.m2m_front_ports is False
         assert nb.module_bay_types is False
 
@@ -6808,7 +6766,6 @@ class TestPreloadIntegrityGuard:
             handle,
             MagicMock(),
             False,
-            False,
             graphql=NetBoxGraphQLClient(url, "token", page_size=10),
             repo_path="/tmp/repo",
             max_threads=2,
@@ -7222,7 +7179,6 @@ class TestSummaryWordingMatchesTheFailedOperation:
             b'{"model":["This field may not be blank."]}'
         )
         nb = NetBox(mock_settings, mock_handle)
-        nb.modules = True
         nb._process_single_module_type(
             {"manufacturer": {"slug": "panduit"}, "model": "FAP6WBUSC", "slug": "fap6wbusc"},
             "/repo/module-types/Panduit/FAP6WBUSC.yaml",

--- a/tests/test_update_failure_resolver.py
+++ b/tests/test_update_failure_resolver.py
@@ -314,57 +314,18 @@ def test_classifier_count_fallback_when_count_query_fails():
     assert res.dependent_devices_count == 5
 
 
-def test_new_filters_uses_device_type_id_key():
-    """new_filters=True must call filter(device_type_id=...) not devicetype_id=...
+def test_the_device_bay_template_lookup_uses_the_supported_filter_key():
+    """The 4.1 rename is below the supported floor, so only device_type_id is ever sent.
 
-    This matters because NetBox >= 4.1 changed the query param name.
-    Passing the wrong key causes pynetbox to silently return ALL templates.
+    The wrong key does not raise: pynetbox silently returns every template, so the
+    classifier would report an unrelated device type as the blocker.
     """
     nb = _make_netbox()
-    classify_device_type_update_failure(
-        SUBDEVICE_ROLE_ERROR_DICT,
-        netbox=nb,
-        device_type_id=99,
-        device_type_yaml={},
-        new_filters=True,
-    )
+    classify_device_type_update_failure(SUBDEVICE_ROLE_ERROR_DICT, netbox=nb, device_type_id=99, device_type_yaml={})
     nb.dcim.device_bay_templates.filter.assert_called_once_with(device_type_id=99)
 
 
-def test_old_filters_uses_devicetype_id_key():
-    """new_filters=False (default) must call filter(devicetype_id=...) for NetBox < 4.1."""
-    nb = _make_netbox()
-    classify_device_type_update_failure(
-        SUBDEVICE_ROLE_ERROR_DICT,
-        netbox=nb,
-        device_type_id=99,
-        device_type_yaml={},
-        new_filters=False,
-    )
-    nb.dcim.device_bay_templates.filter.assert_called_once_with(devicetype_id=99)
-
-
-def test_count_dependent_devices_uses_new_filter_key():
-    """When new_filters=True, dcim.devices must be queried with device_type_id= not devicetype_id=."""
+def test_the_dependent_device_count_uses_the_supported_filter_key():
     nb = _make_netbox(devices=[], device_count=0)
-    classify_device_type_update_failure(
-        SUBDEVICE_ROLE_ERROR_DICT,
-        netbox=nb,
-        device_type_id=77,
-        device_type_yaml={},
-        new_filters=True,
-    )
+    classify_device_type_update_failure(SUBDEVICE_ROLE_ERROR_DICT, netbox=nb, device_type_id=77, device_type_yaml={})
     nb.dcim.devices.filter.assert_called_once_with(device_type_id=77, limit=5)
-
-
-def test_count_dependent_devices_uses_legacy_filter_key():
-    """When new_filters=False (default), dcim.devices must be queried with devicetype_id=."""
-    nb = _make_netbox(devices=[], device_count=0)
-    classify_device_type_update_failure(
-        SUBDEVICE_ROLE_ERROR_DICT,
-        netbox=nb,
-        device_type_id=77,
-        device_type_yaml={},
-        new_filters=False,
-    )
-    nb.dcim.devices.filter.assert_called_once_with(devicetype_id=77, limit=5)


### PR DESCRIPTION
Closes #133. Stacked on #134 (`feat/port-mappings-export`); review that one first.

## What is now constant

The importer refuses anything below NetBox 4.3, so three of the five feature flags can no longer be false on a server it will talk to:

| flag | threshold | at 4.3+ |
|---|---|---|
| `modules` | >= 3.2 | always true — **removed** |
| `new_filters` | >= 4.1 | always true — **removed** |
| `rack_types` | >= 4.1 | always true — **removed** |
| `m2m_front_ports` | >= 4.5 | still varies — kept |
| `module_bay_types` | >= 4.7 | still varies — kept |

The true side of every branch they guarded is kept, so behaviour is unchanged on any supported server.

## One correction to the issue

The issue asked to delete `core/compat.py` outright. That is no longer right: #132 added `parse_netbox_version` and `supports_module_bay_types` there, and both `netbox_api` and `graphql_client` use them. Only the four filter-key helpers go — the `devicetype_id` / `moduletype_id` spelling they chose between is unreachable at 4.1 and later.

## Tests

Tests that asserted the removed behaviour are deleted rather than adapted. A test that pins the legacy filter name, or the "Rack types require NetBox >= 4.1" skip, is asserting what no supported deployment executes — which is the misleading coverage the issue was written about.

The four filter-key tests collapse into two saying the supported key is the only one ever sent. That still catches the failure that mattered: the wrong key does not raise, pynetbox silently returns every row, so the classifier would report an unrelated device type as the blocker.

Dead scaffolding on the test side went too (stubs setting `.modules` / `.rack_types` that production no longer reads).

## Result

Net −223 lines. 1218 tests, coverage up from 97.64% to 97.75%, ruff and mypy clean.

The integration matrix is the real check here: v4.3.7 is the floor, so it exercises the paths these flags used to guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Module and rack type imports are now processed consistently without version-based availability checks.
  * Module bays are always created during device type synchronization.
  * NetBox queries now consistently use the current device and module type filter names.

* **Bug Fixes**
  * Improved consistency for imports and update-failure handling on supported NetBox versions.

* **Tests**
  * Updated test coverage to reflect the unified NetBox behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->